### PR TITLE
feat: typewriter objective text on first-round countdown

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Orbital Breach</title>
     <style>
       html, body {
@@ -24,6 +24,7 @@
       body {
         position: fixed;
         inset: 0;
+        touch-action: none;
       }
 
       canvas {

--- a/client/index.html
+++ b/client/index.html
@@ -25,10 +25,14 @@
         position: fixed;
         inset: 0;
         touch-action: none;
+        -webkit-user-select: none;
+        user-select: none;
       }
 
       canvas {
         display: block;
+        -webkit-user-select: none;
+        user-select: none;
       }
     </style>
   </head>

--- a/client/src/arena/portalEnergyWall.ts
+++ b/client/src/arena/portalEnergyWall.ts
@@ -134,6 +134,17 @@ export class PortalEnergyWall {
    * Call this whenever a projectile hits the portal barrier.
    */
   public spawnImpact(worldPos: THREE.Vector3, bulletColor: number): void {
+    // Evict the oldest impact to cap concurrent geometry allocations on mobile.
+    if (this.impacts.length >= 4) {
+      const oldest = this.impacts.shift()!;
+      this.scene.remove(oldest.ring);
+      (oldest.ring.material as THREE.Material).dispose();
+      oldest.ring.geometry.dispose();
+      this.scene.remove(oldest.sparks);
+      (oldest.sparks.material as THREE.Material).dispose();
+      oldest.sparks.geometry.dispose();
+    }
+
     const col = bulletColor;
 
     // ── Expanding ring (oriented to lie in the portal plane) ──────────

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -6,6 +6,8 @@ import { HUD } from '../render/hud';
 import { SceneManager } from '../render/scene';
 import { GunViewModel } from '../render/gun';
 import { MainMenu } from '../ui/menu';
+import { MobileControls } from '../ui/mobileControls';
+import { isTouchDevice } from '../platform';
 import { generateArenaLayout } from '../arena/states';
 import { FEATURE_FLAGS } from '../featureFlags';
 import { GRAB_RADIUS } from '../../../shared/constants';
@@ -39,6 +41,8 @@ export class App {
 
   private lastTime = 0;
   private thirdPerson = false;
+  private readonly mobile = isTouchDevice();
+  private mobileControls: MobileControls | null = null;
 
   public constructor() {
     this.sceneMgr = new SceneManager();
@@ -58,18 +62,30 @@ export class App {
     this.round.onBeginRound = () => this.beginNewRound();
     this.round.onCountdownEnd = () => this.arena.setPortalDoorsOpen(true);
 
-    this.sceneMgr.getRenderer().domElement.addEventListener('mousedown', () => {
-      if (this.round.getPhase() === 'LOBBY' || this.menu.isVisible() || this.input.isLocked()) {
-        return;
-      }
-      this.input.lockPointer(this.sceneMgr.getRenderer().domElement);
-    });
+    if (this.mobile) {
+      this.mobileControls = new MobileControls(this.input);
+      this.mobileControls.mount();
+      this.mobileControls.hide(); // hidden until play starts
+    } else {
+      // Desktop only: re-lock pointer when clicking back onto the canvas mid-game
+      this.sceneMgr.getRenderer().domElement.addEventListener('mousedown', () => {
+        if (this.round.getPhase() === 'LOBBY' || this.menu.isVisible() || this.input.isLocked()) {
+          return;
+        }
+        this.input.lockPointer(this.sceneMgr.getRenderer().domElement);
+      });
+    }
   }
 
   public start(): void {
     this.menu.show();
     this.menu.onPlay = () => {
-      this.input.lockPointer(this.sceneMgr.getRenderer().domElement);
+      if (this.mobile) {
+        this.input.setMobileControlsActive(true);
+        this.mobileControls?.show();
+      } else {
+        this.input.lockPointer(this.sceneMgr.getRenderer().domElement);
+      }
       this.beginNewRound();
     };
 
@@ -148,7 +164,7 @@ export class App {
       || this.player.phase === 'GRABBING'
       || this.player.phase === 'AIMING';
     if (!this.round.isPlaying()) return;
-    if (!this.input.isLocked() || !inZeroG) return;
+    if (!this.input.canControlGame() || !inZeroG) return;
     if (!this.player.canFire() || !this.input.consumeFire()) return;
 
     const useThirdPersonMuzzle = this.thirdPerson

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -136,7 +136,7 @@ export class App {
 
     this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie);
     this.updateGunVisibility(isSelfie);
-    this.updateHud();
+    this.updateHud(dt);
     this.renderDebugTuningOverlay();
 
     this.sceneMgr.render();
@@ -271,7 +271,7 @@ export class App {
     this.gun.setVisible(firstPersonGunVisible);
   }
 
-  private updateHud(): void {
+  private updateHud(dt: number): void {
     let nearBar = this.arena.getNearestBar(this.player.getPosition(), GRAB_RADIUS) !== null;
     if (this.player.phase === 'BREACH' && !this.arena.isGoalDoorOpen(this.player.currentBreachTeam)) {
       nearBar = false;
@@ -301,6 +301,8 @@ export class App {
       tabHeld: this.input.isTabHeld(),
       ownTeam,
       enemyTeam,
+      dt,
+      team: this.player.team,
     });
   }
 }

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -66,6 +66,7 @@ export class App {
       this.mobileControls = new MobileControls(this.input);
       this.mobileControls.mount();
       this.mobileControls.hide(); // hidden until play starts
+      this.mobileControls.onViewToggle = () => { this.thirdPerson = !this.thirdPerson; };
     } else {
       // Desktop only: re-lock pointer when clicking back onto the canvas mid-game
       this.sceneMgr.getRenderer().domElement.addEventListener('mousedown', () => {
@@ -303,6 +304,7 @@ export class App {
       const max = this.player.maxLaunchPower();
       const pct = max > 0 ? this.player.launchPower / max : 0;
       this.mobileControls.setPowerLevel(pct, showPower);
+      this.mobileControls.setViewMode(this.thirdPerson);
     }
 
     const ownTeam: FullPlayerInfo[] = [{

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -294,6 +294,17 @@ export class App {
     }
     const inBreach = this.arena.isInBreachRoom(this.player.getPosition(), this.player.team);
 
+    // Sync mobile controls to current game state
+    if (this.mobile && this.mobileControls) {
+      const canGrab = !this.player.damage.leftArm && !this.player.damage.frozen;
+      this.mobileControls.setPhase(this.player.phase);
+      this.mobileControls.setNearBar(nearBar, canGrab);
+      const showPower = this.player.phase === 'GRABBING' || this.player.phase === 'AIMING';
+      const max = this.player.maxLaunchPower();
+      const pct = max > 0 ? this.player.launchPower / max : 0;
+      this.mobileControls.setPowerLevel(pct, showPower);
+    }
+
     const ownTeam: FullPlayerInfo[] = [{
       id: 'local',
       name: 'You',

--- a/client/src/input.ts
+++ b/client/src/input.ts
@@ -1,4 +1,5 @@
 import { FIRE_RATE } from '../../shared/constants';
+import { applyMobileLookDelta, mergeWalkAxes, type MobileLookState } from './input/mobileInputLogic';
 
 export class InputManager {
   private keys          = new Set<string>();
@@ -88,12 +89,11 @@ export class InputManager {
   // ── Mobile input ──────────────────────────────────────────────────
   /** Accumulate a touch look delta (called from MobileControls on pointermove). */
   public setMobileLookDelta(dx: number, dy: number): void {
-    this.touchLookDx += dx;
-    if (this.aimingActive) {
-      this.aimDy += dy;
-    } else {
-      this.touchLookDy += dy;
-    }
+    const state: MobileLookState = { touchLookDx: this.touchLookDx, touchLookDy: this.touchLookDy, aimDy: this.aimDy };
+    applyMobileLookDelta(state, this.aimingActive, dx, dy);
+    this.touchLookDx = state.touchLookDx;
+    this.touchLookDy = state.touchLookDy;
+    this.aimDy = state.aimDy;
   }
 
   /** Set virtual joystick axes from mobile controls. x: strafe, z: forward (+z = forward). */
@@ -152,10 +152,7 @@ export class InputManager {
   public getWalkAxes(): { x: number; z: number } {
     const kx = (this.keys.has('KeyD') ? 1 : 0) - (this.keys.has('KeyA') ? 1 : 0);
     const kz = (this.keys.has('KeyW') ? 1 : 0) - (this.keys.has('KeyS') ? 1 : 0);
-    return {
-      x: Math.max(-1, Math.min(1, kx + this.mobileMoveX)),
-      z: Math.max(-1, Math.min(1, kz + this.mobileMoveZ)),
-    };
+    return mergeWalkAxes(kx, kz, this.mobileMoveX, this.mobileMoveZ);
   }
 
   /** @deprecated use getWalkAxes() — kept for server sim compatibility */

--- a/client/src/input.ts
+++ b/client/src/input.ts
@@ -13,6 +13,13 @@ export class InputManager {
   private gunTuneResetPressed = false;
   private gunTunePrintPressed = false;
 
+  // Mobile touch input state
+  private touchLookDx = 0;
+  private touchLookDy = 0;
+  private mobileMoveX = 0;
+  private mobileMoveZ = 0;
+  private mobileControlsActive = false;
+
   public mouseSensitivity = 0.002;
 
   public constructor() {
@@ -78,12 +85,58 @@ export class InputManager {
     this.aimingActive = active;
   }
 
+  // ── Mobile input ──────────────────────────────────────────────────
+  /** Accumulate a touch look delta (called from MobileControls on pointermove). */
+  public setMobileLookDelta(dx: number, dy: number): void {
+    this.touchLookDx += dx;
+    if (this.aimingActive) {
+      this.aimDy += dy;
+    } else {
+      this.touchLookDy += dy;
+    }
+  }
+
+  /** Set virtual joystick axes from mobile controls. x: strafe, z: forward (+z = forward). */
+  public setMobileMoveAxes(x: number, z: number): void {
+    this.mobileMoveX = x;
+    this.mobileMoveZ = z;
+  }
+
+  /** Simulate Space key held from mobile jump/charge button. */
+  public setMobileJumpHeld(active: boolean): void {
+    if (active) this.keys.add('Space');
+    else this.keys.delete('Space');
+  }
+
+  /** One-shot grab press from mobile grab button (mirrors E key). */
+  public pressMobileGrab(): void {
+    this.grabPressed = true;
+  }
+
+  /** Simulate LMB held from mobile fire button. */
+  public setMobileFireHeld(active: boolean): void {
+    if (active) this.keys.add('MouseLeft');
+    else this.keys.delete('MouseLeft');
+  }
+
+  /** Enable mobile control mode — bypasses pointer-lock requirement in canControlGame(). */
+  public setMobileControlsActive(active: boolean): void {
+    this.mobileControlsActive = active;
+  }
+
+  /** Returns true when the player can control the game (pointer locked on desktop, or mobile controls active). */
+  public canControlGame(): boolean {
+    return this.mobileControlsActive || this.isLocked();
+  }
+
   // ── Mouse delta ───────────────────────────────────────────────────
   public consumeMouseDelta(): { dx: number; dy: number } {
-    const dx = this.mouseDx;
-    const dy = this.mouseDy;
+    const dx = this.mouseDx + this.touchLookDx;
+    const dy = this.mouseDy + this.touchLookDy;
     this.mouseDx = 0;
     this.mouseDy = 0;
+    this.touchLookDx = 0;
+    this.touchLookDy = 0;
     return { dx, dy };
   }
 
@@ -95,11 +148,13 @@ export class InputManager {
   }
 
   // ── Movement ──────────────────────────────────────────────────────
-  /** WASD walk axes (XZ only). Used in breach room. */
+  /** WASD walk axes (XZ only). Used in breach room. Merges keyboard + mobile joystick. */
   public getWalkAxes(): { x: number; z: number } {
+    const kx = (this.keys.has('KeyD') ? 1 : 0) - (this.keys.has('KeyA') ? 1 : 0);
+    const kz = (this.keys.has('KeyW') ? 1 : 0) - (this.keys.has('KeyS') ? 1 : 0);
     return {
-      x: (this.keys.has('KeyD') ? 1 : 0) - (this.keys.has('KeyA') ? 1 : 0),
-      z: (this.keys.has('KeyW') ? 1 : 0) - (this.keys.has('KeyS') ? 1 : 0),
+      x: Math.max(-1, Math.min(1, kx + this.mobileMoveX)),
+      z: Math.max(-1, Math.min(1, kz + this.mobileMoveZ)),
     };
   }
 
@@ -213,10 +268,15 @@ export class InputManager {
     this.mouseDx = 0;
     this.mouseDy = 0;
     this.aimDy = 0;
+    this.touchLookDx = 0;
+    this.touchLookDy = 0;
+    this.mobileMoveX = 0;
+    this.mobileMoveZ = 0;
     this.grabPressed = false;
     this.thirdPersonTogglePressed = false;
     this.gunTuneTogglePressed = false;
     this.gunTuneResetPressed = false;
     this.gunTunePrintPressed = false;
+    // mobileControlsActive is intentionally preserved across blur/visibility changes
   }
 }

--- a/client/src/input/mobileInputLogic.ts
+++ b/client/src/input/mobileInputLogic.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure stateless helpers extracted from InputManager's mobile-input paths.
+ * Having them separate makes them unit-testable without a browser environment.
+ */
+
+export interface MobileLookState {
+  touchLookDx: number;
+  touchLookDy: number;
+  aimDy: number;
+}
+
+/**
+ * Route a touch look delta into the correct accumulator.
+ * When aiming is active, dy charges launch power (aimDy); otherwise it pans the camera.
+ */
+export function applyMobileLookDelta(
+  state: MobileLookState,
+  aimingActive: boolean,
+  dx: number,
+  dy: number,
+): void {
+  state.touchLookDx += dx;
+  if (aimingActive) {
+    state.aimDy += dy;
+  } else {
+    state.touchLookDy += dy;
+  }
+}
+
+/**
+ * Merge keyboard walk axes with mobile joystick axes, clamped to [-1, 1].
+ */
+export function mergeWalkAxes(
+  keyX: number,
+  keyZ: number,
+  mobileX: number,
+  mobileZ: number,
+): { x: number; z: number } {
+  return {
+    x: Math.max(-1, Math.min(1, keyX + mobileX)),
+    z: Math.max(-1, Math.min(1, keyZ + mobileZ)),
+  };
+}
+
+/**
+ * Determine if a power-level change crosses a haptic threshold.
+ * Returns vibration duration in ms when a threshold is crossed, null otherwise.
+ * Thresholds: 25 %, 50 %, 75 %, 100 % (100 % gives a longer buzz).
+ */
+export function checkHapticThreshold(lastPct: number, currentPct: number): number | null {
+  const thresholds = [0.25, 0.5, 0.75, 1.0];
+  for (const t of thresholds) {
+    if (lastPct < t && currentPct >= t) {
+      return currentPct >= 1.0 ? 40 : 15;
+    }
+  }
+  return null;
+}

--- a/client/src/input/mobileInputLogic.ts
+++ b/client/src/input/mobileInputLogic.ts
@@ -42,17 +42,3 @@ export function mergeWalkAxes(
   };
 }
 
-/**
- * Determine if a power-level change crosses a haptic threshold.
- * Returns vibration duration in ms when a threshold is crossed, null otherwise.
- * Thresholds: 25 %, 50 %, 75 %, 100 % (100 % gives a longer buzz).
- */
-export function checkHapticThreshold(lastPct: number, currentPct: number): number | null {
-  const thresholds = [0.25, 0.5, 0.75, 1.0];
-  for (const t of thresholds) {
-    if (lastPct < t && currentPct >= t) {
-      return currentPct >= 1.0 ? 40 : 15;
-    }
-  }
-  return null;
-}

--- a/client/src/platform.ts
+++ b/client/src/platform.ts
@@ -1,0 +1,9 @@
+export function isTouchDevice(): boolean {
+  return navigator.maxTouchPoints > 0;
+}
+
+export function getViewportSize(): { width: number; height: number } {
+  const vv = window.visualViewport;
+  if (vv) return { width: Math.round(vv.width), height: Math.round(vv.height) };
+  return { width: window.innerWidth, height: window.innerHeight };
+}

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -17,16 +17,25 @@ export interface HudState {
   tabHeld: boolean;
   ownTeam: FullPlayerInfo[];
   enemyTeam: EnemyPlayerInfo[];
+  dt: number;
+  team: 0 | 1;
 }
 
 /**
  * HUD controller: owns the rendered HUD view and maps gameplay state into
- * DOM updates. Stateless apart from the cached element references — each
- * call to `update` overwrites every dynamic element from the incoming
- * HudState so state drift between frames is impossible.
+ * DOM updates. Per-frame state (typewriter progress, phase tracking) is kept
+ * here; everything else is derived from the incoming HudState each tick.
  */
 export class HUD {
   private view: HudElements;
+
+  // Typewriter state — only active during the very first countdown
+  private isFirstRound = true;
+  private prevPhase: GamePhase = 'LOBBY';
+  private typewriterTimer = 0;
+  private typewriterIdx = 0;
+  private static readonly OBJECTIVE_TEXT =
+    'Objective — Breach Enemy Portal or Freeze them ALL';
 
   public constructor() {
     this.view = createHudView();
@@ -42,8 +51,17 @@ export class HUD {
   }
 
   public update(state: HudState): void {
+    // Track phase transitions to detect first-round vs subsequent rounds
+    if (state.phase !== this.prevPhase) {
+      if (this.prevPhase === 'ROUND_END' && state.phase === 'COUNTDOWN') {
+        this.isFirstRound = false;
+      }
+      this.prevPhase = state.phase;
+    }
+
     this.renderScore(state.score);
     this.renderCountdown(state.phase, state.countdown);
+    this.renderObjectiveTypewriter(state.phase, state.dt, state.team);
     this.renderBreachIndicator(state.inBreach);
     this.renderGrabPrompt(state.playerPhase, state.nearBar, state.damage);
     this.renderPowerBar(state.playerPhase, state.launchPower, state.maxLaunchPower);
@@ -61,6 +79,39 @@ export class HUD {
       this.view.countdown.textContent = String(Math.ceil(countdown));
     } else {
       this.view.countdown.style.display = 'none';
+    }
+  }
+
+  private renderObjectiveTypewriter(phase: GamePhase, dt: number, team: 0 | 1): void {
+    const el = this.view.objective;
+    if (this.isFirstRound && phase === 'COUNTDOWN') {
+      // Team color: inverted against the same-colored portal/energy wall behind the text.
+      // Dark backdrop + bright team-tint text ensures contrast regardless of background glow.
+      const textColor  = team === 0 ? '#aaffff' : '#ffaaff';
+      const glowColor  = team === 0 ? '#00ffff' : '#ff00ff';
+      // Dark complement of the team hue so the background blocks the glow bleed
+      const backdropBg = team === 0 ? 'rgba(0,8,8,0.72)' : 'rgba(8,0,8,0.72)';
+
+      el.style.color      = textColor;
+      el.style.textShadow = `0 0 12px ${glowColor}`;
+      el.style.background = backdropBg;
+      el.style.padding    = '4px 14px';
+      el.style.borderRadius = '4px';
+      el.style.display = 'block';
+
+      this.typewriterTimer += dt;
+      const CHARS_PER_SEC = 20;
+      this.typewriterIdx = Math.min(
+        HUD.OBJECTIVE_TEXT.length,
+        Math.floor(this.typewriterTimer * CHARS_PER_SEC),
+      );
+      el.textContent = HUD.OBJECTIVE_TEXT.slice(0, this.typewriterIdx);
+    } else if (phase === 'PLAYING') {
+      el.style.display = 'none';
+      this.typewriterTimer = 0;
+      this.typewriterIdx = 0;
+    } else {
+      el.style.display = 'none';
     }
   }
 

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -1,6 +1,9 @@
 import type { DamageState, FullPlayerInfo, EnemyPlayerInfo } from '../../../shared/schema';
 import { createHudView, type HudElements } from './hud/hudView';
 import { buildScoreboardHtml } from './hud/scoreboard';
+import { isTouchDevice } from '../platform';
+
+const IS_MOBILE = isTouchDevice();
 
 export type GamePhase = 'LOBBY' | 'COUNTDOWN' | 'PLAYING' | 'ROUND_END';
 
@@ -78,15 +81,20 @@ export class HUD {
     let show = false;
 
     if (playerPhase === 'AIMING') {
-      show = true;
-      promptText = '↓ Pull mouse to charge power  ·  Release [SPACE] to launch';
-      el.style.fontSize = '14px';
-      el.style.color = '#ffff88';
-      el.style.textShadow = '0 0 8px #ffaa00';
+      // On mobile the vertical power bar is sufficient — skip text prompt.
+      if (!IS_MOBILE) {
+        show = true;
+        promptText = '↓ Pull mouse to charge power  ·  Release [SPACE] to launch';
+        el.style.fontSize = '14px';
+        el.style.color = '#ffff88';
+        el.style.textShadow = '0 0 8px #ffaa00';
+      }
     } else if (playerPhase === 'GRABBING') {
       show = true;
-      promptText = 'Hold [SPACE] to aim  ·  [E] to release bar';
-      el.style.fontSize = '15px';
+      promptText = IS_MOBILE
+        ? 'Hold LAUNCH & drag ↓ to charge'
+        : 'Hold [SPACE] to aim  ·  [E] to release bar';
+      el.style.fontSize = IS_MOBILE ? '13px' : '15px';
       el.style.color = '#aaffff';
       el.style.textShadow = '0 0 8px #00ffff';
     } else if (
@@ -95,11 +103,14 @@ export class HUD {
       && !damage.leftArm
       && !damage.frozen
     ) {
-      show = true;
-      promptText = '[E]  GRAB BAR';
-      el.style.fontSize = '17px';
-      el.style.color = '#aaffff';
-      el.style.textShadow = '0 0 8px #00ffff';
+      // On mobile the GRAB button appears instead; skip this text.
+      if (!IS_MOBILE) {
+        show = true;
+        promptText = '[E]  GRAB BAR';
+        el.style.fontSize = '17px';
+        el.style.color = '#aaffff';
+        el.style.textShadow = '0 0 8px #00ffff';
+      }
     }
 
     el.style.display = show ? 'block' : 'none';
@@ -111,6 +122,11 @@ export class HUD {
     launchPower: number,
     maxLaunchPower: number,
   ): void {
+    // On mobile the MobileControls vertical bar handles power display.
+    if (IS_MOBILE) {
+      this.view.powerWrap.style.display = 'none';
+      return;
+    }
     const showBar = playerPhase === 'GRABBING' || playerPhase === 'AIMING';
     this.view.powerWrap.style.display = showBar ? 'block' : 'none';
 

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -11,6 +11,14 @@ const HUD_MARKUP = `
     color:#fff;text-shadow:0 0 40px #00ffff;letter-spacing:0.05em;
   ">10</div>
 
+  <!-- First-round objective typewriter (shown only during first countdown) -->
+  <div id="hud-objective" style="
+    display:none;position:absolute;left:50%;top:58%;
+    transform:translateX(-50%);font-size:16px;letter-spacing:3px;
+    color:#aaffff;text-shadow:0 0 12px #00ffff;text-align:center;
+    max-width:600px;white-space:nowrap;
+  "></div>
+
   <div id="hud-crosshair" style="
     position:absolute;left:50%;top:50%;
     transform:translate(-50%,-50%);
@@ -68,6 +76,7 @@ const HUD_MARKUP = `
 export interface HudElements {
   root: HTMLDivElement;
   countdown: HTMLDivElement;
+  objective: HTMLDivElement;
   score: HTMLDivElement;
   breach: HTMLDivElement;
   grab: HTMLDivElement;
@@ -101,6 +110,7 @@ export function createHudView(): HudElements {
   return {
     root,
     countdown: q('hud-countdown'),
+    objective: q('hud-objective'),
     score: q('hud-score'),
     breach: q('hud-breach'),
     grab: q('hud-grab'),

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -26,6 +26,7 @@ const HUD_MARKUP = `
   <div id="hud-breach" style="
     display:none;position:absolute;bottom:22px;left:50%;
     transform:translateX(-50%);font-size:13px;color:#88ddff;opacity:0.75;
+    white-space:nowrap;
   ">▼ BREACH ROOM — GRAVITY ACTIVE ▼</div>
 
   <div id="hud-grab" style="

--- a/client/src/render/scene.ts
+++ b/client/src/render/scene.ts
@@ -17,6 +17,7 @@ export class SceneManager {
     );
 
     this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5));
     this.renderer.setSize(window.innerWidth, window.innerHeight);
     document.body.appendChild(this.renderer.domElement);
 

--- a/client/src/render/scene.ts
+++ b/client/src/render/scene.ts
@@ -27,11 +27,16 @@ export class SceneManager {
 
     this.scene.add(new THREE.AmbientLight(0x445577, 1.0));
 
-    window.addEventListener("resize", () => {
-      this.camera.aspect = window.innerWidth / window.innerHeight;
+    const handleResize = (): void => {
+      const vp = window.visualViewport;
+      const w = vp ? Math.round(vp.width) : window.innerWidth;
+      const h = vp ? Math.round(vp.height) : window.innerHeight;
+      this.camera.aspect = w / h;
       this.camera.updateProjectionMatrix();
-      this.renderer.setSize(window.innerWidth, window.innerHeight);
-    });
+      this.renderer.setSize(w, h);
+    };
+    window.addEventListener("resize", handleResize);
+    window.visualViewport?.addEventListener("resize", handleResize);
   }
 
   public render(): void {

--- a/client/src/ui/menu.ts
+++ b/client/src/ui/menu.ts
@@ -1,4 +1,5 @@
 import { createMenuView, injectMenuStyle, type MenuElements } from './menu/menuView';
+import { isTouchDevice } from '../platform';
 
 const STORAGE_KEY = 'orbital_player_name';
 
@@ -27,7 +28,10 @@ export class MainMenu {
       const v = elements.nameInput.value.trim();
       if (v) localStorage.setItem(STORAGE_KEY, v);
     });
-    elements.nameInput.focus();
+    // Skip auto-focus on mobile to avoid unwanted virtual keyboard on load
+    if (!isTouchDevice()) {
+      elements.nameInput.focus();
+    }
 
     elements.playButton.addEventListener('click', () => {
       this.saveName();

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -1,3 +1,5 @@
+import { isTouchDevice } from '../../platform';
+
 /**
  * Main menu DOM view: injects the stylesheet on first use, builds the
  * menu element from HTML, and exposes the mutable handles (name input,
@@ -148,6 +150,16 @@ const CSS = `
     font-size: 10px; color: #2a3d50; letter-spacing: 2px;
     font-family: 'Share Tech Mono', monospace;
   }
+
+  @media (max-width: 540px) {
+    .menu-title    { font-size: 36px; letter-spacing: 6px; }
+    .menu-subtitle { font-size: 10px; letter-spacing: 3px; margin-bottom: 32px; }
+    .menu-section  { margin-bottom: 20px; }
+    .menu-divider  { width: 80%; }
+    .menu-input    { width: 80%; max-width: 260px; padding: 10px 16px; }
+    .menu-btn      { padding: 14px 44px; font-size: 14px; letter-spacing: 4px; }
+    .menu-controls { font-size: 10px; line-height: 2.0; margin-top: 24px; padding: 0 16px; }
+  }
 `;
 
 export interface MenuElements {
@@ -165,6 +177,21 @@ export function injectMenuStyle(): HTMLStyleElement {
 }
 
 export function createMenuView(savedName: string): MenuElements {
+  const mobile = isTouchDevice();
+  const controlsHtml = mobile
+    ? `Drag right side to look &nbsp;&middot;&nbsp; Left stick to move<br>
+       <span class="menu-key">FIRE</span> Freeze shot &nbsp;&middot;&nbsp;
+       <span class="menu-key">GRAB</span> Grab bar &nbsp;&middot;&nbsp;
+       <span class="menu-key">JUMP</span> Charge launch`
+    : `<span class="menu-key">WASD</span> Move &nbsp;&middot;&nbsp;
+       <span class="menu-key">E</span> Grab bar &nbsp;&middot;&nbsp;
+       <span class="menu-key">SPACE</span> Charge launch<br>
+       <span class="menu-key">LMB</span> Freeze shot &nbsp;&middot;&nbsp;
+       <span class="menu-key">V</span> Third-person view &nbsp;&middot;&nbsp;
+       <span class="menu-key">B</span> Selfie view<br>
+       <span class="menu-key">MOUSE</span> Look &nbsp;&middot;&nbsp;
+       <span class="menu-key">ESC</span> Release cursor`;
+
   const container = document.createElement('div');
   container.innerHTML = `
     <div class="menu-root" id="menu-root">
@@ -179,7 +206,8 @@ export function createMenuView(savedName: string): MenuElements {
       <div class="menu-section">
         <div class="menu-label">Call Sign</div>
         <input class="menu-input" id="menu-name" type="text"
-          placeholder="ENTER NAME" maxlength="16" value="${escapeHtml(savedName)}" autocomplete="off" />
+          placeholder="ENTER NAME" maxlength="16" value="${escapeHtml(savedName)}"
+          autocomplete="off" inputmode="${mobile ? 'text' : 'text'}" />
       </div>
 
       <div class="menu-divider"></div>
@@ -188,16 +216,7 @@ export function createMenuView(savedName: string): MenuElements {
         <button class="menu-btn" id="btn-play">PLAY SOLO</button>
       </div>
 
-      <div class="menu-controls">
-        <span class="menu-key">WASD</span> Move &nbsp;&middot;&nbsp;
-        <span class="menu-key">E</span> Grab bar &nbsp;&middot;&nbsp;
-        <span class="menu-key">SPACE</span> Charge launch<br>
-        <span class="menu-key">LMB</span> Freeze shot &nbsp;&middot;&nbsp;
-        <span class="menu-key">V</span> Third-person view &nbsp;&middot;&nbsp;
-        <span class="menu-key">B</span> Selfie view<br>
-        <span class="menu-key">MOUSE</span> Look &nbsp;&middot;&nbsp;
-        <span class="menu-key">ESC</span> Release cursor
-      </div>
+      <div class="menu-controls">${controlsHtml}</div>
 
       <div class="menu-version">v0.1.0 &middot; ORBITAL BREACH</div>
     </div>

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -160,6 +160,18 @@ const CSS = `
     .menu-btn      { padding: 14px 44px; font-size: 14px; letter-spacing: 4px; }
     .menu-controls { font-size: 10px; line-height: 2.0; margin-top: 24px; padding: 0 16px; }
   }
+
+  /* Landscape mobile: reduce vertical rhythm to fit in ~430px viewport height */
+  @media (max-height: 560px) {
+    .menu-title    { font-size: 30px; letter-spacing: 6px; margin-bottom: 4px; }
+    .menu-subtitle { font-size: 9px; letter-spacing: 3px; margin-bottom: 14px; }
+    .menu-section  { margin-bottom: 10px; }
+    .menu-label    { font-size: 9px; letter-spacing: 3px; margin-bottom: 6px; }
+    .menu-divider  { margin: 2px 0 12px; width: 80%; }
+    .menu-input    { padding: 8px 16px; font-size: 13px; width: 220px; }
+    .menu-btn      { padding: 10px 40px; font-size: 13px; letter-spacing: 4px; }
+    .menu-controls { font-size: 9px; line-height: 1.75; margin-top: 10px; padding: 0 24px; }
+  }
 `;
 
 export interface MenuElements {
@@ -179,10 +191,11 @@ export function injectMenuStyle(): HTMLStyleElement {
 export function createMenuView(savedName: string): MenuElements {
   const mobile = isTouchDevice();
   const controlsHtml = mobile
-    ? `Drag right side to look &nbsp;&middot;&nbsp; Left stick to move<br>
+    ? `Drag screen to look &nbsp;&middot;&nbsp; Left stick walks in gravity room<br>
        <span class="menu-key">FIRE</span> Freeze shot &nbsp;&middot;&nbsp;
-       <span class="menu-key">GRAB</span> Grab bar &nbsp;&middot;&nbsp;
-       <span class="menu-key">JUMP</span> Charge launch`
+       <span class="menu-key">GRAB</span> Grip bar &nbsp;&middot;&nbsp;
+       <span class="menu-key">JUMP&nbsp;/&nbsp;LAUNCH</span> Hold &amp; drag down to charge, release to launch<br>
+       <span class="menu-key">3RD&nbsp;/&nbsp;1ST</span> Toggle camera view`
     : `<span class="menu-key">WASD</span> Move &nbsp;&middot;&nbsp;
        <span class="menu-key">E</span> Grab bar &nbsp;&middot;&nbsp;
        <span class="menu-key">SPACE</span> Charge launch<br>

--- a/client/src/ui/mobileControls.ts
+++ b/client/src/ui/mobileControls.ts
@@ -280,7 +280,7 @@ export class MobileControls {
 
   /** Called every frame with normalised power (0–1) and whether to show the meter. */
   public setPowerLevel(pct: number, show: boolean): void {
-    this.powerTrack.style.display = show ? '' : 'none';
+    this.powerTrack.style.display = show ? 'block' : 'none';
     if (!show) {
       this.lastHapticPct = 0;
       return;

--- a/client/src/ui/mobileControls.ts
+++ b/client/src/ui/mobileControls.ts
@@ -1,4 +1,5 @@
 import { InputManager } from '../input';
+import { checkHapticThreshold } from '../input/mobileInputLogic';
 
 const MOBILE_LOOK_SCALE = 4.0;
 
@@ -290,14 +291,8 @@ export class MobileControls {
     this.powerFill.style.height = `${(pct * 100).toFixed(1)}%`;
     this.powerFill.style.background = `hsl(${h}, 90%, 55%)`;
 
-    // Haptic feedback at 25 % thresholds
-    const thresholds = [0.25, 0.5, 0.75, 1.0];
-    for (const t of thresholds) {
-      if (this.lastHapticPct < t && pct >= t) {
-        navigator.vibrate?.(pct >= 1.0 ? 40 : 15);
-        break;
-      }
-    }
+    const vibrateMs = checkHapticThreshold(this.lastHapticPct, pct);
+    if (vibrateMs !== null) navigator.vibrate?.(vibrateMs);
     this.lastHapticPct = pct;
   }
 

--- a/client/src/ui/mobileControls.ts
+++ b/client/src/ui/mobileControls.ts
@@ -1,5 +1,4 @@
 import { InputManager } from '../input';
-import { checkHapticThreshold } from '../input/mobileInputLogic';
 
 const MOBILE_LOOK_SCALE = 4.0;
 
@@ -172,9 +171,6 @@ export class MobileControls {
   private styleEl: HTMLStyleElement | null = null;
   private input: InputManager;
 
-  // Haptic threshold tracking
-  private lastHapticPct = 0;
-
   constructor(input: InputManager) {
     this.input = input;
 
@@ -255,17 +251,14 @@ export class MobileControls {
     this.joystickZone.style.display = inGravity ? '' : 'none';
 
     // Vertical power track: only when on a bar
-    // (hidden via setPowerLevel show flag too, but gate here for clarity)
     if (!onBar) {
       this.powerTrack.style.display = 'none';
     }
 
-    // JUMP label transforms to LAUNCH when on bar
-    if (onBar) {
-      this.jumpBtn.textContent = 'LAUNCH';
-    } else {
-      this.jumpBtn.textContent = 'JUMP';
-    }
+    // JUMP: only in gravity room or on bar; hidden while floating free
+    const showJump = inGravity || onBar;
+    this.jumpBtn.style.display = showJump ? 'flex' : 'none';
+    this.jumpBtn.textContent = onBar ? 'LAUNCH' : 'JUMP';
   }
 
   /** Called every frame — show GRAB button only when the player can grab a nearby bar. */
@@ -282,18 +275,11 @@ export class MobileControls {
   /** Called every frame with normalised power (0–1) and whether to show the meter. */
   public setPowerLevel(pct: number, show: boolean): void {
     this.powerTrack.style.display = show ? 'block' : 'none';
-    if (!show) {
-      this.lastHapticPct = 0;
-      return;
-    }
+    if (!show) return;
 
     const h = 120 - pct * 120;
     this.powerFill.style.height = `${(pct * 100).toFixed(1)}%`;
     this.powerFill.style.background = `hsl(${h}, 90%, 55%)`;
-
-    const vibrateMs = checkHapticThreshold(this.lastHapticPct, pct);
-    if (vibrateMs !== null) navigator.vibrate?.(vibrateMs);
-    this.lastHapticPct = pct;
   }
 
   // ─── Private helpers ────────────────────────────────────────────────────────

--- a/client/src/ui/mobileControls.ts
+++ b/client/src/ui/mobileControls.ts
@@ -128,6 +128,22 @@ const CSS = `
     background: rgba(255, 200, 0, 0.38);
     border-color: rgba(255, 200, 0, 0.65);
   }
+  .mob-btn-view {
+    width: 52px;
+    height: 26px;
+    border-radius: 5px;
+    bottom: calc(8px + env(safe-area-inset-bottom, 0px));
+    left: 8px;
+    background: rgba(180, 180, 255, 0.10);
+    border: 1px solid rgba(180, 180, 255, 0.28);
+    color: rgba(180, 180, 255, 0.70);
+    font-size: 9px;
+    letter-spacing: 1px;
+  }
+  .mob-btn-view.mob-pressed {
+    background: rgba(180, 180, 255, 0.28);
+    border-color: rgba(180, 180, 255, 0.55);
+  }
 `;
 
 export class MobileControls {
@@ -141,6 +157,9 @@ export class MobileControls {
   private fireBtn: HTMLDivElement;
   private jumpBtn: HTMLDivElement;
   private grabBtn: HTMLDivElement;
+  private viewBtn: HTMLDivElement;
+
+  public onViewToggle: (() => void) | null = null;
 
   private joystickPointerId = -1;
   private joystickCenterX = 0;
@@ -193,15 +212,18 @@ export class MobileControls {
     this.fireBtn = this.makeBtn('mob-btn-fire', 'FIRE');
     this.jumpBtn = this.makeBtn('mob-btn-jump', 'JUMP');
     this.grabBtn = this.makeBtn('mob-btn-grab', 'GRAB');
+    this.viewBtn = this.makeBtn('mob-btn-view', '3RD');
     this.container.appendChild(this.fireBtn);
     this.container.appendChild(this.jumpBtn);
     this.container.appendChild(this.grabBtn);
+    this.container.appendChild(this.viewBtn);
 
     this.bindLookArea();
     this.bindJoystick();
     this.bindFireBtn();
     this.bindJumpBtn();
     this.bindGrabBtn();
+    this.bindViewBtn();
   }
 
   public mount(): void {
@@ -248,7 +270,12 @@ export class MobileControls {
   /** Called every frame — show GRAB button only when the player can grab a nearby bar. */
   public setNearBar(near: boolean, canGrab: boolean): void {
     const showGrab = near && canGrab;
-    this.grabBtn.style.display = showGrab ? '' : 'none';
+    this.grabBtn.style.display = showGrab ? 'flex' : 'none';
+  }
+
+  /** Called every frame — updates view toggle label to show the opposite of current mode. */
+  public setViewMode(thirdPerson: boolean): void {
+    this.viewBtn.textContent = thirdPerson ? '1ST' : '3RD';
   }
 
   /** Called every frame with normalised power (0–1) and whether to show the meter. */
@@ -425,6 +452,19 @@ export class MobileControls {
     };
     this.jumpBtn.addEventListener('pointerup', end);
     this.jumpBtn.addEventListener('pointercancel', end);
+  }
+
+  // VIEW TOGGLE: tap = switch 1st/3rd person
+  private bindViewBtn(): void {
+    this.viewBtn.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.viewBtn.classList.add('mob-pressed');
+      this.onViewToggle?.();
+    });
+    const end = (): void => { this.viewBtn.classList.remove('mob-pressed'); };
+    this.viewBtn.addEventListener('pointerup', end);
+    this.viewBtn.addEventListener('pointercancel', end);
   }
 
   // GRAB: one-shot press; drag = look

--- a/client/src/ui/mobileControls.ts
+++ b/client/src/ui/mobileControls.ts
@@ -1,0 +1,296 @@
+import { InputManager } from '../input';
+
+const CSS = `
+  .mob-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    pointer-events: none;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+  }
+  .mob-look {
+    position: absolute;
+    inset: 0;
+    pointer-events: all;
+    touch-action: none;
+  }
+  .mob-joystick-zone {
+    position: absolute;
+    bottom: calc(48px + env(safe-area-inset-bottom, 0px));
+    left: 24px;
+    width: 128px;
+    height: 128px;
+    pointer-events: all;
+    touch-action: none;
+    z-index: 1;
+  }
+  .mob-joystick-base {
+    width: 128px;
+    height: 128px;
+    border-radius: 64px;
+    background: rgba(0, 255, 255, 0.07);
+    border: 2px solid rgba(0, 255, 255, 0.22);
+    position: relative;
+  }
+  .mob-joystick-thumb {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    border-radius: 25px;
+    background: rgba(0, 255, 255, 0.28);
+    border: 2px solid rgba(0, 255, 255, 0.55);
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+  }
+  .mob-btn {
+    position: absolute;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: all;
+    touch-action: none;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    transition: background 0.08s ease, border-color 0.08s ease;
+    -webkit-tap-highlight-color: transparent;
+    z-index: 1;
+  }
+  .mob-btn-fire {
+    width: 80px;
+    height: 80px;
+    bottom: calc(48px + env(safe-area-inset-bottom, 0px));
+    right: 28px;
+    background: rgba(255, 50, 100, 0.15);
+    border: 2px solid rgba(255, 50, 100, 0.38);
+    color: rgba(255, 120, 150, 0.8);
+  }
+  .mob-btn-fire.mob-pressed {
+    background: rgba(255, 50, 100, 0.45);
+    border-color: rgba(255, 50, 100, 0.8);
+  }
+  .mob-btn-jump {
+    width: 64px;
+    height: 64px;
+    bottom: calc(148px + env(safe-area-inset-bottom, 0px));
+    right: 40px;
+    background: rgba(0, 255, 255, 0.12);
+    border: 2px solid rgba(0, 255, 255, 0.28);
+    color: rgba(0, 220, 255, 0.75);
+  }
+  .mob-btn-jump.mob-pressed {
+    background: rgba(0, 255, 255, 0.35);
+    border-color: rgba(0, 255, 255, 0.65);
+  }
+  .mob-btn-grab {
+    width: 60px;
+    height: 60px;
+    bottom: calc(52px + env(safe-area-inset-bottom, 0px));
+    right: 128px;
+    background: rgba(255, 200, 0, 0.12);
+    border: 2px solid rgba(255, 200, 0, 0.28);
+    color: rgba(255, 200, 0, 0.75);
+  }
+  .mob-btn-grab.mob-pressed {
+    background: rgba(255, 200, 0, 0.38);
+    border-color: rgba(255, 200, 0, 0.65);
+  }
+`;
+
+export class MobileControls {
+  private container: HTMLDivElement;
+  private lookArea: HTMLDivElement;
+  private joystickBase: HTMLDivElement;
+  private joystickThumb: HTMLDivElement;
+  private fireBtn: HTMLDivElement;
+  private jumpBtn: HTMLDivElement;
+  private grabBtn: HTMLDivElement;
+
+  private joystickPointerId = -1;
+  private joystickCenterX = 0;
+  private joystickCenterY = 0;
+  private readonly JOYSTICK_RADIUS = 52;
+
+  private lookPointers = new Map<number, { x: number; y: number }>();
+
+  private styleEl: HTMLStyleElement | null = null;
+  private input: InputManager;
+
+  constructor(input: InputManager) {
+    this.input = input;
+
+    this.styleEl = document.createElement('style');
+    this.styleEl.textContent = CSS;
+    document.head.appendChild(this.styleEl);
+
+    this.container = document.createElement('div');
+    this.container.className = 'mob-overlay';
+
+    // Look area covers the full screen; joystick and buttons sit on top (z-index: 1)
+    this.lookArea = document.createElement('div');
+    this.lookArea.className = 'mob-look';
+    this.container.appendChild(this.lookArea);
+
+    // Joystick
+    const joystickZone = document.createElement('div');
+    joystickZone.className = 'mob-joystick-zone';
+    this.joystickBase = document.createElement('div');
+    this.joystickBase.className = 'mob-joystick-base';
+    this.joystickThumb = document.createElement('div');
+    this.joystickThumb.className = 'mob-joystick-thumb';
+    this.joystickBase.appendChild(this.joystickThumb);
+    joystickZone.appendChild(this.joystickBase);
+    this.container.appendChild(joystickZone);
+
+    // Buttons (appended after look area → higher implicit z-index within same stacking context)
+    this.fireBtn = this.makeBtn('mob-btn-fire', 'FIRE');
+    this.jumpBtn = this.makeBtn('mob-btn-jump', 'JUMP');
+    this.grabBtn = this.makeBtn('mob-btn-grab', 'GRAB');
+    this.container.appendChild(this.fireBtn);
+    this.container.appendChild(this.jumpBtn);
+    this.container.appendChild(this.grabBtn);
+
+    this.bindLookArea();
+    this.bindJoystick();
+    this.bindButton(this.fireBtn,
+      () => this.input.setMobileFireHeld(true),
+      () => this.input.setMobileFireHeld(false),
+    );
+    this.bindButton(this.jumpBtn,
+      () => this.input.setMobileJumpHeld(true),
+      () => this.input.setMobileJumpHeld(false),
+    );
+    this.bindButton(this.grabBtn,
+      () => this.input.pressMobileGrab(),
+      () => { /* grab is one-shot, no release action */ },
+    );
+  }
+
+  public mount(): void {
+    document.body.appendChild(this.container);
+  }
+
+  public show(): void {
+    this.container.style.display = '';
+  }
+
+  public hide(): void {
+    this.container.style.display = 'none';
+    this.input.setMobileFireHeld(false);
+    this.input.setMobileJumpHeld(false);
+    this.input.setMobileMoveAxes(0, 0);
+  }
+
+  public isVisible(): boolean {
+    return this.container.style.display !== 'none';
+  }
+
+  private makeBtn(className: string, label: string): HTMLDivElement {
+    const el = document.createElement('div');
+    el.className = `mob-btn ${className}`;
+    el.textContent = label;
+    return el;
+  }
+
+  private bindLookArea(): void {
+    this.lookArea.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      this.lookArea.setPointerCapture(e.pointerId);
+      this.lookPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    });
+
+    this.lookArea.addEventListener('pointermove', (e) => {
+      const prev = this.lookPointers.get(e.pointerId);
+      if (!prev) return;
+      const dx = e.clientX - prev.x;
+      const dy = e.clientY - prev.y;
+      this.input.setMobileLookDelta(dx, dy);
+      this.lookPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    });
+
+    const endLook = (e: PointerEvent): void => {
+      this.lookPointers.delete(e.pointerId);
+    };
+    this.lookArea.addEventListener('pointerup', endLook);
+    this.lookArea.addEventListener('pointercancel', endLook);
+  }
+
+  private bindJoystick(): void {
+    this.joystickBase.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation(); // don't let look area pick up this touch
+      if (this.joystickPointerId !== -1) return;
+      this.joystickPointerId = e.pointerId;
+      this.joystickBase.setPointerCapture(e.pointerId);
+      const rect = this.joystickBase.getBoundingClientRect();
+      this.joystickCenterX = rect.left + rect.width / 2;
+      this.joystickCenterY = rect.top + rect.height / 2;
+      this.updateJoystick(e.clientX, e.clientY);
+    });
+
+    this.joystickBase.addEventListener('pointermove', (e) => {
+      if (e.pointerId !== this.joystickPointerId) return;
+      this.updateJoystick(e.clientX, e.clientY);
+    });
+
+    const endJoystick = (e: PointerEvent): void => {
+      if (e.pointerId !== this.joystickPointerId) return;
+      this.joystickPointerId = -1;
+      this.joystickThumb.style.transform = 'translate(-50%, -50%)';
+      this.input.setMobileMoveAxes(0, 0);
+    };
+    this.joystickBase.addEventListener('pointerup', endJoystick);
+    this.joystickBase.addEventListener('pointercancel', endJoystick);
+  }
+
+  private updateJoystick(clientX: number, clientY: number): void {
+    const dx = clientX - this.joystickCenterX;
+    const dy = clientY - this.joystickCenterY;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const clamped = Math.min(len, this.JOYSTICK_RADIUS);
+    const nx = len > 0 ? dx / len : 0;
+    const ny = len > 0 ? dy / len : 0;
+
+    this.joystickThumb.style.transform =
+      `translate(calc(-50% + ${nx * clamped}px), calc(-50% + ${ny * clamped}px))`;
+
+    // normX: right = +1 (strafe right), normZ: up on screen = +1 (forward)
+    this.input.setMobileMoveAxes(
+      nx * (clamped / this.JOYSTICK_RADIUS),
+      -ny * (clamped / this.JOYSTICK_RADIUS),
+    );
+  }
+
+  private bindButton(
+    el: HTMLDivElement,
+    onDown: () => void,
+    onUp: () => void,
+  ): void {
+    const active = new Set<number>();
+
+    el.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      el.setPointerCapture(e.pointerId);
+      active.add(e.pointerId);
+      el.classList.add('mob-pressed');
+      onDown();
+    });
+
+    const end = (e: PointerEvent): void => {
+      active.delete(e.pointerId);
+      if (active.size === 0) {
+        el.classList.remove('mob-pressed');
+        onUp();
+      }
+    };
+    el.addEventListener('pointerup', end);
+    el.addEventListener('pointercancel', end);
+  }
+}

--- a/client/src/ui/mobileControls.ts
+++ b/client/src/ui/mobileControls.ts
@@ -1,5 +1,7 @@
 import { InputManager } from '../input';
 
+const MOBILE_LOOK_SCALE = 4.0;
+
 const CSS = `
   .mob-overlay {
     position: fixed;
@@ -45,6 +47,30 @@ const CSS = `
     top: 50%;
     transform: translate(-50%, -50%);
     pointer-events: none;
+  }
+  .mob-power-track {
+    position: absolute;
+    left: 24px;
+    bottom: calc(48px + env(safe-area-inset-bottom, 0px));
+    width: 14px;
+    height: 180px;
+    background: rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(0, 255, 255, 0.4);
+    border-radius: 7px;
+    z-index: 1;
+    overflow: hidden;
+    display: none;
+    pointer-events: none;
+  }
+  .mob-power-fill {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 0%;
+    background: hsl(120, 90%, 55%);
+    border-radius: 7px;
+    transition: none;
   }
   .mob-btn {
     position: absolute;
@@ -96,6 +122,7 @@ const CSS = `
     background: rgba(255, 200, 0, 0.12);
     border: 2px solid rgba(255, 200, 0, 0.28);
     color: rgba(255, 200, 0, 0.75);
+    display: none;
   }
   .mob-btn-grab.mob-pressed {
     background: rgba(255, 200, 0, 0.38);
@@ -106,8 +133,11 @@ const CSS = `
 export class MobileControls {
   private container: HTMLDivElement;
   private lookArea: HTMLDivElement;
+  private joystickZone: HTMLDivElement;
   private joystickBase: HTMLDivElement;
   private joystickThumb: HTMLDivElement;
+  private powerTrack: HTMLDivElement;
+  private powerFill: HTMLDivElement;
   private fireBtn: HTMLDivElement;
   private jumpBtn: HTMLDivElement;
   private grabBtn: HTMLDivElement;
@@ -122,6 +152,9 @@ export class MobileControls {
   private styleEl: HTMLStyleElement | null = null;
   private input: InputManager;
 
+  // Haptic threshold tracking
+  private lastHapticPct = 0;
+
   constructor(input: InputManager) {
     this.input = input;
 
@@ -132,23 +165,31 @@ export class MobileControls {
     this.container = document.createElement('div');
     this.container.className = 'mob-overlay';
 
-    // Look area covers the full screen; joystick and buttons sit on top (z-index: 1)
+    // Look area covers full screen; buttons/joystick sit on top (z-index: 1)
     this.lookArea = document.createElement('div');
     this.lookArea.className = 'mob-look';
     this.container.appendChild(this.lookArea);
 
-    // Joystick
-    const joystickZone = document.createElement('div');
-    joystickZone.className = 'mob-joystick-zone';
+    // Joystick zone
+    this.joystickZone = document.createElement('div');
+    this.joystickZone.className = 'mob-joystick-zone';
     this.joystickBase = document.createElement('div');
     this.joystickBase.className = 'mob-joystick-base';
     this.joystickThumb = document.createElement('div');
     this.joystickThumb.className = 'mob-joystick-thumb';
     this.joystickBase.appendChild(this.joystickThumb);
-    joystickZone.appendChild(this.joystickBase);
-    this.container.appendChild(joystickZone);
+    this.joystickZone.appendChild(this.joystickBase);
+    this.container.appendChild(this.joystickZone);
 
-    // Buttons (appended after look area → higher implicit z-index within same stacking context)
+    // Vertical power track (replaces joystick area when grabbing/aiming)
+    this.powerTrack = document.createElement('div');
+    this.powerTrack.className = 'mob-power-track';
+    this.powerFill = document.createElement('div');
+    this.powerFill.className = 'mob-power-fill';
+    this.powerTrack.appendChild(this.powerFill);
+    this.container.appendChild(this.powerTrack);
+
+    // Buttons (appended after look area → higher implicit z within same stacking context)
     this.fireBtn = this.makeBtn('mob-btn-fire', 'FIRE');
     this.jumpBtn = this.makeBtn('mob-btn-jump', 'JUMP');
     this.grabBtn = this.makeBtn('mob-btn-grab', 'GRAB');
@@ -158,18 +199,9 @@ export class MobileControls {
 
     this.bindLookArea();
     this.bindJoystick();
-    this.bindButton(this.fireBtn,
-      () => this.input.setMobileFireHeld(true),
-      () => this.input.setMobileFireHeld(false),
-    );
-    this.bindButton(this.jumpBtn,
-      () => this.input.setMobileJumpHeld(true),
-      () => this.input.setMobileJumpHeld(false),
-    );
-    this.bindButton(this.grabBtn,
-      () => this.input.pressMobileGrab(),
-      () => { /* grab is one-shot, no release action */ },
-    );
+    this.bindFireBtn();
+    this.bindJumpBtn();
+    this.bindGrabBtn();
   }
 
   public mount(): void {
@@ -191,6 +223,59 @@ export class MobileControls {
     return this.container.style.display !== 'none';
   }
 
+  /** Called every frame from gameApp to sync controls to player state. */
+  public setPhase(phase: string): void {
+    const inGravity = phase === 'BREACH';
+    const onBar = phase === 'GRABBING' || phase === 'AIMING';
+
+    // Joystick: only in gravity (BREACH) walk mode
+    this.joystickZone.style.display = inGravity ? '' : 'none';
+
+    // Vertical power track: only when on a bar
+    // (hidden via setPowerLevel show flag too, but gate here for clarity)
+    if (!onBar) {
+      this.powerTrack.style.display = 'none';
+    }
+
+    // JUMP label transforms to LAUNCH when on bar
+    if (onBar) {
+      this.jumpBtn.textContent = 'LAUNCH';
+    } else {
+      this.jumpBtn.textContent = 'JUMP';
+    }
+  }
+
+  /** Called every frame — show GRAB button only when the player can grab a nearby bar. */
+  public setNearBar(near: boolean, canGrab: boolean): void {
+    const showGrab = near && canGrab;
+    this.grabBtn.style.display = showGrab ? '' : 'none';
+  }
+
+  /** Called every frame with normalised power (0–1) and whether to show the meter. */
+  public setPowerLevel(pct: number, show: boolean): void {
+    this.powerTrack.style.display = show ? '' : 'none';
+    if (!show) {
+      this.lastHapticPct = 0;
+      return;
+    }
+
+    const h = 120 - pct * 120;
+    this.powerFill.style.height = `${(pct * 100).toFixed(1)}%`;
+    this.powerFill.style.background = `hsl(${h}, 90%, 55%)`;
+
+    // Haptic feedback at 25 % thresholds
+    const thresholds = [0.25, 0.5, 0.75, 1.0];
+    for (const t of thresholds) {
+      if (this.lastHapticPct < t && pct >= t) {
+        navigator.vibrate?.(pct >= 1.0 ? 40 : 15);
+        break;
+      }
+    }
+    this.lastHapticPct = pct;
+  }
+
+  // ─── Private helpers ────────────────────────────────────────────────────────
+
   private makeBtn(className: string, label: string): HTMLDivElement {
     const el = document.createElement('div');
     el.className = `mob-btn ${className}`;
@@ -208,8 +293,8 @@ export class MobileControls {
     this.lookArea.addEventListener('pointermove', (e) => {
       const prev = this.lookPointers.get(e.pointerId);
       if (!prev) return;
-      const dx = e.clientX - prev.x;
-      const dy = e.clientY - prev.y;
+      const dx = (e.clientX - prev.x) * MOBILE_LOOK_SCALE;
+      const dy = (e.clientY - prev.y) * MOBILE_LOOK_SCALE;
       this.input.setMobileLookDelta(dx, dy);
       this.lookPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
     });
@@ -224,7 +309,7 @@ export class MobileControls {
   private bindJoystick(): void {
     this.joystickBase.addEventListener('pointerdown', (e) => {
       e.preventDefault();
-      e.stopPropagation(); // don't let look area pick up this touch
+      e.stopPropagation();
       if (this.joystickPointerId !== -1) return;
       this.joystickPointerId = e.pointerId;
       this.joystickBase.setPointerCapture(e.pointerId);
@@ -260,37 +345,120 @@ export class MobileControls {
     this.joystickThumb.style.transform =
       `translate(calc(-50% + ${nx * clamped}px), calc(-50% + ${ny * clamped}px))`;
 
-    // normX: right = +1 (strafe right), normZ: up on screen = +1 (forward)
+    // normX: right=+1 (strafe right), normZ: up on screen=+1 (forward)
     this.input.setMobileMoveAxes(
       nx * (clamped / this.JOYSTICK_RADIUS),
       -ny * (clamped / this.JOYSTICK_RADIUS),
     );
   }
 
-  private bindButton(
-    el: HTMLDivElement,
-    onDown: () => void,
-    onUp: () => void,
-  ): void {
+  // FIRE: hold = shoot; drag = look (issues 2D + 3)
+  private bindFireBtn(): void {
+    const lastPos = new Map<number, { x: number; y: number }>();
     const active = new Set<number>();
 
-    el.addEventListener('pointerdown', (e) => {
+    this.fireBtn.addEventListener('pointerdown', (e) => {
       e.preventDefault();
       e.stopPropagation();
-      el.setPointerCapture(e.pointerId);
+      this.fireBtn.setPointerCapture(e.pointerId);
       active.add(e.pointerId);
-      el.classList.add('mob-pressed');
-      onDown();
+      lastPos.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      this.fireBtn.classList.add('mob-pressed');
+      this.input.setMobileFireHeld(true);
+    });
+
+    this.fireBtn.addEventListener('pointermove', (e) => {
+      const prev = lastPos.get(e.pointerId);
+      if (!prev) return;
+      const dx = (e.clientX - prev.x) * MOBILE_LOOK_SCALE;
+      const dy = (e.clientY - prev.y) * MOBILE_LOOK_SCALE;
+      this.input.setMobileLookDelta(dx, dy);
+      lastPos.set(e.pointerId, { x: e.clientX, y: e.clientY });
     });
 
     const end = (e: PointerEvent): void => {
       active.delete(e.pointerId);
+      lastPos.delete(e.pointerId);
       if (active.size === 0) {
-        el.classList.remove('mob-pressed');
-        onUp();
+        this.fireBtn.classList.remove('mob-pressed');
+        this.input.setMobileFireHeld(false);
       }
     };
-    el.addEventListener('pointerup', end);
-    el.addEventListener('pointercancel', end);
+    this.fireBtn.addEventListener('pointerup', end);
+    this.fireBtn.addEventListener('pointercancel', end);
+  }
+
+  // JUMP / LAUNCH: hold = Space (charge); drag down = charge power via aimingActive routing;
+  // drag horizontal = look. Single-finger launch with haptic feedback.
+  private bindJumpBtn(): void {
+    const lastPos = new Map<number, { x: number; y: number }>();
+    const active = new Set<number>();
+
+    this.jumpBtn.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.jumpBtn.setPointerCapture(e.pointerId);
+      active.add(e.pointerId);
+      lastPos.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      this.jumpBtn.classList.add('mob-pressed');
+      this.input.setMobileJumpHeld(true);
+    });
+
+    this.jumpBtn.addEventListener('pointermove', (e) => {
+      const prev = lastPos.get(e.pointerId);
+      if (!prev) return;
+      // setMobileLookDelta handles routing: when aimingActive, dy → aimDy (charge);
+      // otherwise dy → touchLookDy (look up/down). dx always → look left/right.
+      const dx = (e.clientX - prev.x) * MOBILE_LOOK_SCALE;
+      const dy = (e.clientY - prev.y) * MOBILE_LOOK_SCALE;
+      this.input.setMobileLookDelta(dx, dy);
+      lastPos.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    });
+
+    const end = (e: PointerEvent): void => {
+      active.delete(e.pointerId);
+      lastPos.delete(e.pointerId);
+      if (active.size === 0) {
+        this.jumpBtn.classList.remove('mob-pressed');
+        this.input.setMobileJumpHeld(false);
+      }
+    };
+    this.jumpBtn.addEventListener('pointerup', end);
+    this.jumpBtn.addEventListener('pointercancel', end);
+  }
+
+  // GRAB: one-shot press; drag = look
+  private bindGrabBtn(): void {
+    const lastPos = new Map<number, { x: number; y: number }>();
+    const active = new Set<number>();
+
+    this.grabBtn.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.grabBtn.setPointerCapture(e.pointerId);
+      active.add(e.pointerId);
+      lastPos.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      this.grabBtn.classList.add('mob-pressed');
+      this.input.pressMobileGrab();
+    });
+
+    this.grabBtn.addEventListener('pointermove', (e) => {
+      const prev = lastPos.get(e.pointerId);
+      if (!prev) return;
+      const dx = (e.clientX - prev.x) * MOBILE_LOOK_SCALE;
+      const dy = (e.clientY - prev.y) * MOBILE_LOOK_SCALE;
+      this.input.setMobileLookDelta(dx, dy);
+      lastPos.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    });
+
+    const end = (e: PointerEvent): void => {
+      active.delete(e.pointerId);
+      lastPos.delete(e.pointerId);
+      if (active.size === 0) {
+        this.grabBtn.classList.remove('mob-pressed');
+      }
+    };
+    this.grabBtn.addEventListener('pointerup', end);
+    this.grabBtn.addEventListener('pointercancel', end);
   }
 }

--- a/docs/MOBILE_SUPPORT_IMPLEMENTATION_PLAN.md
+++ b/docs/MOBILE_SUPPORT_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,512 @@
+# ORBITAL BREACH - Mobile Support Implementation Plan
+
+## Goal
+
+Create a production-ready implementation branch and PR that makes Orbital Breach playable on modern mobile browsers, with a focus on iPhone Safari and Android Chrome, while preserving the existing desktop keyboard + mouse experience.
+
+This document is written for Claude Code to execute directly in the repository.
+
+## Why this work is needed
+
+The current client is desktop-only.
+
+Current blockers observed in the repo:
+
+- `client/src/input.ts` only supports keyboard, mouse move, mouse buttons, and pointer lock.
+- `client/src/game/gameApp.ts` starts control flow through mouse down and pointer lock.
+- `client/src/game/gameApp.ts` blocks firing unless `input.isLocked()` is true.
+- `client/src/render/scene.ts` uses full-resolution rendering with antialiasing and no device pixel ratio cap.
+- `client/index.html` uses a basic viewport meta tag and does not prepare for mobile-safe in-game gestures.
+
+## Non-negotiable requirements
+
+1. Do not break desktop controls.
+2. Do not remove pointer lock support for desktop.
+3. Add a separate mobile input path.
+4. Do not require an external library for virtual joysticks unless absolutely necessary.
+5. Keep architecture clean and type-safe.
+6. Keep changes scoped to client-side gameplay and UI.
+7. Make the game playable on touch devices even if controls are initially minimal.
+8. Prefer simple, robust controls over over-designed UI.
+
+## Definition of done
+
+A PR is complete when all of the following are true:
+
+- The game can start on mobile with a tap-based start flow.
+- A touch device can look around, move, jump/charge, grab, and fire.
+- Gameplay no longer depends on pointer lock on mobile.
+- Desktop behavior still works as before.
+- The client builds successfully.
+- Existing tests still pass.
+- Add at least basic tests for the new mobile-related pure logic where practical.
+- README includes mobile control instructions.
+
+## High-level strategy
+
+Implement mobile support in 6 layers:
+
+1. Platform detection and control mode abstraction
+2. Touch-capable input state inside `InputManager`
+3. On-screen mobile controls overlay
+4. Control gating in game loop no longer tied only to pointer lock
+5. Mobile-safe renderer and viewport adjustments
+6. Documentation and test coverage
+
+## Required branch and PR workflow
+
+Claude Code should do the following in order:
+
+1. Create a new branch from `main` named:
+   - `feature/mobile-support`
+2. Implement all changes on that branch.
+3. Run client build and tests.
+4. Update docs.
+5. Open a PR into `main`.
+
+Suggested PR title:
+
+`Add mobile touch controls and mobile-safe gameplay support`
+
+Suggested PR body:
+
+```md
+## Summary
+- add touch/mobile input path alongside desktop controls
+- add on-screen mobile controls overlay
+- remove pointer-lock-only gameplay gating on mobile
+- improve mobile viewport and rendering behavior
+- document mobile controls in README
+
+## Testing
+- npm test
+- npm run build
+- manual smoke test on desktop
+- manual smoke test on iPhone/Android browser
+```
+
+## Repo-specific implementation plan
+
+### 1. Add platform and capability detection
+
+Create a new file:
+
+- `client/src/platform.ts`
+
+Add utilities:
+
+- `isTouchDevice(): boolean`
+- `isMobileLikeDevice(): boolean`
+- `supportsPointerLock(): boolean`
+- `getViewportSize(): { width: number; height: number }`
+
+Implementation notes:
+
+- Use `navigator.maxTouchPoints > 0` and touch capability detection.
+- Do not rely only on user agent.
+- `getViewportSize()` should prefer `window.visualViewport` when available.
+- Keep this file dependency-free.
+
+### 2. Refactor input model to support desktop and mobile
+
+Modify:
+
+- `client/src/input.ts`
+
+Current issue:
+
+The class is hard-wired to keys, mouse, and pointer lock.
+
+Required changes:
+
+- Preserve all current desktop behavior.
+- Add internal touch state for mobile.
+- Add a concept of control mode or platform mode.
+
+Add new internal state roughly like:
+
+```ts
+private touchLookDx = 0;
+private touchLookDy = 0;
+private mobileMoveX = 0;
+private mobileMoveZ = 0;
+private mobileJumpHeld = false;
+private mobileGrabPressed = false;
+private mobileFireHeld = false;
+private mobileControlsActive = false;
+private desktopPointerLockRequired = true;
+```
+
+Add new public methods:
+
+- `setMobileLookDelta(dx: number, dy: number): void`
+- `setMobileMoveAxes(x: number, z: number): void`
+- `setMobileJumpHeld(active: boolean): void`
+- `pressMobileGrab(): void`
+- `setMobileFireHeld(active: boolean): void`
+- `setMobileControlsActive(active: boolean): void`
+- `canControlGame(): boolean`
+- `isUsingTouchControls(): boolean`
+
+Behavior requirements:
+
+- `consumeMouseDelta()` should merge desktop mouse deltas and touch look deltas.
+- `getWalkAxes()` should combine desktop keyboard axes and mobile virtual joystick axes without exceeding normal magnitude.
+- `isJumping()` and `isAiming()` should respect mobile jump/charge hold.
+- `consumeGrab()` should work with touch button press.
+- `consumeFire()` should work with held mobile fire button and existing fire cooldown.
+- `canControlGame()` should return:
+  - desktop: `isLocked()`
+  - mobile: `mobileControlsActive`
+
+Do not remove `lockPointer()` or `isLocked()`.
+
+### 3. Add a dedicated mobile controls overlay
+
+Create new files:
+
+- `client/src/ui/mobileControls.ts`
+- optionally `client/src/ui/mobileControlsView.ts`
+
+This should be a DOM overlay, not Three.js UI.
+
+Minimum controls to implement:
+
+- Left thumb joystick area for movement
+- Right-side drag area for look
+- Fire button
+- Grab button
+- Jump / Charge button
+
+Optional controls:
+
+- Third-person toggle button
+- Scoreboard button
+
+Required behavior:
+
+- Left joystick controls `getWalkAxes()` equivalent input.
+- Right-side drag controls camera look.
+- Jump button should act like holding `Space`.
+- Grab button should act like one-shot `E` press.
+- Fire button should behave like holding LMB.
+
+UX constraints:
+
+- Large touch targets
+- Semi-transparent controls
+- Controls should not overlap critical HUD text where possible
+- Add `touch-action: none` on relevant elements
+- Prevent pinch zoom and page scrolling while actively playing
+
+Recommended API:
+
+```ts
+class MobileControls {
+  constructor(input: InputManager)
+  mount(): void
+  unmount(): void
+  show(): void
+  hide(): void
+  setEnabled(enabled: boolean): void
+  isVisible(): boolean
+}
+```
+
+Implementation guidance:
+
+- Use Pointer Events if possible.
+- Fall back carefully only if needed.
+- Keep DOM creation encapsulated inside this class.
+- Avoid React or external UI packages.
+
+### 4. Update game start and control gating
+
+Modify:
+
+- `client/src/game/gameApp.ts`
+
+Current issue:
+
+Gameplay assumes pointer lock as the universal gate for active control.
+
+Required changes:
+
+- Instantiate `MobileControls` when touch/mobile is detected.
+- On mobile, do not require pointer lock to start playing.
+- On desktop, keep current pointer lock behavior.
+- Introduce a clear start flow for mobile.
+
+Required logic changes:
+
+#### Start flow
+
+Current desktop start flow can remain.
+
+For mobile:
+
+- Tapping Play should enable mobile controls.
+- Start the round without attempting pointer lock.
+- Show controls after the menu is dismissed.
+
+#### Firing gate
+
+Change this logic in `tickWeaponFire()`:
+
+Current:
+
+```ts
+if (!this.input.isLocked() || !inZeroG) return;
+```
+
+Replace with:
+
+```ts
+if (!this.input.canControlGame() || !inZeroG) return;
+```
+
+Also review any other logic that wrongly assumes active play requires pointer lock.
+
+#### Canvas interaction
+
+Current constructor binds `mousedown` on renderer DOM element to request pointer lock.
+
+Keep that only for desktop-capable pointer lock flows.
+
+Do not bind mobile start behavior to `mousedown`.
+
+### 5. Add mobile-safe scene and viewport behavior
+
+Modify:
+
+- `client/src/render/scene.ts`
+- `client/index.html`
+
+#### `scene.ts` changes
+
+Required:
+
+- Cap pixel ratio for mobile and general safety:
+
+```ts
+this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5));
+```
+
+- Use viewport helper from `platform.ts` for initial size and resize updates.
+- Ensure resize logic handles mobile browser chrome changes.
+
+Recommended:
+
+- Consider disabling antialias on mobile if performance is poor.
+- Keep initial implementation conservative and simple.
+
+#### `index.html` changes
+
+Replace viewport meta with something mobile-safe:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no" />
+```
+
+Add CSS safeguards:
+
+- `touch-action: none` on `body`, `canvas`, and control overlay roots where appropriate
+- prevent selection/callout where useful
+- preserve full-screen fixed layout
+
+### 6. Keep HUD and menu usable on mobile
+
+Inspect and adjust if needed:
+
+- `client/src/render/hud.ts`
+- `client/src/ui/menu.ts`
+- `client/src/ui/menu/menuView.ts`
+
+Requirements:
+
+- Menu buttons must remain tappable.
+- HUD must not fully overlap movement/fire controls.
+- If needed, shift some HUD elements upward or inward on narrow screens.
+- Do not redesign the whole UI unless necessary.
+
+### 7. Add README mobile controls documentation
+
+Modify:
+
+- `README.md`
+
+Add a new subsection near Controls:
+
+```md
+### Mobile Controls
+
+- Left thumb: move
+- Right thumb drag: look
+- Fire button: shoot
+- Grab button: grab nearest bar
+- Jump/Charge button: jump in breach room, hold to charge while grabbing
+```
+
+Also update Current Status if mobile support becomes available.
+
+### 8. Testing requirements
+
+Run and fix as needed:
+
+- root tests if configured
+- client build
+- any relevant lint/typecheck scripts available in package.json
+
+At minimum, Claude Code must run:
+
+```bash
+npm test
+cd client && npm run build
+```
+
+If repo scripts differ, inspect package.json and use the actual available scripts.
+
+### 9. Add or update tests
+
+Inspect current test setup and add tests for pure logic where practical.
+
+Good candidates:
+
+- platform detection helper behavior where mockable
+- input merging logic in `InputManager`
+- control gating behavior via `canControlGame()`
+
+Do not waste time trying to fully automate browser touch UI behavior if that becomes brittle. Focus on pure logic and build safety.
+
+## Concrete file checklist
+
+### New files expected
+
+- `client/src/platform.ts`
+- `client/src/ui/mobileControls.ts`
+- optional supporting style/view file if needed
+
+### Files likely to modify
+
+- `client/index.html`
+- `client/src/input.ts`
+- `client/src/game/gameApp.ts`
+- `client/src/render/scene.ts`
+- `client/src/render/hud.ts` if overlap requires tweaks
+- `client/src/ui/menu.ts` if start flow needs mobile path
+- `client/src/ui/menu/menuView.ts` if button labels or instructions need updates
+- `README.md`
+
+## Important implementation details
+
+### Movement joystick
+
+Keep it simple.
+
+Suggested approach:
+
+- A fixed circular touch region at bottom-left
+- Track active pointer id
+- Compute vector from joystick center to current pointer position
+- Clamp to radius
+- Normalize to `[-1, 1]`
+- Feed `input.setMobileMoveAxes(x, z)`
+
+Map screen movement to game movement like:
+
+- right = positive X
+- up = positive Z
+
+### Look drag
+
+Suggested approach:
+
+- Right half-screen drag zone or floating zone at bottom-right
+- Track pointer delta each move event
+- Apply scaled deltas into `input.setMobileLookDelta(dx, dy)`
+- Tune sensitivity separately from desktop if needed
+
+### Jump / charge behavior
+
+Keep semantics aligned with existing game rules:
+
+- In breach room: jump
+- While grabbing: hold to charge
+- Release: handled by existing player logic when `isAiming()` becomes false
+
+### Fire behavior
+
+Mobile fire button should set a held state.
+`consumeFire()` should continue to use cooldown logic already present.
+
+### Grab behavior
+
+Grab should remain a one-shot action, not a held state.
+
+### Performance fallback
+
+If mobile performance is poor after initial implementation, add a simple mobile quality flag such as:
+
+- lower pixel ratio cap
+- disable antialias on touch devices
+
+Only do this if needed.
+
+## Suggested commit breakdown
+
+1. `feat: add platform detection utilities for mobile support`
+2. `feat: extend input manager with touch control state`
+3. `feat: add mobile controls overlay`
+4. `refactor: decouple gameplay control gating from pointer lock`
+5. `perf: improve mobile viewport and renderer behavior`
+6. `docs: document mobile controls in README`
+7. `test: add coverage for mobile input/control logic`
+
+## Manual QA checklist
+
+Claude Code should include this checklist in the PR description or internal notes.
+
+### Desktop
+
+- Menu still opens normally
+- Play still locks pointer on desktop
+- WASD movement still works
+- Mouse look still works
+- Fire still works
+- Grab/jump still work
+- No regressions in round flow
+
+### Mobile
+
+- Game loads in mobile browser
+- Play starts the round without pointer lock
+- Left joystick moves player
+- Right drag looks around
+- Fire button shoots
+- Grab button works near a bar
+- Jump/charge button works in both contexts
+- No page scrolling while playing
+- Orientation changes do not permanently break layout
+
+## Constraints and anti-patterns
+
+Do not:
+
+- rewrite the whole input system from scratch if additive refactor works
+- add a game engine UI library
+- couple touch controls directly into unrelated gameplay classes
+- gate mobile gameplay behind pointer lock hacks
+- use a user-agent-only solution
+
+## Final deliverables
+
+Claude Code must produce:
+
+1. A working implementation branch: `feature/mobile-support`
+2. A PR into `main`
+3. Updated README docs
+4. Passing build/tests or clearly documented remaining issues
+
+## Execution note for Claude Code
+
+Make reasonable decisions without blocking on open questions. If a detail is ambiguous, choose the simplest implementation that preserves desktop behavior and makes mobile playable first.

--- a/tests/mobileInputLogic.test.ts
+++ b/tests/mobileInputLogic.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
   applyMobileLookDelta,
   mergeWalkAxes,
-  checkHapticThreshold,
   type MobileLookState,
 } from '../client/src/input/mobileInputLogic';
 
@@ -86,40 +85,3 @@ describe('mergeWalkAxes', () => {
   });
 });
 
-describe('checkHapticThreshold', () => {
-  it('returns null when no threshold is crossed', () => {
-    expect(checkHapticThreshold(0.1, 0.2)).toBeNull();
-    expect(checkHapticThreshold(0.5, 0.6)).toBeNull();
-  });
-
-  it('returns 15 ms when crossing 25 % threshold', () => {
-    expect(checkHapticThreshold(0.2, 0.25)).toBe(15);
-    expect(checkHapticThreshold(0.0, 0.3)).toBe(15);
-  });
-
-  it('returns 15 ms when crossing 50 % threshold', () => {
-    expect(checkHapticThreshold(0.4, 0.5)).toBe(15);
-  });
-
-  it('returns 15 ms when crossing 75 % threshold', () => {
-    expect(checkHapticThreshold(0.7, 0.76)).toBe(15);
-  });
-
-  it('returns 40 ms when crossing 100 % threshold', () => {
-    expect(checkHapticThreshold(0.9, 1.0)).toBe(40);
-  });
-
-  it('returns null when already past a threshold (no re-trigger)', () => {
-    expect(checkHapticThreshold(0.26, 0.3)).toBeNull();
-    expect(checkHapticThreshold(1.0, 1.0)).toBeNull();
-  });
-
-  it('fires only the first crossed threshold in a large jump', () => {
-    // Jumping from 0 to 0.8 crosses 0.25 first — should return 15, not 40
-    expect(checkHapticThreshold(0.0, 0.8)).toBe(15);
-  });
-
-  it('returns null when power decreases', () => {
-    expect(checkHapticThreshold(0.8, 0.5)).toBeNull();
-  });
-});

--- a/tests/mobileInputLogic.test.ts
+++ b/tests/mobileInputLogic.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyMobileLookDelta,
+  mergeWalkAxes,
+  checkHapticThreshold,
+  type MobileLookState,
+} from '../client/src/input/mobileInputLogic';
+
+function makeState(overrides?: Partial<MobileLookState>): MobileLookState {
+  return { touchLookDx: 0, touchLookDy: 0, aimDy: 0, ...overrides };
+}
+
+describe('applyMobileLookDelta', () => {
+  it('routes dx to touchLookDx in both modes', () => {
+    const s = makeState();
+    applyMobileLookDelta(s, false, 10, 0);
+    expect(s.touchLookDx).toBe(10);
+  });
+
+  it('routes dy to touchLookDy when not aiming', () => {
+    const s = makeState();
+    applyMobileLookDelta(s, false, 0, 5);
+    expect(s.touchLookDy).toBe(5);
+    expect(s.aimDy).toBe(0);
+  });
+
+  it('routes dy to aimDy when aiming active', () => {
+    const s = makeState();
+    applyMobileLookDelta(s, true, 0, 5);
+    expect(s.aimDy).toBe(5);
+    expect(s.touchLookDy).toBe(0);
+  });
+
+  it('accumulates multiple calls', () => {
+    const s = makeState();
+    applyMobileLookDelta(s, false, 3, 4);
+    applyMobileLookDelta(s, false, 1, 2);
+    expect(s.touchLookDx).toBe(4);
+    expect(s.touchLookDy).toBe(6);
+  });
+
+  it('switches routing mid-drag when aimingActive changes', () => {
+    const s = makeState();
+    applyMobileLookDelta(s, false, 0, 10);
+    applyMobileLookDelta(s, true, 0, 20);
+    expect(s.touchLookDy).toBe(10);
+    expect(s.aimDy).toBe(20);
+  });
+
+  it('negative dx accumulates correctly', () => {
+    const s = makeState({ touchLookDx: 5 });
+    applyMobileLookDelta(s, false, -8, 0);
+    expect(s.touchLookDx).toBe(-3);
+  });
+});
+
+describe('mergeWalkAxes', () => {
+  it('returns keyboard axis when no mobile input', () => {
+    expect(mergeWalkAxes(1, 0, 0, 0)).toEqual({ x: 1, z: 0 });
+  });
+
+  it('returns mobile axis when no keyboard input', () => {
+    expect(mergeWalkAxes(0, 0, 0.5, 0.8)).toEqual({ x: 0.5, z: 0.8 });
+  });
+
+  it('sums keyboard and mobile axes', () => {
+    expect(mergeWalkAxes(0.5, 0, 0.3, 0)).toEqual({ x: 0.8, z: 0 });
+  });
+
+  it('clamps sum to 1 when both push same direction', () => {
+    expect(mergeWalkAxes(1, 0, 1, 0)).toEqual({ x: 1, z: 0 });
+  });
+
+  it('clamps sum to -1 when both push negative direction', () => {
+    expect(mergeWalkAxes(-1, 0, -0.8, 0)).toEqual({ x: -1, z: 0 });
+  });
+
+  it('does not clamp when inputs cancel out', () => {
+    expect(mergeWalkAxes(1, 0, -1, 0)).toEqual({ x: 0, z: 0 });
+  });
+
+  it('handles diagonal inputs independently on both axes', () => {
+    const result = mergeWalkAxes(0.6, 0.4, 0.3, 0.5);
+    expect(result.x).toBeCloseTo(0.9);
+    expect(result.z).toBeCloseTo(0.9);
+  });
+});
+
+describe('checkHapticThreshold', () => {
+  it('returns null when no threshold is crossed', () => {
+    expect(checkHapticThreshold(0.1, 0.2)).toBeNull();
+    expect(checkHapticThreshold(0.5, 0.6)).toBeNull();
+  });
+
+  it('returns 15 ms when crossing 25 % threshold', () => {
+    expect(checkHapticThreshold(0.2, 0.25)).toBe(15);
+    expect(checkHapticThreshold(0.0, 0.3)).toBe(15);
+  });
+
+  it('returns 15 ms when crossing 50 % threshold', () => {
+    expect(checkHapticThreshold(0.4, 0.5)).toBe(15);
+  });
+
+  it('returns 15 ms when crossing 75 % threshold', () => {
+    expect(checkHapticThreshold(0.7, 0.76)).toBe(15);
+  });
+
+  it('returns 40 ms when crossing 100 % threshold', () => {
+    expect(checkHapticThreshold(0.9, 1.0)).toBe(40);
+  });
+
+  it('returns null when already past a threshold (no re-trigger)', () => {
+    expect(checkHapticThreshold(0.26, 0.3)).toBeNull();
+    expect(checkHapticThreshold(1.0, 1.0)).toBeNull();
+  });
+
+  it('fires only the first crossed threshold in a large jump', () => {
+    // Jumping from 0 to 0.8 crosses 0.25 first — should return 15, not 40
+    expect(checkHapticThreshold(0.0, 0.8)).toBe(15);
+  });
+
+  it('returns null when power decreases', () => {
+    expect(checkHapticThreshold(0.8, 0.5)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Streams the objective sentence character-by-character during the **first** game's countdown only; subsequent rounds skip it
- Text color and dark backdrop match the local player's team (cyan / magenta) for legibility against the portal/energy-wall glow

## Files changed
- client/src/game/gameApp.ts — fires the typewriter hook on first countdown
- client/src/render/hud.ts — typewriter animation + team-color styling
- client/src/render/hud/hudView.ts — injects the typewriter DOM element

## Test plan
- [x] Start a game, observe typewriter text during first countdown (correct team color)
- [x] Complete round 1 and start round 2 — typewriter should NOT replay
- [x] TypeScript compiles clean: cd client && node_modules/.bin/tsc --noEmit
- [x] All unit tests pass: 
pm test from repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full touch device support with on-screen joystick controls, camera look, and action buttons (fire, jump, grab, view toggle)
  * Added objective display with animated typewriter effect and team-specific styling during first round countdown
  * Mobile-optimized HUD and menu with responsive layouts for small screens and landscape viewports

* **Documentation**
  * Mobile support implementation plan

* **Tests**
  * Mobile input logic validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->