### PR TITLE
Release staging to main: solo AI bots and round polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ CLAUDE.local.md
 # Root-level dev tooling (concurrently) — not part of deployable code
 /package.json
 /package-lock.json
+/.codex

--- a/README.md
+++ b/README.md
@@ -1,222 +1,122 @@
 # ORBITAL BREACH
 
-> **Vibe Game Jam 2026 Entry** · Zero-G Arena Shooter · Up to 20v20
+Zero-G arena shooter for Vibe Game Jam 2026.
 
-A fast-paced multiplayer first-person shooter where teams compete to breach each other's gravity chamber in a zero-gravity arena. Grab bars to launch yourself at high velocity, coordinate with teammates to freeze enemies and secure victory.
+The current branch focuses on local solo play with AI bots. `PLAY SOLO` now supports `1v1`, `5v5`, `10v10`, and `20v20` local skirmishes, while the later Colyseus multiplayer phase stays documented but intentionally unimplemented here.
 
 ---
 
-## How to Play
+## How To Play
 
 ### Objective
-Be the first player to float through the enemy's **breach portal** into their gravity room. Each breach scores a point for your team.
+Float through the enemy breach portal to score for your team. Freeze shots disable enemy movement and abilities for the rest of the round.
 
 ### Controls
 
 | Input | Action |
-|-------|--------|
-| `WASD` | Move (in breach room only) |
-| `Space` | Jump (breach room) / Hold to charge launch (while grabbing a bar) |
-| `E` | Grab nearest bar |
+|---|---|
+| `WASD` | Move inside breach rooms |
+| `Mouse` | Look around |
+| `Space` | Jump in breach rooms / hold to charge launch while grabbing |
+| `E` | Grab or release a bar |
 | `LMB` | Fire freeze pistol |
 | `V` | Toggle third-person view |
 | `B` | Hold selfie view |
-| `Mouse` | Look — gravity FPS in breach room, free zero-G in arena |
 | `Tab` | Show scoreboard |
-| `Esc` | Release mouse |
+| `Esc` | Release cursor |
 
-### Zero-G Movement
-The arena has **no gravity**. You move by:
-1. **Grabbing bars** — orange cylinders on obstacles (`E` when near one)
-2. **Charging** — hold `Space` while grabbing; mouse-Y adjusts launch power
-3. **Launching** — release `Space` to fly in camera direction
+### Solo Bot Modes
 
-### Damage Zones
-Being hit by a freeze shot affects specific body zones:
-- **Head / Body** → Frozen for the round (drifts helplessly)
-- **Right Arm** → Cannot fire pistol
-- **Left Arm** → Cannot grab bars
-- **Legs** → Launch power capped at 75% for one leg and 50% for both legs
+From the main menu, choose one of these local match sizes before pressing `PLAY SOLO`:
+
+- `1v1 Skirmish`
+- `5v5 Squad Clash`
+- `10v10 Arena Rush`
+- `20v20 Zero-G War`
+
+The player is always placed on Team Cyan, and the remaining slots are filled with bots.
 
 ---
 
 ## Running Locally
 
 ### Prerequisites
+
 - Node.js 18+
 
 ### Development
 
 ```bash
-# Terminal 1 — server (ws://localhost:3001)
+# Terminal 1
 cd server && npm install && npm run dev
 
-# Terminal 2 — client (http://localhost:5173)
+# Terminal 2
 cd client && npm install && npm run dev
 ```
 
-Open **http://localhost:5173**
+Open [http://localhost:5173](http://localhost:5173).
 
-### Production Build
+### Build
 
 ```bash
-cd client && npm run build    # outputs to client/dist/
-cd server && npm run build    # outputs to server/dist/
+cd client && npm run build
+cd server && npm run build
 ```
 
-### Deployment
-- **Client**: Vercel (configured in `vercel.json`)
-- **Server**: Requires separate Node.js hosting like [Colyseus](https://colyseus.io/) — set `PORT` env var (default: 3001)
+### Validation Commands
+
+```bash
+npm test
+.\client\node_modules\.bin\tsc.cmd -p client/tsconfig.json --noEmit
+.\server\node_modules\.bin\tsc.cmd -p server/tsconfig.json --noEmit
+```
 
 ---
 
-## Project Structure
+## Architecture Summary
 
-```
-Orbital-Breach/
-├── .claude/                         # AI context files for Claude integration
-├── .gitignore                       # Git ignore configuration
-├── .impeccable.md                   # Code quality standards documentation
-├── .worktreeinclude                 # Git worktree inclusion rules
-├── CLAUDE.md                        # Development notes and AI prompts
-├── README.md                        # This file - project documentation
-├── tsconfig.test.json               # TypeScript config for test files
-├── vercel.json                      # Vercel deployment configuration
-├── vitest.config.ts                 # Vitest test runner configuration
-│
-├── client/                          # Vite + Three.js browser app (TypeScript)
-│   ├── index.html                   # HTML entry point for web app
-│   ├── package.json                 # Client dependencies and scripts
-│   ├── package-lock.json            # Locked dependency versions
-│   ├── tsconfig.json                # TypeScript configuration for client
-│   ├── vite.config.ts               # Vite build configuration
-│   ├── public/
-│   │   └── models/                  # 3D model assets in GLB format
-│   │       ├── Alien.glb            # Player character model
-│   │       ├── Alien_Helmet.glb     # Helmet/head model
-│   │       └── Ray Gun.glb          # Weapon visual model
-│   └── src/
-│       ├── main.ts                  # Application entry point - bootstraps game
-│       ├── app.ts                   # Game orchestrator - high-level game logic
-│       ├── camera.ts                # Dual-mode camera controller (gravity & zero-G)
-│       ├── combat.ts                # Combat system stub (in progress)
-│       ├── config.ts                # Global game configuration and settings
-│       ├── featureFlags.ts          # Feature toggle system for experimental features
-│       ├── input.ts                 # Keyboard and mouse input handler
-│       ├── physics.ts               # Physics calculations and collision detection
-│       ├── player.ts                # Player state machine stub
-│       ├── projectile.ts            # Projectile/bullet behavior and logic
-│       ├── arena/                   # Arena geometry and game mechanics
-│       │   ├── arena.ts             # Main arena manager and setup
-│       │   ├── bar.ts               # Grab bar implementation for zero-G movement
-│       │   ├── breachRoomQueries.ts # Breach room intersection and query tests
-│       │   ├── breachWalls.ts       # Breach room wall geometry and colliders
-│       │   ├── goal.ts              # Breach portal mechanics and scoring
-│       │   ├── obstacleCollision.ts # Obstacle collision detection system
-│       │   ├── portalBars.ts        # Portal bar visualization and placement
-│       │   ├── portalEnergyWall.ts  # Portal energy barrier visual effects
-│       │   └── states.ts            # Arena state enum (active, paused, etc.)
-│       ├── game/                    # Game loop and core systems
-│       │   ├── gameApp.ts           # Main game app controller and loop manager
-│       │   ├── bulletCollision.ts   # Bullet-to-player collision detection
-│       │   ├── cameraYawFromBreach.ts # Camera orientation helper for breach rooms
-│       │   ├── gunTuneOverlay.ts    # Debug UI for weapon tuning
-│       │   ├── projectileSystem.ts  # Projectile spawn and update system
-│       │   ├── roundController.ts   # Round state management and transitions
-│       │   └── weaponFire.ts        # Weapon firing logic and constraints
-│       ├── net/                     # Networking layer (WebSocket)
-│       │   ├── client.ts            # WebSocket client network manager
-│       │   ├── messages.ts          # Network message type definitions
-│       │   └── reconciliation.ts    # Server reconciliation stub (in progress)
-│       ├── player/                  # Player-specific mechanics
-│       │   ├── localPlayer.ts       # Local player state machine and controller
-│       │   ├── playerAnimationController.ts # Animation state management
-│       │   ├── playerCombat.ts      # Player combat state and damage zones
-│       │   ├── playerGrabPose.ts    # Grab pose animation and IK
-│       │   ├── playerSpawn.ts       # Player spawn location and logic
-│       │   ├── playerThirdPersonGun.ts # Third-person gun visual and positioning
-│       │   └── playerTypes.ts       # TypeScript interfaces for player data
-│       ├── render/                  # Rendering and UI
-│       │   ├── gun.ts               # Gun visual model loader and setup
-│       │   ├── hud.ts               # HUD manager and coordinate system
-│       │   ├── materials.ts         # Three.js material definitions and shared materials
-│       │   ├── scene.ts             # Three.js scene initialization and setup
-│       │   └── hud/                 # HUD UI components
-│       │       ├── hudView.ts       # Main HUD display (health, ammo, score)
-│       │       └── scoreboard.ts    # Player scoreboard and team scores
-│       ├── ui/                      # UI screens and menus
-│       │   ├── menu.ts              # Menu controller and navigation
-│       │   └── menu/
-│       │       └── menuView.ts      # Main menu UI view and buttons
-│       └── util/                    # Utility functions and helpers
-│           ├── math.ts              # Math utility functions and vector helpers
-│           └── pool.ts              # Object pool utility for garbage collection
-│
-├── server/                          # Node.js WebSocket server (authoritative)
-│   ├── package.json                 # Server dependencies and scripts
-│   ├── package-lock.json            # Locked dependency versions
-│   ├── tsconfig.json                # TypeScript configuration for server
-│   └── src/
-│       ├── index.ts                 # Server entry point and initialization
-│       ├── player.ts                # Server-side player state and data
-│       ├── room.ts                  # Match/room lifecycle management
-│       ├── sim.ts                   # Authoritative physics simulator
-│       └── net/
-│           ├── messageCodec.ts      # Message encoding and decoding
-│           └── wsServer.ts          # WebSocket server setup and handlers
-│
-├── shared/                          # Shared TypeScript code (client & server)
-│   ├── schema.ts                    # Network message types and protocol
-│   ├── constants.ts                 # Game tuning parameters and balance values
-│   └── arena-gen.ts                 # Procedural arena generation algorithm
-│
-├── docs/                            # Documentation files
-│   ├── ARCHITECTURE.md              # Detailed architecture and system design
-│   └── TESTING.md                   # Testing guide and test strategies
-│
-└── tests/                           # Unit and integration tests
-    ├── arena-gen.test.ts            # Arena generation algorithm tests
-    ├── breachRoomQueries.test.ts    # Breach room intersection query tests
-    ├── bulletCollision.test.ts      # Bullet collision system tests
-    ├── cameraYawFromBreach.test.ts  # Camera orientation calculation tests
-    └── smoke.test.ts                # Basic smoke tests
-```
+### Client
 
-### Networking Model
-- Authoritative server at 20 Hz tick rate
-- Client-side prediction with server reconciliation (in progress)
-- Entity interpolation for remote players (in progress)
-- Deterministic arena: same seed → identical layout on both ends
+- `client/src/game/gameApp.ts`: top-level loop, menu flow, HUD updates, projectile updates
+- `client/src/match/localMatch.ts`: local solo match coordinator for bots, rosters, scoring, and actor hit handling
+- `client/src/match/botBrain.ts`: bot decision logic for bar seeking, aiming, firing, and breach-room walking
+- `client/src/match/simulatedPlayerAvatar.ts`: lightweight bot rendering
+- `client/src/player/localPlayer.ts`: human-controlled actor state and movement
+- `client/src/game/projectileSystem.ts`: projectile visuals plus nearest-hit resolution against obstacles, portal shields, and actors
+
+### Shared
+
+- `shared/match.ts`: solo match-size and bot-fill helpers
+- `shared/player-logic.ts`: transport-neutral hit classification, launch-power, and spawn helpers
+- `shared/vec3.ts`: lightweight vector math
+- `shared/schema.ts`: shared enums and HUD/network-facing types
+
+### Server
+
+- Current `server/` WebSocket transport remains placeholder infrastructure on this branch
+- The later Colyseus migration is documented in [docs/COLYSEUS_MULTIPLAYER_IMPLEMENTATION_PLAN.md](docs/COLYSEUS_MULTIPLAYER_IMPLEMENTATION_PLAN.md)
 
 ---
 
 ## Current Status
 
-Solo play is fully functional. Multiplayer, lobby, bots, and sound are in active development for jam submission.
-
 | Feature | Status |
 |---|---|
-| Zero-G movement (grab bars, launch, drift) | ✅ Done |
-| Breach rooms with gravity | ✅ Done |
-| Freeze pistol + hit zones | ✅ Done |
-| Portal doors (open on round start) | ✅ Done |
-| Procedural arena generation | ✅ Done |
-| HUD (score, power bar, damage, countdown) | ✅ Done |
-| Main menu | 🔄 In progress |
-| Sound engine | 🔄 In progress |
-| Real multiplayer (WebSocket) | 🔄 In progress |
-| Lobby + ready-up | 🔄 In progress |
-| Bot AI | 🔄 In progress |
-| Remote player rendering | 🔄 In progress |
-| Kill feed | 🔄 In progress |
-| All-frozen win condition | 🔄 In progress |
-| GLTF character models | ⬜ Planned |
+| Zero-G movement, grab, and launch | Done |
+| Breach rooms and portal doors | Done |
+| Freeze pistol and damage zones | Done |
+| Main menu | Done |
+| Local solo bot matches | Done |
+| Match size selector (`1v1`, `5v5`, `10v10`, `20v20`) | Done |
+| Local bot rendering and scoreboards | Done |
+| WebSocket multiplayer transport | Placeholder |
+| Colyseus lobby multiplayer | Planned |
 
 ---
 
-## Credits
+## Docs
 
-- 3D Models: [Quaternius](https://quaternius.com)
-- Rendering: [Three.js](https://threejs.org)
-- Build: [Vite](https://vitejs.dev)
-- Entry: [Vibe Game Jam 2026](https://vibej.am/2026/)
+- [Architecture](docs/ARCHITECTURE.md)
+- [Testing](docs/TESTING.md)
+- [AI Bots Implementation Plan](docs/AI_BOTS_IMPLEMENTATION_PLAN.md)
+- [Colyseus Multiplayer Plan](docs/COLYSEUS_MULTIPLAYER_IMPLEMENTATION_PLAN.md)

--- a/client/src/arena/arena.ts
+++ b/client/src/arena/arena.ts
@@ -153,6 +153,10 @@ export class Arena {
     return nearest;
   }
 
+  public getAllBarGrabPoints(): THREE.Vector3[] {
+    return this.barObjects.map((bar) => bar.getGrabPoint());
+  }
+
   public bounceObstacles(state: PhysicsState): void {
     const boxes = this.obstaclesGroup.children.map((child) =>
       new THREE.Box3().setFromObject(child as THREE.Mesh),

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -350,6 +350,7 @@ export class App {
       score: this.match.getScore(),
       phase: this.round.getPhase(),
       countdown: this.round.getCountdown(),
+      roundTimeRemaining: this.round.getRoundTimeRemaining(),
       playerPhase: this.player.phase,
       launchPower: this.player.launchPower,
       maxLaunchPower: this.player.maxLaunchPower(),

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -10,6 +10,7 @@ import { LocalPlayer } from "../player";
 import { GunViewModel } from "../render/gun";
 import { HUD } from "../render/hud";
 import { SceneManager } from "../render/scene";
+import { KillFeed } from "../ui/kill-feed";
 import { MainMenu } from "../ui/menu";
 import { MobileControls } from "../ui/mobileControls";
 import { cameraYawFacingBreachOpening } from "./cameraYawFromBreach";
@@ -27,6 +28,7 @@ export class App {
   private gunTuneOverlay = new GunTuneOverlay();
   private hud: HUD;
   private input: InputManager;
+  private killFeed = new KillFeed();
   private lastTime = 0;
   private match: LocalMatch;
   private menu: MainMenu;
@@ -52,13 +54,33 @@ export class App {
     this.sceneMgr.getScene().add(this.sceneMgr.getCamera());
     this.gun = new GunViewModel(this.sceneMgr.getCamera());
 
-    this.player.onRoundWin = (team) => {
-      this.match.recordHumanScore(team);
-      this.onRoundWin(team);
+    this.match.onEvent = (event) => {
+      switch (event.type) {
+        case "hitConfirm":
+          this.hud.triggerHitConfirm(event.team);
+          break;
+        case "freeze":
+          this.killFeed.addKill(
+            event.killerName,
+            event.killerTeam,
+            event.victimName,
+            event.victimTeam,
+          );
+          break;
+        case "score":
+          this.killFeed.addScore(event.scorerName, event.scorerTeam);
+          break;
+        case "roundWin":
+          this.onRoundWin(event.winningTeam);
+          break;
+        case "roundTie":
+          this.onRoundTie();
+          break;
+      }
     };
-    this.match.onScore = (team) => this.onRoundWin(team);
     this.round.onBeginRound = () => this.beginNewRound();
     this.round.onCountdownEnd = () => this.arena.setPortalDoorsOpen(true);
+    this.round.onRoundTimeout = () => this.match.handleRoundTimeout();
 
     if (this.mobile) {
       this.mobileControls = new MobileControls(this.input);
@@ -105,8 +127,7 @@ export class App {
 
     const layout = generateArenaLayout();
     this.arena.loadLayout(layout);
-    this.player.resetForNewRound(this.arena);
-    this.match.resetForRound(this.arena);
+    this.match.resetForRound(this.arena, this.player);
 
     const openAxis = this.arena.getBreachOpenAxis(this.player.team);
     const openSign = this.arena.getBreachOpenSign(this.player.team);
@@ -118,7 +139,15 @@ export class App {
 
   private onRoundWin(team: 0 | 1): void {
     if (!this.round.isPlaying()) return;
+    this.projectiles.clear();
     this.hud.showRoundEnd(team === 0 ? "CYAN WINS" : "MAGENTA WINS");
+    this.round.endRound();
+  }
+
+  private onRoundTie(): void {
+    if (!this.round.isPlaying()) return;
+    this.projectiles.clear();
+    this.hud.showRoundEnd("TIE");
     this.round.endRound();
   }
 

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -1,48 +1,42 @@
-import { Arena } from '../arena/arena';
-import { CameraController } from '../camera';
-import { InputManager } from '../input';
-import { LocalPlayer } from '../player';
-import { HUD } from '../render/hud';
-import { SceneManager } from '../render/scene';
-import { GunViewModel } from '../render/gun';
-import { MainMenu } from '../ui/menu';
-import { MobileControls } from '../ui/mobileControls';
-import { isTouchDevice } from '../platform';
-import { generateArenaLayout } from '../arena/states';
-import { FEATURE_FLAGS } from '../featureFlags';
-import { GRAB_RADIUS } from '../../../shared/constants';
-import type { FullPlayerInfo, EnemyPlayerInfo } from '../../../shared/schema';
-import { RoundController } from './roundController';
-import { ProjectileSystem } from './projectileSystem';
-import { buildShotFromCamera } from './weaponFire';
-import { GunTuneOverlay } from './gunTuneOverlay';
-import { FloatArmTuneOverlay } from './floatArmTuneOverlay';
-import { cameraYawFacingBreachOpening } from './cameraYawFromBreach';
+import { GRAB_RADIUS } from "../../../shared/constants";
+import { generateArenaLayout } from "../arena/states";
+import { Arena } from "../arena/arena";
+import { CameraController } from "../camera";
+import { FEATURE_FLAGS } from "../featureFlags";
+import { InputManager } from "../input";
+import { LocalMatch } from "../match/localMatch";
+import { isTouchDevice } from "../platform";
+import { LocalPlayer } from "../player";
+import { GunViewModel } from "../render/gun";
+import { HUD } from "../render/hud";
+import { SceneManager } from "../render/scene";
+import { MainMenu } from "../ui/menu";
+import { MobileControls } from "../ui/mobileControls";
+import { cameraYawFacingBreachOpening } from "./cameraYawFromBreach";
+import { FloatArmTuneOverlay } from "./floatArmTuneOverlay";
+import { ProjectileSystem } from "./projectileSystem";
+import { RoundController } from "./roundController";
+import { GunTuneOverlay } from "./gunTuneOverlay";
+import { buildShotFromCamera } from "./weaponFire";
 
-/**
- * Top-level game composition. Owns every subsystem, wires callbacks
- * between them, and runs the per-frame loop. Responsibilities are
- * intentionally thin: anything non-trivial lives in a game/* submodule
- * or one of the domain classes (LocalPlayer, Arena, InputManager, etc.).
- */
 export class App {
-  private sceneMgr: SceneManager;
-  private input: InputManager;
-  private cam: CameraController;
-  private player: LocalPlayer;
   private arena: Arena;
-  private hud: HUD;
-  private menu: MainMenu;
-  private round = new RoundController();
-  private projectiles: ProjectileSystem;
+  private cam: CameraController;
+  private floatArmTuneOverlay = new FloatArmTuneOverlay();
   private gun: GunViewModel;
   private gunTuneOverlay = new GunTuneOverlay();
-  private floatArmTuneOverlay = new FloatArmTuneOverlay();
-
+  private hud: HUD;
+  private input: InputManager;
   private lastTime = 0;
-  private thirdPerson = false;
+  private match: LocalMatch;
+  private menu: MainMenu;
   private readonly mobile = isTouchDevice();
   private mobileControls: MobileControls | null = null;
+  private player: LocalPlayer;
+  private projectiles: ProjectileSystem;
+  private round = new RoundController();
+  private sceneMgr: SceneManager;
+  private thirdPerson = false;
 
   public constructor() {
     this.sceneMgr = new SceneManager();
@@ -53,24 +47,29 @@ export class App {
     this.hud = new HUD();
     this.menu = new MainMenu();
     this.projectiles = new ProjectileSystem(this.sceneMgr.getScene());
+    this.match = new LocalMatch(this.sceneMgr.getScene());
 
-    // Camera must be in the scene graph so parented children (gun model) render.
     this.sceneMgr.getScene().add(this.sceneMgr.getCamera());
     this.gun = new GunViewModel(this.sceneMgr.getCamera());
 
-    this.player.onRoundWin = (team) => this.onRoundWin(team);
+    this.player.onRoundWin = (team) => {
+      this.match.recordHumanScore(team);
+      this.onRoundWin(team);
+    };
+    this.match.onScore = (team) => this.onRoundWin(team);
     this.round.onBeginRound = () => this.beginNewRound();
     this.round.onCountdownEnd = () => this.arena.setPortalDoorsOpen(true);
 
     if (this.mobile) {
       this.mobileControls = new MobileControls(this.input);
       this.mobileControls.mount();
-      this.mobileControls.hide(); // hidden until play starts
-      this.mobileControls.onViewToggle = () => { this.thirdPerson = !this.thirdPerson; };
+      this.mobileControls.hide();
+      this.mobileControls.onViewToggle = () => {
+        this.thirdPerson = !this.thirdPerson;
+      };
     } else {
-      // Desktop only: re-lock pointer when clicking back onto the canvas mid-game
-      this.sceneMgr.getRenderer().domElement.addEventListener('mousedown', () => {
-        if (this.round.getPhase() === 'LOBBY' || this.menu.isVisible() || this.input.isLocked()) {
+      this.sceneMgr.getRenderer().domElement.addEventListener("mousedown", () => {
+        if (this.round.getPhase() === "LOBBY" || this.menu.isVisible() || this.input.isLocked()) {
           return;
         }
         this.input.lockPointer(this.sceneMgr.getRenderer().domElement);
@@ -80,17 +79,24 @@ export class App {
 
   public start(): void {
     this.menu.show();
-    this.menu.onPlay = () => {
+    this.menu.onPlay = (selection) => {
+      this.match.startNewGame({
+        humanName: selection.name,
+        humanTeam: 0,
+        teamSize: selection.teamSize,
+      });
+
       if (this.mobile) {
         this.input.setMobileControlsActive(true);
         this.mobileControls?.show();
       } else {
         this.input.lockPointer(this.sceneMgr.getRenderer().domElement);
       }
+
       this.beginNewRound();
     };
 
-    requestAnimationFrame((t) => this.loop(t));
+    requestAnimationFrame((timestamp) => this.loop(timestamp));
   }
 
   private beginNewRound(): void {
@@ -100,11 +106,10 @@ export class App {
     const layout = generateArenaLayout();
     this.arena.loadLayout(layout);
     this.player.resetForNewRound(this.arena);
+    this.match.resetForRound(this.arena);
 
     const openAxis = this.arena.getBreachOpenAxis(this.player.team);
     const openSign = this.arena.getBreachOpenSign(this.player.team);
-    // resetForBreachSpawn seeds zeroGQuat so subsequent setZeroGMode(false)
-    // calls don't overwrite the correct yaw with stale zero-G orientation.
     this.cam.resetForBreachSpawn(cameraYawFacingBreachOpening(openAxis, openSign));
 
     this.arena.setPortalDoorsOpen(false);
@@ -113,8 +118,7 @@ export class App {
 
   private onRoundWin(team: 0 | 1): void {
     if (!this.round.isPlaying()) return;
-    const label = team === 0 ? 'CYAN WINS' : 'MAGENTA WINS';
-    this.hud.showRoundEnd(label);
+    this.hud.showRoundEnd(team === 0 ? "CYAN WINS" : "MAGENTA WINS");
     this.round.endRound();
   }
 
@@ -122,10 +126,8 @@ export class App {
     const dt = Math.min((timestamp - this.lastTime) / 1000, 0.033);
     this.lastTime = timestamp;
 
-    // CRITICAL ORDER: mode switches must run before consumeMouseDelta so
-    // InputManager routes mouse-Y correctly between look and aim.
-    this.input.setAimingMode(this.player.phase === 'AIMING');
-    this.cam.setZeroGMode(this.player.phase !== 'BREACH');
+    this.input.setAimingMode(this.player.phase === "AIMING");
+    this.cam.setZeroGMode(this.player.phase !== "BREACH");
     this.cam.tickTransition(dt);
 
     const { dx, dy } = this.input.consumeMouseDelta();
@@ -137,12 +139,19 @@ export class App {
     this.player.update(this.input, this.cam, this.arena, dt);
     this.arena.update(dt);
 
+    const botShots = this.match.tick(dt, this.arena, this.player, this.round.isPlaying());
+    for (const shot of botShots) {
+      this.projectiles.spawn(shot.origin, shot.direction, shot.team, shot.ownerId);
+    }
+
     this.tickWeaponFire();
     this.projectiles.update(
       dt,
       this.arena.getObstacleAABBs(),
       this.arena.getPortalBarrierAABBs(),
+      this.match.getProjectileTargets(this.player),
       (hitPos, color) => this.arena.triggerPortalImpact(hitPos, color),
+      (hit) => this.match.handleProjectileHit(hit, this.player, this.cam),
     );
     this.tickGunTuning();
 
@@ -157,13 +166,14 @@ export class App {
     this.renderDebugTuningOverlay();
 
     this.sceneMgr.render();
-    requestAnimationFrame((t) => this.loop(t));
+    requestAnimationFrame((nextTimestamp) => this.loop(nextTimestamp));
   }
 
   private tickWeaponFire(): void {
-    const inZeroG = this.player.phase === 'FLOATING'
-      || this.player.phase === 'GRABBING'
-      || this.player.phase === 'AIMING';
+    const inZeroG = this.player.phase === "FLOATING"
+      || this.player.phase === "GRABBING"
+      || this.player.phase === "AIMING";
+
     if (!this.round.isPlaying()) return;
     if (!this.input.canControlGame() || !inZeroG) return;
     if (!this.player.canFire() || !this.input.consumeFire()) return;
@@ -172,7 +182,8 @@ export class App {
       || (FEATURE_FLAGS.thirdPersonLookBehind && this.input.isSelfieHeld());
     const shot = buildShotFromCamera(this.player, this.cam, this.gun, useThirdPersonMuzzle);
     if (!shot) return;
-    this.projectiles.spawn(shot.origin, shot.direction, shot.color);
+
+    this.projectiles.spawn(shot.origin, shot.direction, this.player.team, "local-player");
     this.player.triggerArmRecoil();
   }
 
@@ -180,7 +191,7 @@ export class App {
     const tuning = FEATURE_FLAGS.debugTuning;
     if (!tuning.enabled) return;
 
-    if (tuning.target === 'Pistol') {
+    if (tuning.target === "Pistol") {
       if (this.input.consumeGunTuneToggle()) this.player.toggleThirdPersonGunTuning();
       if (this.input.consumeGunTuneReset()) this.player.resetThirdPersonGunTuning();
       if (this.input.consumeGunTunePrint()) {
@@ -221,12 +232,12 @@ export class App {
 
     this.gunTuneOverlay.render(
       this.player.getThirdPersonGunTuningState(),
-      tuning.enabled && tuning.target === 'Pistol',
+      tuning.enabled && tuning.target === "Pistol",
     );
 
     if (!this.player.isFloatLimbTarget(tuning.target)) {
       this.floatArmTuneOverlay.render(
-        { target: 'FloatRightArm', rotation: this.player.getFloatLimbTuningState('FloatRightArm').rotation },
+        { target: "FloatRightArm", rotation: this.player.getFloatLimbTuningState("FloatRightArm").rotation },
         false,
         false,
       );
@@ -244,33 +255,33 @@ export class App {
     try {
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(text);
-        console.info('[DebugTuning] Copied tuning values to clipboard.');
+        console.info("[DebugTuning] Copied tuning values to clipboard.");
         return;
       }
     } catch (error) {
-      console.warn('[DebugTuning] Clipboard API failed, trying fallback copy.', error);
+      console.warn("[DebugTuning] Clipboard API failed, trying fallback copy.", error);
     }
 
-    const textarea = document.createElement('textarea');
+    const textarea = document.createElement("textarea");
     textarea.value = text;
-    textarea.setAttribute('readonly', '');
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    textarea.style.pointerEvents = 'none';
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    textarea.style.pointerEvents = "none";
     document.body.appendChild(textarea);
     textarea.focus();
     textarea.select();
     textarea.setSelectionRange(0, textarea.value.length);
 
     try {
-      const copied = document.execCommand('copy');
+      const copied = document.execCommand("copy");
       if (copied) {
-        console.info('[DebugTuning] Copied tuning values to clipboard.');
+        console.info("[DebugTuning] Copied tuning values to clipboard.");
       } else {
-        console.warn('[DebugTuning] Clipboard copy failed; value is still in the console.');
+        console.warn("[DebugTuning] Clipboard copy failed; value is still in the console.");
       }
     } catch (error) {
-      console.warn('[DebugTuning] Clipboard fallback failed; value is still in the console.', error);
+      console.warn("[DebugTuning] Clipboard fallback failed; value is still in the console.", error);
     } finally {
       document.body.removeChild(textarea);
     }
@@ -278,47 +289,36 @@ export class App {
 
   private updateGunVisibility(isSelfie: boolean): void {
     const phase = this.round.getPhase();
-    const playerAlive = this.player.phase !== 'RESPAWNING';
-    const roundActive = phase !== 'LOBBY';
+    const playerAlive = this.player.phase !== "RESPAWNING";
+    const roundActive = phase !== "LOBBY";
 
-    const thirdPersonGunVisible = roundActive && playerAlive && (this.thirdPerson || isSelfie);
-    this.player.setThirdPersonGunVisible(thirdPersonGunVisible);
-
-    const firstPersonGunVisible = roundActive && playerAlive && !this.thirdPerson && !isSelfie;
-    this.gun.setVisible(firstPersonGunVisible);
+    this.player.setThirdPersonGunVisible(
+      roundActive && playerAlive && (this.thirdPerson || isSelfie),
+    );
+    this.gun.setVisible(roundActive && playerAlive && !this.thirdPerson && !isSelfie);
   }
 
   private updateHud(dt: number): void {
     let nearBar = this.arena.getNearestBar(this.player.getPosition(), GRAB_RADIUS) !== null;
-    if (this.player.phase === 'BREACH' && !this.arena.isGoalDoorOpen(this.player.currentBreachTeam)) {
+    if (this.player.phase === "BREACH" && !this.arena.isGoalDoorOpen(this.player.currentBreachTeam)) {
       nearBar = false;
     }
     const inBreach = this.arena.isInBreachRoom(this.player.getPosition(), this.player.team);
 
-    // Sync mobile controls to current game state
     if (this.mobile && this.mobileControls) {
       const canGrab = !this.player.damage.leftArm && !this.player.damage.frozen;
       this.mobileControls.setPhase(this.player.phase);
       this.mobileControls.setNearBar(nearBar, canGrab);
-      const showPower = this.player.phase === 'GRABBING' || this.player.phase === 'AIMING';
+      const showPower = this.player.phase === "GRABBING" || this.player.phase === "AIMING";
       const max = this.player.maxLaunchPower();
       const pct = max > 0 ? this.player.launchPower / max : 0;
       this.mobileControls.setPowerLevel(pct, showPower);
       this.mobileControls.setViewMode(this.thirdPerson);
     }
 
-    const ownTeam: FullPlayerInfo[] = [{
-      id: 'local',
-      name: 'You',
-      frozen: this.player.damage.frozen,
-      kills: this.player.kills,
-      deaths: this.player.deaths,
-      ping: 0,
-    }];
-    const enemyTeam: EnemyPlayerInfo[] = [];
-
+    const rosters = this.match.getHudRosters(this.player);
     this.hud.update({
-      score: { team0: this.player.kills, team1: 0 },
+      score: this.match.getScore(),
       phase: this.round.getPhase(),
       countdown: this.round.getCountdown(),
       playerPhase: this.player.phase,
@@ -328,8 +328,8 @@ export class App {
       inBreach,
       damage: this.player.damage,
       tabHeld: this.input.isTabHeld(),
-      ownTeam,
-      enemyTeam,
+      ownTeam: rosters.ownTeam,
+      enemyTeam: rosters.enemyTeam,
       dt,
       team: this.player.team,
     });

--- a/client/src/game/projectileActorCollision.ts
+++ b/client/src/game/projectileActorCollision.ts
@@ -1,0 +1,36 @@
+import * as THREE from "three";
+
+export function segmentSphereHitPoint(
+  oldPos: THREE.Vector3,
+  newPos: THREE.Vector3,
+  center: THREE.Vector3,
+  radius: number,
+): THREE.Vector3 | null {
+  const segment = new THREE.Vector3().subVectors(newPos, oldPos);
+  const lengthSq = segment.lengthSq();
+
+  if (lengthSq <= 1e-10) {
+    return oldPos.distanceToSquared(center) <= radius * radius ? oldPos.clone() : null;
+  }
+
+  const fromCenter = new THREE.Vector3().subVectors(oldPos, center);
+  const a = lengthSq;
+  const b = 2 * fromCenter.dot(segment);
+  const c = fromCenter.lengthSq() - radius * radius;
+  const discriminant = b * b - 4 * a * c;
+
+  if (discriminant < 0) {
+    return null;
+  }
+
+  const root = Math.sqrt(discriminant);
+  const t1 = (-b - root) / (2 * a);
+  const t2 = (-b + root) / (2 * a);
+  const t = [t1, t2].find((candidate) => candidate >= 0 && candidate <= 1);
+
+  if (t === undefined) {
+    return null;
+  }
+
+  return oldPos.clone().addScaledVector(segment, t);
+}

--- a/client/src/game/projectileSystem.ts
+++ b/client/src/game/projectileSystem.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import { ARENA_SIZE } from "../../../shared/constants";
-import { Projectile } from "../projectile";
+import { Projectile, type ProjectileTrailMode } from "../projectile";
 import { bulletHitPoint } from "./bulletCollision";
 import { segmentSphereHitPoint } from "./projectileActorCollision";
 
@@ -15,19 +15,25 @@ const PORTAL_DIST = 9.0;
 const WALL_INTENSITY = 5.0;
 const WALL_DIST = 6.0;
 
+const MAX_FLASH_POOL = 18;
+const MAX_SPARK_POOL = 14;
 const SPARK_DURATION = 0.32;
 const SPARK_COUNT = 22;
 
 interface HitFlash {
-  light: THREE.PointLight;
+  active: boolean;
   age: number;
+  light: THREE.PointLight;
+  peak: number;
 }
 
 interface SparkBurst {
+  active: boolean;
+  age: number;
+  count: number;
   points: THREE.Points;
   positions: Float32Array;
   velocities: Float32Array;
-  age: number;
 }
 
 export interface ProjectileActorTarget {
@@ -51,9 +57,12 @@ type CollisionHit =
   | { kind: "portal"; point: THREE.Vector3; distance: number };
 
 export class ProjectileSystem {
-  private projectiles: Projectile[] = [];
   private flashes: HitFlash[] = [];
+  private projectilePool: Projectile[] = [];
+  private projectiles: Projectile[] = [];
   private sparks: SparkBurst[] = [];
+  private readonly tmpDirection = new THREE.Vector3();
+  private readonly tmpSparkNormal = new THREE.Vector3();
 
   public constructor(private readonly scene: THREE.Scene) {}
 
@@ -63,7 +72,9 @@ export class ProjectileSystem {
     team: 0 | 1,
     ownerId: string,
   ): void {
-    this.projectiles.push(new Projectile(this.scene, origin, direction, team, ownerId));
+    const projectile = this.projectilePool.pop() ?? new Projectile(this.scene);
+    projectile.reset(origin, direction, team, ownerId);
+    this.projectiles.push(projectile);
   }
 
   public update(
@@ -74,16 +85,20 @@ export class ProjectileSystem {
     onPortalHit: (pos: THREE.Vector3, color: number) => void,
     onActorHit: (hit: ProjectileActorHit) => void,
   ): void {
+    const fxMode = this.currentFxMode();
+    const trailMode = this.currentTrailMode(fxMode);
+
     for (const projectile of this.projectiles) {
       if (projectile.dead) continue;
 
-      const oldPos = projectile.getPosition().clone();
+      projectile.setTrailMode(trailMode);
       projectile.update(dt);
       let handledFlash = false;
 
       if (!projectile.dead) {
+        const oldPos = projectile.getPreviousPosition();
         const newPos = projectile.getPosition();
-        const direction = new THREE.Vector3().subVectors(newPos, oldPos).normalize();
+        const direction = this.tmpDirection.subVectors(newPos, oldPos).normalize();
         const nearestHit = this.findNearestHit(
           projectile,
           oldPos,
@@ -98,16 +113,21 @@ export class ProjectileSystem {
           handledFlash = true;
 
           if (nearestHit.kind === "obstacle") {
-            this.spawnFlash(nearestHit.point, projectile.getTeamColor(), OBS_INTENSITY, OBS_DIST);
-            this.spawnSparks(nearestHit.point, projectile.getTeamColor(), null);
+            this.spawnFlash(nearestHit.point, projectile.getTeamColor(), OBS_INTENSITY, OBS_DIST, fxMode);
+            this.spawnSparks(nearestHit.point, projectile.getTeamColor(), null, fxMode);
           } else if (nearestHit.kind === "portal") {
-            this.spawnFlash(nearestHit.point, projectile.getTeamColor(), PORTAL_INTENSITY, PORTAL_DIST);
+            this.spawnFlash(nearestHit.point, projectile.getTeamColor(), PORTAL_INTENSITY, PORTAL_DIST, fxMode);
             onPortalHit(nearestHit.point, projectile.getTeamColor());
           } else {
-            this.spawnFlash(nearestHit.point, projectile.getTeamColor(), OBS_INTENSITY, OBS_DIST);
-            this.spawnSparks(nearestHit.point, projectile.getTeamColor(), direction.clone().negate());
+            this.spawnFlash(nearestHit.point, projectile.getTeamColor(), OBS_INTENSITY, OBS_DIST, fxMode);
+            this.spawnSparks(
+              nearestHit.point,
+              projectile.getTeamColor(),
+              this.tmpSparkNormal.copy(direction).negate(),
+              fxMode,
+            );
             onActorHit({
-              direction,
+              direction: direction.clone(),
               impactPoint: nearestHit.point,
               ownerId: projectile.getOwnerId(),
               targetId: nearestHit.targetId,
@@ -120,59 +140,98 @@ export class ProjectileSystem {
         const rawPos = projectile.getPosition();
         const wallPos = this.clampToArena(rawPos);
         const isWall = this.isAtArenaBoundary(rawPos);
-        this.spawnFlash(wallPos, projectile.getTeamColor(), WALL_INTENSITY, WALL_DIST);
+        this.spawnFlash(wallPos, projectile.getTeamColor(), WALL_INTENSITY, WALL_DIST, fxMode);
         if (isWall) {
-          this.spawnSparks(wallPos, projectile.getTeamColor(), this.inwardWallNormal(wallPos));
+          this.spawnSparks(
+            wallPos,
+            projectile.getTeamColor(),
+            this.inwardWallNormal(wallPos),
+            fxMode,
+          );
         }
       }
     }
 
-    this.projectiles = this.projectiles.filter((projectile) => !projectile.dead);
-
-    for (const flash of this.flashes) {
-      flash.age += dt;
-      const t = Math.min(flash.age / FLASH_DURATION, 1);
-      flash.light.intensity = (flash.light.userData.peak as number) * (1 - t * t);
-    }
-    for (const flash of this.flashes.filter((item) => item.age >= FLASH_DURATION)) {
-      this.scene.remove(flash.light);
-      flash.light.dispose();
-    }
-    this.flashes = this.flashes.filter((item) => item.age < FLASH_DURATION);
-
-    for (const spark of this.sparks) {
-      spark.age += dt;
-      for (let i = 0; i < SPARK_COUNT; i += 1) {
-        spark.positions[i * 3] += spark.velocities[i * 3] * dt;
-        spark.positions[i * 3 + 1] += spark.velocities[i * 3 + 1] * dt;
-        spark.positions[i * 3 + 2] += spark.velocities[i * 3 + 2] * dt;
-      }
-      (spark.points.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
-      const t = spark.age / SPARK_DURATION;
-      (spark.points.material as THREE.PointsMaterial).opacity = Math.max(0, 1 - t * t);
-    }
-    for (const spark of this.sparks.filter((item) => item.age >= SPARK_DURATION)) {
-      this.scene.remove(spark.points);
-      spark.points.geometry.dispose();
-      (spark.points.material as THREE.Material).dispose();
-    }
-    this.sparks = this.sparks.filter((item) => item.age < SPARK_DURATION);
+    this.recycleDeadProjectiles();
+    this.updateFlashes(dt);
+    this.updateSparks(dt);
   }
 
   public clear(): void {
-    for (const projectile of this.projectiles) projectile.dispose();
+    for (const projectile of this.projectiles) {
+      projectile.dispose();
+      this.projectilePool.push(projectile);
+    }
     this.projectiles = [];
+
     for (const flash of this.flashes) {
-      this.scene.remove(flash.light);
-      flash.light.dispose();
+      flash.active = false;
+      flash.light.visible = false;
     }
-    this.flashes = [];
+
     for (const spark of this.sparks) {
-      this.scene.remove(spark.points);
-      spark.points.geometry.dispose();
-      (spark.points.material as THREE.Material).dispose();
+      spark.active = false;
+      spark.points.visible = false;
     }
-    this.sparks = [];
+  }
+
+  private acquireFlash(): HitFlash | null {
+    const existing = this.flashes.find((flash) => !flash.active);
+    if (existing) return existing;
+    if (this.flashes.length >= MAX_FLASH_POOL) return null;
+
+    const light = new THREE.PointLight(0xffffff, 0, 0, 2);
+    light.visible = false;
+    this.scene.add(light);
+
+    const flash: HitFlash = { active: false, age: 0, light, peak: 0 };
+    this.flashes.push(flash);
+    return flash;
+  }
+
+  private acquireSparkBurst(): SparkBurst | null {
+    const existing = this.sparks.find((spark) => !spark.active);
+    if (existing) return existing;
+    if (this.sparks.length >= MAX_SPARK_POOL) return null;
+
+    const positions = new Float32Array(SPARK_COUNT * 3);
+    const velocities = new Float32Array(SPARK_COUNT * 3);
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+    const material = new THREE.PointsMaterial({
+      blending: THREE.AdditiveBlending,
+      color: 0xffffff,
+      depthWrite: false,
+      opacity: 1,
+      size: 0.07,
+      transparent: true,
+    });
+    const points = new THREE.Points(geometry, material);
+    points.visible = false;
+    this.scene.add(points);
+
+    const spark: SparkBurst = {
+      active: false,
+      age: 0,
+      count: 0,
+      points,
+      positions,
+      velocities,
+    };
+    this.sparks.push(spark);
+    return spark;
+  }
+
+  private currentFxMode(): "normal" | "high" | "extreme" {
+    if (this.projectiles.length >= 90) return "extreme";
+    if (this.projectiles.length >= 45) return "high";
+    return "normal";
+  }
+
+  private currentTrailMode(mode: "normal" | "high" | "extreme"): ProjectileTrailMode {
+    if (mode === "extreme") return "hidden";
+    if (mode === "high") return "reduced";
+    return "full";
   }
 
   private findNearestHit(
@@ -218,61 +277,13 @@ export class ProjectileSystem {
     return nearest;
   }
 
-  private spawnFlash(pos: THREE.Vector3, color: number, intensity: number, dist: number): void {
-    const light = new THREE.PointLight(color, intensity, dist, 2);
-    light.position.copy(pos);
-    light.userData.peak = intensity;
-    this.scene.add(light);
-    this.flashes.push({ light, age: 0 });
-  }
-
-  private spawnSparks(pos: THREE.Vector3, color: number, normal: THREE.Vector3 | null): void {
-    const positions = new Float32Array(SPARK_COUNT * 3);
-    const velocities = new Float32Array(SPARK_COUNT * 3);
-
-    const nrm = normal ?? new THREE.Vector3(0, 1, 0);
-    const t1 = new THREE.Vector3();
-    const t2 = new THREE.Vector3();
-    if (Math.abs(nrm.x) < 0.9) {
-      t1.crossVectors(nrm, new THREE.Vector3(1, 0, 0)).normalize();
-    } else {
-      t1.crossVectors(nrm, new THREE.Vector3(0, 1, 0)).normalize();
-    }
-    t2.crossVectors(nrm, t1);
-
-    const phiMax = normal ? Math.PI / 2 : Math.PI;
-
-    for (let i = 0; i < SPARK_COUNT; i += 1) {
-      positions[i * 3] = pos.x;
-      positions[i * 3 + 1] = pos.y;
-      positions[i * 3 + 2] = pos.z;
-
-      const theta = Math.random() * Math.PI * 2;
-      const phi = Math.random() * phiMax;
-      const speed = 2.5 + Math.random() * 5.5;
-      const cp = Math.cos(phi);
-      const sp = Math.sin(phi);
-      const ct = Math.cos(theta);
-      const st = Math.sin(theta);
-
-      velocities[i * 3] = (nrm.x * cp + (t1.x * ct + t2.x * st) * sp) * speed;
-      velocities[i * 3 + 1] = (nrm.y * cp + (t1.y * ct + t2.y * st) * sp) * speed;
-      velocities[i * 3 + 2] = (nrm.z * cp + (t1.z * ct + t2.z * st) * sp) * speed;
-    }
-
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
-    const material = new THREE.PointsMaterial({
-      blending: THREE.AdditiveBlending,
-      color,
-      depthWrite: false,
-      opacity: 1,
-      size: 0.07,
-      transparent: true,
-    });
-    const points = new THREE.Points(geometry, material);
-    this.scene.add(points);
-    this.sparks.push({ points, positions, velocities, age: 0 });
+  private inwardWallNormal(clampedPos: THREE.Vector3): THREE.Vector3 {
+    const ax = Math.abs(clampedPos.x);
+    const ay = Math.abs(clampedPos.y);
+    const az = Math.abs(clampedPos.z);
+    if (ax >= ay && ax >= az) return new THREE.Vector3(-Math.sign(clampedPos.x), 0, 0);
+    if (ay >= ax && ay >= az) return new THREE.Vector3(0, -Math.sign(clampedPos.y), 0);
+    return new THREE.Vector3(0, 0, -Math.sign(clampedPos.z));
   }
 
   private isAtArenaBoundary(pos: THREE.Vector3): boolean {
@@ -291,12 +302,133 @@ export class ProjectileSystem {
     );
   }
 
-  private inwardWallNormal(clampedPos: THREE.Vector3): THREE.Vector3 {
-    const ax = Math.abs(clampedPos.x);
-    const ay = Math.abs(clampedPos.y);
-    const az = Math.abs(clampedPos.z);
-    if (ax >= ay && ax >= az) return new THREE.Vector3(-Math.sign(clampedPos.x), 0, 0);
-    if (ay >= ax && ay >= az) return new THREE.Vector3(0, -Math.sign(clampedPos.y), 0);
-    return new THREE.Vector3(0, 0, -Math.sign(clampedPos.z));
+  private recycleDeadProjectiles(): void {
+    if (this.projectiles.length === 0) return;
+
+    const active: Projectile[] = [];
+    for (const projectile of this.projectiles) {
+      if (projectile.dead) {
+        this.projectilePool.push(projectile);
+      } else {
+        active.push(projectile);
+      }
+    }
+    this.projectiles = active;
+  }
+
+  private spawnFlash(
+    pos: THREE.Vector3,
+    color: number,
+    intensity: number,
+    distance: number,
+    mode: "normal" | "high" | "extreme",
+  ): void {
+    const flash = this.acquireFlash();
+    if (!flash) return;
+
+    const intensityScale = mode === "normal" ? 1 : mode === "high" ? 0.7 : 0.45;
+
+    flash.active = true;
+    flash.age = 0;
+    flash.peak = intensity * intensityScale;
+    flash.light.position.copy(pos);
+    flash.light.color.setHex(color);
+    flash.light.distance = distance * intensityScale;
+    flash.light.intensity = flash.peak;
+    flash.light.visible = true;
+  }
+
+  private spawnSparks(
+    pos: THREE.Vector3,
+    color: number,
+    normal: THREE.Vector3 | null,
+    mode: "normal" | "high" | "extreme",
+  ): void {
+    const sparkCount = mode === "normal" ? SPARK_COUNT : mode === "high" ? 10 : 0;
+    if (sparkCount <= 0) return;
+
+    const spark = this.acquireSparkBurst();
+    if (!spark) return;
+
+    const nrm = normal ?? new THREE.Vector3(0, 1, 0);
+    const tangentA = new THREE.Vector3();
+    const tangentB = new THREE.Vector3();
+    if (Math.abs(nrm.x) < 0.9) {
+      tangentA.crossVectors(nrm, new THREE.Vector3(1, 0, 0)).normalize();
+    } else {
+      tangentA.crossVectors(nrm, new THREE.Vector3(0, 1, 0)).normalize();
+    }
+    tangentB.crossVectors(nrm, tangentA);
+    const phiMax = normal ? Math.PI / 2 : Math.PI;
+
+    spark.active = true;
+    spark.age = 0;
+    spark.count = sparkCount;
+    spark.points.visible = true;
+    const material = spark.points.material as THREE.PointsMaterial;
+    material.color.setHex(color);
+    material.opacity = 1;
+
+    for (let i = 0; i < SPARK_COUNT; i += 1) {
+      spark.positions[i * 3] = pos.x;
+      spark.positions[i * 3 + 1] = pos.y;
+      spark.positions[i * 3 + 2] = pos.z;
+
+      if (i >= sparkCount) {
+        spark.velocities[i * 3] = 0;
+        spark.velocities[i * 3 + 1] = 0;
+        spark.velocities[i * 3 + 2] = 0;
+        continue;
+      }
+
+      const theta = Math.random() * Math.PI * 2;
+      const phi = Math.random() * phiMax;
+      const speed = 2.5 + Math.random() * 5.5;
+      const cp = Math.cos(phi);
+      const sp = Math.sin(phi);
+      const ct = Math.cos(theta);
+      const st = Math.sin(theta);
+
+      spark.velocities[i * 3] = (nrm.x * cp + (tangentA.x * ct + tangentB.x * st) * sp) * speed;
+      spark.velocities[i * 3 + 1] = (nrm.y * cp + (tangentA.y * ct + tangentB.y * st) * sp) * speed;
+      spark.velocities[i * 3 + 2] = (nrm.z * cp + (tangentA.z * ct + tangentB.z * st) * sp) * speed;
+    }
+
+    (spark.points.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+  }
+
+  private updateFlashes(dt: number): void {
+    for (const flash of this.flashes) {
+      if (!flash.active) continue;
+
+      flash.age += dt;
+      const t = Math.min(flash.age / FLASH_DURATION, 1);
+      flash.light.intensity = flash.peak * (1 - t * t);
+
+      if (flash.age >= FLASH_DURATION) {
+        flash.active = false;
+        flash.light.visible = false;
+      }
+    }
+  }
+
+  private updateSparks(dt: number): void {
+    for (const spark of this.sparks) {
+      if (!spark.active) continue;
+
+      spark.age += dt;
+      for (let i = 0; i < spark.count; i += 1) {
+        spark.positions[i * 3] += spark.velocities[i * 3] * dt;
+        spark.positions[i * 3 + 1] += spark.velocities[i * 3 + 1] * dt;
+        spark.positions[i * 3 + 2] += spark.velocities[i * 3 + 2] * dt;
+      }
+      (spark.points.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+      (spark.points.material as THREE.PointsMaterial).opacity = Math.max(0, 1 - (spark.age / SPARK_DURATION) ** 2);
+
+      if (spark.age >= SPARK_DURATION) {
+        spark.active = false;
+        spark.points.visible = false;
+      }
+    }
   }
 }

--- a/client/src/game/projectileSystem.ts
+++ b/client/src/game/projectileSystem.ts
@@ -1,156 +1,222 @@
-import * as THREE from 'three';
-import { ARENA_SIZE } from '../../../shared/constants';
-import { Projectile } from '../projectile';
-import { bulletHitPoint } from './bulletCollision';
+import * as THREE from "three";
+import { ARENA_SIZE } from "../../../shared/constants";
+import { Projectile } from "../projectile";
+import { bulletHitPoint } from "./bulletCollision";
+import { segmentSphereHitPoint } from "./projectileActorCollision";
 
-const BULLET_RADIUS  = 0.07;
-const FLASH_DURATION = 0.13;   // seconds
-const ARENA_LIMIT    = ARENA_SIZE / 2;  // 20
+const BULLET_RADIUS = 0.07;
+const FLASH_DURATION = 0.13;
+const ARENA_LIMIT = ARENA_SIZE / 2;
 
-// Flash params per hit type.
-const OBS_INTENSITY    = 5.0;  const OBS_DIST    = 6.0;
-const PORTAL_INTENSITY = 9.0;  const PORTAL_DIST = 9.0;
-const WALL_INTENSITY   = 5.0;  const WALL_DIST   = 6.0;
+const OBS_INTENSITY = 5.0;
+const OBS_DIST = 6.0;
+const PORTAL_INTENSITY = 9.0;
+const PORTAL_DIST = 9.0;
+const WALL_INTENSITY = 5.0;
+const WALL_DIST = 6.0;
 
 const SPARK_DURATION = 0.32;
-const SPARK_COUNT    = 22;
+const SPARK_COUNT = 22;
 
-interface HitFlash   { light: THREE.PointLight; age: number; }
-interface SparkBurst { points: THREE.Points; positions: Float32Array; velocities: Float32Array; age: number; }
+interface HitFlash {
+  light: THREE.PointLight;
+  age: number;
+}
 
-/**
- * Owns the list of visual projectiles. Three distinct hit paths:
- *
- *   1. Obstacle hit     → surface flash + omnidirectional sparks.
- *   2. Portal barrier   → bigger flash + onPortalHit() for the energy wall ring/sparks.
- *   3. Arena wall       → flash at clamped wall position + hemisphere sparks.
- *   4. Lifetime expiry  → flash only (bullet just fades out).
- *
- * Collision uses bulletHitPoint() — a swept ray-box test — so fast bullets
- * cannot skip through thin obstacles (1-unit plates/beams) in a single frame.
- */
+interface SparkBurst {
+  points: THREE.Points;
+  positions: Float32Array;
+  velocities: Float32Array;
+  age: number;
+}
+
+export interface ProjectileActorTarget {
+  active: boolean;
+  id: string;
+  pos: THREE.Vector3;
+  radius: number;
+  team: 0 | 1;
+}
+
+export interface ProjectileActorHit {
+  direction: THREE.Vector3;
+  impactPoint: THREE.Vector3;
+  ownerId: string;
+  targetId: string;
+}
+
+type CollisionHit =
+  | { kind: "actor"; point: THREE.Vector3; distance: number; targetId: string }
+  | { kind: "obstacle"; point: THREE.Vector3; distance: number }
+  | { kind: "portal"; point: THREE.Vector3; distance: number };
+
 export class ProjectileSystem {
   private projectiles: Projectile[] = [];
-  private flashes:     HitFlash[]   = [];
-  private sparks:      SparkBurst[] = [];
+  private flashes: HitFlash[] = [];
+  private sparks: SparkBurst[] = [];
 
   public constructor(private readonly scene: THREE.Scene) {}
 
-  public spawn(origin: THREE.Vector3, direction: THREE.Vector3, color: number): void {
-    this.projectiles.push(new Projectile(this.scene, origin, direction, color));
+  public spawn(
+    origin: THREE.Vector3,
+    direction: THREE.Vector3,
+    team: 0 | 1,
+    ownerId: string,
+  ): void {
+    this.projectiles.push(new Projectile(this.scene, origin, direction, team, ownerId));
   }
 
-  /**
-   * @param solidBoxes  Obstacle AABBs.
-   * @param portalBoxes Portal barrier AABBs.
-   * @param onPortalHit Called with the world-space surface hit point when a
-   *                    bullet hits a portal barrier. Triggers the energy-wall
-   *                    ring + sparkle effect in PortalEnergyWall.
-   */
   public update(
     dt: number,
     solidBoxes: THREE.Box3[],
     portalBoxes: THREE.Box3[],
+    actorTargets: ProjectileActorTarget[],
     onPortalHit: (pos: THREE.Vector3, color: number) => void,
+    onActorHit: (hit: ProjectileActorHit) => void,
   ): void {
-    for (const p of this.projectiles) {
-      if (p.dead) continue;
+    for (const projectile of this.projectiles) {
+      if (projectile.dead) continue;
 
-      const oldPos = p.getPosition().clone();
-      p.update(dt);
-
+      const oldPos = projectile.getPosition().clone();
+      projectile.update(dt);
       let handledFlash = false;
 
-      if (!p.dead) {
-        const newPos = p.getPosition();
+      if (!projectile.dead) {
+        const newPos = projectile.getPosition();
+        const direction = new THREE.Vector3().subVectors(newPos, oldPos).normalize();
+        const nearestHit = this.findNearestHit(
+          projectile,
+          oldPos,
+          newPos,
+          solidBoxes,
+          portalBoxes,
+          actorTargets,
+        );
 
-        // ── 1. Obstacle ─────────────────────────────────────────────
-        for (const box of solidBoxes) {
-          const hit = bulletHitPoint(oldPos, newPos, box, BULLET_RADIUS);
-          if (hit) {
-            p.dispose();
-            this.spawnFlash(hit, p.getTeamColor(), OBS_INTENSITY, OBS_DIST);
-            this.spawnSparks(hit, p.getTeamColor(), null);
-            handledFlash = true;
-            break;
-          }
-        }
+        if (nearestHit) {
+          projectile.dispose();
+          handledFlash = true;
 
-        // ── 2. Portal barrier ────────────────────────────────────────
-        if (!p.dead) {
-          for (const box of portalBoxes) {
-            const hit = bulletHitPoint(oldPos, newPos, box, BULLET_RADIUS);
-            if (hit) {
-              p.dispose();
-              this.spawnFlash(hit, p.getTeamColor(), PORTAL_INTENSITY, PORTAL_DIST);
-              onPortalHit(hit, p.getTeamColor());
-              handledFlash = true;
-              break;
-            }
+          if (nearestHit.kind === "obstacle") {
+            this.spawnFlash(nearestHit.point, projectile.getTeamColor(), OBS_INTENSITY, OBS_DIST);
+            this.spawnSparks(nearestHit.point, projectile.getTeamColor(), null);
+          } else if (nearestHit.kind === "portal") {
+            this.spawnFlash(nearestHit.point, projectile.getTeamColor(), PORTAL_INTENSITY, PORTAL_DIST);
+            onPortalHit(nearestHit.point, projectile.getTeamColor());
+          } else {
+            this.spawnFlash(nearestHit.point, projectile.getTeamColor(), OBS_INTENSITY, OBS_DIST);
+            this.spawnSparks(nearestHit.point, projectile.getTeamColor(), direction.clone().negate());
+            onActorHit({
+              direction,
+              impactPoint: nearestHit.point,
+              ownerId: projectile.getOwnerId(),
+              targetId: nearestHit.targetId,
+            });
           }
         }
       }
 
-      // ── 3/4. Arena wall or lifetime (killed inside p.update()) ────
-      if (p.dead && !handledFlash) {
-        const rawPos  = p.getPosition();
+      if (projectile.dead && !handledFlash) {
+        const rawPos = projectile.getPosition();
         const wallPos = this.clampToArena(rawPos);
-        const isWall  = this.isAtArenaBoundary(rawPos);
-        this.spawnFlash(wallPos, p.getTeamColor(), WALL_INTENSITY, WALL_DIST);
+        const isWall = this.isAtArenaBoundary(rawPos);
+        this.spawnFlash(wallPos, projectile.getTeamColor(), WALL_INTENSITY, WALL_DIST);
         if (isWall) {
-          this.spawnSparks(wallPos, p.getTeamColor(), this.inwardWallNormal(wallPos));
+          this.spawnSparks(wallPos, projectile.getTeamColor(), this.inwardWallNormal(wallPos));
         }
       }
     }
 
-    this.projectiles = this.projectiles.filter(p => !p.dead);
+    this.projectiles = this.projectiles.filter((projectile) => !projectile.dead);
 
-    // ── Tick and cull flashes ─────────────────────────────────────────
-    for (const f of this.flashes) {
-      f.age += dt;
-      const t = Math.min(f.age / FLASH_DURATION, 1);
-      f.light.intensity = (f.light.userData.peak as number) * (1 - t * t);
+    for (const flash of this.flashes) {
+      flash.age += dt;
+      const t = Math.min(flash.age / FLASH_DURATION, 1);
+      flash.light.intensity = (flash.light.userData.peak as number) * (1 - t * t);
     }
-    for (const f of this.flashes.filter(f => f.age >= FLASH_DURATION)) {
-      this.scene.remove(f.light);
-      f.light.dispose();
+    for (const flash of this.flashes.filter((item) => item.age >= FLASH_DURATION)) {
+      this.scene.remove(flash.light);
+      flash.light.dispose();
     }
-    this.flashes = this.flashes.filter(f => f.age < FLASH_DURATION);
+    this.flashes = this.flashes.filter((item) => item.age < FLASH_DURATION);
 
-    // ── Tick and cull sparks ──────────────────────────────────────────
-    for (const s of this.sparks) {
-      s.age += dt;
-      for (let i = 0; i < SPARK_COUNT; i++) {
-        s.positions[i * 3]     += s.velocities[i * 3]     * dt;
-        s.positions[i * 3 + 1] += s.velocities[i * 3 + 1] * dt;
-        s.positions[i * 3 + 2] += s.velocities[i * 3 + 2] * dt;
+    for (const spark of this.sparks) {
+      spark.age += dt;
+      for (let i = 0; i < SPARK_COUNT; i += 1) {
+        spark.positions[i * 3] += spark.velocities[i * 3] * dt;
+        spark.positions[i * 3 + 1] += spark.velocities[i * 3 + 1] * dt;
+        spark.positions[i * 3 + 2] += spark.velocities[i * 3 + 2] * dt;
       }
-      (s.points.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
-      const t = s.age / SPARK_DURATION;
-      (s.points.material as THREE.PointsMaterial).opacity = Math.max(0, 1 - t * t);
+      (spark.points.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+      const t = spark.age / SPARK_DURATION;
+      (spark.points.material as THREE.PointsMaterial).opacity = Math.max(0, 1 - t * t);
     }
-    for (const s of this.sparks.filter(s => s.age >= SPARK_DURATION)) {
-      this.scene.remove(s.points);
-      s.points.geometry.dispose();
-      (s.points.material as THREE.Material).dispose();
+    for (const spark of this.sparks.filter((item) => item.age >= SPARK_DURATION)) {
+      this.scene.remove(spark.points);
+      spark.points.geometry.dispose();
+      (spark.points.material as THREE.Material).dispose();
     }
-    this.sparks = this.sparks.filter(s => s.age < SPARK_DURATION);
+    this.sparks = this.sparks.filter((item) => item.age < SPARK_DURATION);
   }
 
   public clear(): void {
-    for (const p of this.projectiles) p.dispose();
+    for (const projectile of this.projectiles) projectile.dispose();
     this.projectiles = [];
-    for (const f of this.flashes) { this.scene.remove(f.light); f.light.dispose(); }
+    for (const flash of this.flashes) {
+      this.scene.remove(flash.light);
+      flash.light.dispose();
+    }
     this.flashes = [];
-    for (const s of this.sparks) {
-      this.scene.remove(s.points);
-      s.points.geometry.dispose();
-      (s.points.material as THREE.Material).dispose();
+    for (const spark of this.sparks) {
+      this.scene.remove(spark.points);
+      spark.points.geometry.dispose();
+      (spark.points.material as THREE.Material).dispose();
     }
     this.sparks = [];
   }
 
-  // ── Effect spawners ────────────────────────────────────────────────────
+  private findNearestHit(
+    projectile: Projectile,
+    oldPos: THREE.Vector3,
+    newPos: THREE.Vector3,
+    solidBoxes: THREE.Box3[],
+    portalBoxes: THREE.Box3[],
+    actorTargets: ProjectileActorTarget[],
+  ): CollisionHit | null {
+    let nearest: CollisionHit | null = null;
+
+    for (const box of solidBoxes) {
+      const hit = bulletHitPoint(oldPos, newPos, box, BULLET_RADIUS);
+      if (!hit) continue;
+      const distance = hit.distanceToSquared(oldPos);
+      if (!nearest || distance < nearest.distance) {
+        nearest = { kind: "obstacle", point: hit, distance };
+      }
+    }
+
+    for (const box of portalBoxes) {
+      const hit = bulletHitPoint(oldPos, newPos, box, BULLET_RADIUS);
+      if (!hit) continue;
+      const distance = hit.distanceToSquared(oldPos);
+      if (!nearest || distance < nearest.distance) {
+        nearest = { kind: "portal", point: hit, distance };
+      }
+    }
+
+    for (const actor of actorTargets) {
+      if (!actor.active) continue;
+      if (actor.team === projectile.getTeam()) continue;
+      if (actor.id === projectile.getOwnerId()) continue;
+      const hit = segmentSphereHitPoint(oldPos, newPos, actor.pos, actor.radius);
+      if (!hit) continue;
+      const distance = hit.distanceToSquared(oldPos);
+      if (!nearest || distance < nearest.distance) {
+        nearest = { kind: "actor", point: hit, distance, targetId: actor.id };
+      }
+    }
+
+    return nearest;
+  }
 
   private spawnFlash(pos: THREE.Vector3, color: number, intensity: number, dist: number): void {
     const light = new THREE.PointLight(color, intensity, dist, 2);
@@ -160,18 +226,13 @@ export class ProjectileSystem {
     this.flashes.push({ light, age: 0 });
   }
 
-  /**
-   * Spark burst. When `normal` is non-null, particles fly in a hemisphere
-   * facing that direction (e.g. into the arena from a wall). When null,
-   * particles scatter in all directions (obstacle interior hit).
-   */
   private spawnSparks(pos: THREE.Vector3, color: number, normal: THREE.Vector3 | null): void {
-    const positions  = new Float32Array(SPARK_COUNT * 3);
+    const positions = new Float32Array(SPARK_COUNT * 3);
     const velocities = new Float32Array(SPARK_COUNT * 3);
 
     const nrm = normal ?? new THREE.Vector3(0, 1, 0);
-    const t1  = new THREE.Vector3();
-    const t2  = new THREE.Vector3();
+    const t1 = new THREE.Vector3();
+    const t2 = new THREE.Vector3();
     if (Math.abs(nrm.x) < 0.9) {
       t1.crossVectors(nrm, new THREE.Vector3(1, 0, 0)).normalize();
     } else {
@@ -181,42 +242,44 @@ export class ProjectileSystem {
 
     const phiMax = normal ? Math.PI / 2 : Math.PI;
 
-    for (let i = 0; i < SPARK_COUNT; i++) {
-      positions[i * 3]     = pos.x;
+    for (let i = 0; i < SPARK_COUNT; i += 1) {
+      positions[i * 3] = pos.x;
       positions[i * 3 + 1] = pos.y;
       positions[i * 3 + 2] = pos.z;
 
       const theta = Math.random() * Math.PI * 2;
-      const phi   = Math.random() * phiMax;
+      const phi = Math.random() * phiMax;
       const speed = 2.5 + Math.random() * 5.5;
       const cp = Math.cos(phi);
       const sp = Math.sin(phi);
       const ct = Math.cos(theta);
       const st = Math.sin(theta);
 
-      velocities[i * 3]     = (nrm.x * cp + (t1.x * ct + t2.x * st) * sp) * speed;
+      velocities[i * 3] = (nrm.x * cp + (t1.x * ct + t2.x * st) * sp) * speed;
       velocities[i * 3 + 1] = (nrm.y * cp + (t1.y * ct + t2.y * st) * sp) * speed;
       velocities[i * 3 + 2] = (nrm.z * cp + (t1.z * ct + t2.z * st) * sp) * speed;
     }
 
-    const geo = new THREE.BufferGeometry();
-    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    const mat = new THREE.PointsMaterial({
-      color, size: 0.07, transparent: true, opacity: 1.0,
-      blending: THREE.AdditiveBlending, depthWrite: false,
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+    const material = new THREE.PointsMaterial({
+      blending: THREE.AdditiveBlending,
+      color,
+      depthWrite: false,
+      opacity: 1,
+      size: 0.07,
+      transparent: true,
     });
-    const points = new THREE.Points(geo, mat);
+    const points = new THREE.Points(geometry, material);
     this.scene.add(points);
     this.sparks.push({ points, positions, velocities, age: 0 });
   }
 
-  // ── Helpers ────────────────────────────────────────────────────────────
-
   private isAtArenaBoundary(pos: THREE.Vector3): boolean {
     return (
-      Math.abs(pos.x) > ARENA_LIMIT - 0.5 ||
-      Math.abs(pos.y) > ARENA_LIMIT - 0.5 ||
-      Math.abs(pos.z) > ARENA_LIMIT - 0.5
+      Math.abs(pos.x) > ARENA_LIMIT - 0.5
+      || Math.abs(pos.y) > ARENA_LIMIT - 0.5
+      || Math.abs(pos.z) > ARENA_LIMIT - 0.5
     );
   }
 

--- a/client/src/game/roundController.ts
+++ b/client/src/game/roundController.ts
@@ -1,4 +1,8 @@
-import { COUNTDOWN_SECONDS, ROUND_END_DELAY } from '../../../shared/constants';
+import {
+  COUNTDOWN_SECONDS,
+  ROUND_DURATION_SECONDS,
+  ROUND_END_DELAY,
+} from '../../../shared/constants';
 import type { GamePhase } from '../render/hud';
 
 /**
@@ -11,9 +15,13 @@ import type { GamePhase } from '../render/hud';
 export class RoundController {
   private phase: GamePhase = 'LOBBY';
   private countdownTimer = COUNTDOWN_SECONDS;
+  private restartHandle: ReturnType<typeof setTimeout> | null = null;
+  private roundTimer = ROUND_DURATION_SECONDS;
+  private roundTimeoutFired = false;
 
   public onBeginRound: (() => void) | null = null;
   public onCountdownEnd: (() => void) | null = null;
+  public onRoundTimeout: (() => void) | null = null;
 
   public getPhase(): GamePhase {
     return this.phase;
@@ -23,24 +31,48 @@ export class RoundController {
     return this.countdownTimer;
   }
 
+  public getRoundTimeRemaining(): number {
+    return this.roundTimer;
+  }
+
   public startCountdown(): void {
+    if (this.restartHandle) {
+      clearTimeout(this.restartHandle);
+      this.restartHandle = null;
+    }
     this.phase = 'COUNTDOWN';
     this.countdownTimer = COUNTDOWN_SECONDS;
+    this.roundTimer = ROUND_DURATION_SECONDS;
+    this.roundTimeoutFired = false;
   }
 
   public tick(dt: number): void {
-    if (this.phase !== 'COUNTDOWN') return;
-    this.countdownTimer -= dt;
-    if (this.countdownTimer <= 0) {
-      this.countdownTimer = 0;
-      this.phase = 'PLAYING';
-      this.onCountdownEnd?.();
+    if (this.phase === 'COUNTDOWN') {
+      this.countdownTimer -= dt;
+      if (this.countdownTimer <= 0) {
+        this.countdownTimer = 0;
+        this.phase = 'PLAYING';
+        this.onCountdownEnd?.();
+      }
+      return;
+    }
+
+    if (this.phase === 'PLAYING') {
+      this.roundTimer = Math.max(0, this.roundTimer - dt);
+      if (this.roundTimer <= 0 && !this.roundTimeoutFired) {
+        this.roundTimeoutFired = true;
+        this.onRoundTimeout?.();
+      }
     }
   }
 
   public endRound(): void {
     this.phase = 'ROUND_END';
-    setTimeout(() => {
+    if (this.restartHandle) {
+      clearTimeout(this.restartHandle);
+    }
+    this.restartHandle = setTimeout(() => {
+      this.restartHandle = null;
       this.onBeginRound?.();
     }, ROUND_END_DELAY * 1000);
   }

--- a/client/src/match/arenaQueryAdapter.ts
+++ b/client/src/match/arenaQueryAdapter.ts
@@ -1,0 +1,47 @@
+import * as THREE from "three";
+import type { SharedArenaQuery, BarGrabPoint } from "../../../shared/player-logic";
+import type { Vec3 } from "../../../shared/vec3";
+import { Arena } from "../arena/arena";
+
+export class ArenaQueryAdapter implements SharedArenaQuery {
+  public constructor(private arena: Arena) {}
+
+  public getBreachRoomCenter(team: 0 | 1): Vec3 {
+    const center = this.arena.getBreachRoomCenter(team);
+    return { x: center.x, y: center.y, z: center.z };
+  }
+
+  public getBreachOpenAxis(team: 0 | 1): "x" | "y" | "z" {
+    return this.arena.getBreachOpenAxis(team);
+  }
+
+  public getBreachOpenSign(team: 0 | 1): 1 | -1 {
+    return this.arena.getBreachOpenSign(team);
+  }
+
+  public isGoalDoorOpen(team: 0 | 1): boolean {
+    return this.arena.isGoalDoorOpen(team);
+  }
+
+  public isInBreachRoom(pos: Vec3, team: 0 | 1): boolean {
+    return this.arena.isInBreachRoom(this.toThree(pos), team);
+  }
+
+  public isDeepInBreachRoom(pos: Vec3, team: 0 | 1, depth: number): boolean {
+    return this.arena.isDeepInBreachRoom(this.toThree(pos), team, depth);
+  }
+
+  public getNearestBar(pos: Vec3, radius: number): BarGrabPoint | null {
+    const bar = this.arena.getNearestBar(this.toThree(pos), radius);
+    if (!bar) return null;
+    return { pos: { x: bar.x, y: bar.y, z: bar.z } };
+  }
+
+  public getAllBarGrabPoints(): Vec3[] {
+    return this.arena.getAllBarGrabPoints().map((bar) => ({ x: bar.x, y: bar.y, z: bar.z }));
+  }
+
+  private toThree(vec: Vec3) {
+    return new THREE.Vector3(vec.x, vec.y, vec.z);
+  }
+}

--- a/client/src/match/arenaQueryAdapter.ts
+++ b/client/src/match/arenaQueryAdapter.ts
@@ -19,6 +19,10 @@ export class ArenaQueryAdapter implements SharedArenaQuery {
     return this.arena.getBreachOpenSign(team);
   }
 
+  public getAllBarGrabPoints(): Vec3[] {
+    return this.arena.getAllBarGrabPoints().map((bar) => ({ x: bar.x, y: bar.y, z: bar.z }));
+  }
+
   public isGoalDoorOpen(team: 0 | 1): boolean {
     return this.arena.isGoalDoorOpen(team);
   }
@@ -35,10 +39,6 @@ export class ArenaQueryAdapter implements SharedArenaQuery {
     const bar = this.arena.getNearestBar(this.toThree(pos), radius);
     if (!bar) return null;
     return { pos: { x: bar.x, y: bar.y, z: bar.z } };
-  }
-
-  public getAllBarGrabPoints(): Vec3[] {
-    return this.arena.getAllBarGrabPoints().map((bar) => ({ x: bar.x, y: bar.y, z: bar.z }));
   }
 
   private toThree(vec: Vec3) {

--- a/client/src/match/botBrain.ts
+++ b/client/src/match/botBrain.ts
@@ -1,0 +1,466 @@
+import { GRAB_RADIUS } from "../../../shared/constants";
+import type { SharedArenaQuery } from "../../../shared/player-logic";
+import type { DamageState, PlayerPhase } from "../../../shared/schema";
+import type { Vec3 } from "../../../shared/vec3";
+import { v3 } from "../../../shared/vec3";
+
+const DEFAULT_WORLD_UP = { x: 0, y: 1, z: 0 } as const;
+const MAX_FOCUS_RANGE = 26;
+
+type BotArchetype = "sprinter" | "hunter" | "drifter" | "anchor" | "rookie";
+
+export interface BotSnapshot {
+  currentBreachTeam: 0 | 1;
+  damage: DamageState;
+  phase: PlayerPhase;
+  pos: Vec3;
+  rot: { yaw: number; pitch: number };
+  team: 0 | 1;
+}
+
+export interface EnemySnapshot {
+  id: string;
+  phase: PlayerPhase;
+  pos: Vec3;
+  team: 0 | 1;
+}
+
+export interface BotCommand {
+  aimHeld: boolean;
+  fire: boolean;
+  grab: boolean;
+  lookPitch: number;
+  lookYaw: number;
+  targetBar: Vec3 | null;
+  walkAxes: { x: number; z: number };
+}
+
+export interface BarSelectionTuning {
+  directionWeight?: number;
+  distanceWeight?: number;
+  lateralBias?: number;
+  verticalBias?: number;
+  noiseSeed?: number;
+  pathNoise?: number;
+}
+
+export interface BotPersonality {
+  aimNoise: number;
+  aimReleaseMax: number;
+  aimReleaseMin: number;
+  archetype: BotArchetype;
+  barDirectionWeight: number;
+  barDistanceWeight: number;
+  barLateralBias: number;
+  barVerticalBias: number;
+  breachForwardBias: number;
+  breachStrafeAmplitude: number;
+  breachWeaveSpeed: number;
+  decisionInterval: number;
+  enemyFocusBias: number;
+  fireCooldown: number;
+  fireRange: number;
+  grabDecisionDelay: number;
+  launchChargeSeconds: number;
+  pathNoise: number;
+  rngSeed: number;
+  weaveOffset: number;
+}
+
+export function pickPreferredBar(
+  botPos: Vec3,
+  bars: Vec3[],
+  preferredDirection: Vec3,
+  tuning: BarSelectionTuning = {},
+): Vec3 | null {
+  const preferred = v3.normalize(preferredDirection);
+  const lateralRaw = v3.cross(DEFAULT_WORLD_UP, preferred);
+  const lateral = v3.lengthSq(lateralRaw) > 1e-6
+    ? v3.normalize(lateralRaw)
+    : { x: 1, y: 0, z: 0 };
+  let bestBar: Vec3 | null = null;
+  let bestScore = -Infinity;
+
+  for (const bar of bars) {
+    const toBar = v3.sub(bar, botPos);
+    const distance = v3.length(toBar);
+    if (distance <= 1e-6) return v3.clone(bar);
+
+    const normal = v3.normalize(toBar);
+    const directionScore = v3.dot(normal, preferred);
+    const distanceScore = 1 / Math.max(distance, 0.001);
+    const lateralScore = v3.dot(normal, lateral);
+    const verticalScore = normal.y;
+    const noiseScore = sampleBarNoise(bar, tuning.noiseSeed ?? 0);
+    const score = directionScore * (tuning.directionWeight ?? 3)
+      + distanceScore * (tuning.distanceWeight ?? 1)
+      + lateralScore * (tuning.lateralBias ?? 0)
+      + verticalScore * (tuning.verticalBias ?? 0)
+      + noiseScore * (tuning.pathNoise ?? 0);
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestBar = v3.clone(bar);
+    }
+  }
+
+  return bestBar;
+}
+
+function directionToRotation(dir: Vec3): { yaw: number; pitch: number } {
+  const normal = v3.normalize(dir);
+  return {
+    yaw: Math.atan2(-normal.x, -normal.z),
+    pitch: Math.asin(Math.max(-1, Math.min(1, normal.y))),
+  };
+}
+
+function breachExitDirection(arena: SharedArenaQuery, team: 0 | 1): Vec3 {
+  const axis = arena.getBreachOpenAxis(team);
+  const sign = arena.getBreachOpenSign(team);
+  return axis === "x"
+    ? { x: sign, y: 0, z: 0 }
+    : axis === "y"
+      ? { x: 0, y: sign, z: 0 }
+      : { x: 0, y: 0, z: sign };
+}
+
+function findNearestEnemy(
+  bot: BotSnapshot,
+  enemies: EnemySnapshot[],
+  maxDistance = MAX_FOCUS_RANGE,
+): EnemySnapshot | null {
+  let best: EnemySnapshot | null = null;
+  let bestDistance = maxDistance;
+
+  for (const enemy of enemies) {
+    if (enemy.team === bot.team) continue;
+    if (enemy.phase === "FROZEN" || enemy.phase === "RESPAWNING") continue;
+    const distance = v3.dist(bot.pos, enemy.pos);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = enemy;
+    }
+  }
+
+  return best;
+}
+
+export function createBotPersonality(id: string, team: 0 | 1): BotPersonality {
+  const seeded = createSeededRandom(hashString(`${id}:${team}`));
+  const archetypes: BotArchetype[] = ["sprinter", "hunter", "drifter", "anchor", "rookie"];
+  const archetype = archetypes[Math.floor(seeded() * archetypes.length)];
+  const sideBias = seeded() < 0.5 ? -1 : 1;
+  const profile = createArchetypeProfile(archetype, seeded, sideBias);
+  profile.rngSeed = hashString(`${id}:${team}:rng`);
+  return profile;
+}
+
+export class BotBrain {
+  private aimProgress = 0;
+  private decisionTimer = 0;
+  private fireCooldown = 0;
+  private grabDelay = 0;
+  private lastPhase: PlayerPhase | null = null;
+  private releaseThreshold = 0;
+  private roamTime = 0;
+  private rngState = 0;
+  private selectedBar: Vec3 | null = null;
+
+  public constructor(
+    private readonly personality: BotPersonality = createBotPersonality("bot-default", 0),
+  ) {
+    this.rngState = personality.rngSeed >>> 0;
+    this.releaseThreshold = this.randomReleaseThreshold();
+  }
+
+  public tick(
+    bot: BotSnapshot,
+    arena: SharedArenaQuery,
+    bars: Vec3[],
+    enemies: EnemySnapshot[],
+    dt: number,
+  ): BotCommand {
+    this.roamTime += dt;
+    this.fireCooldown = Math.max(0, this.fireCooldown - dt);
+    this.decisionTimer = Math.max(0, this.decisionTimer - dt);
+
+    if (bot.phase !== this.lastPhase) {
+      this.handlePhaseChange(bot.phase);
+      this.lastPhase = bot.phase;
+    }
+
+    const enemyPortal = arena.getBreachRoomCenter((1 - bot.team) as 0 | 1);
+    const preferredBar = this.choosePreferredBar(bot.pos, bars, v3.sub(enemyPortal, bot.pos));
+    const focusEnemy = findNearestEnemy(
+      bot,
+      enemies,
+      Math.min(MAX_FOCUS_RANGE, this.personality.fireRange * (0.8 + this.personality.enemyFocusBias)),
+    );
+    const firingEnemy = findNearestEnemy(bot, enemies, this.personality.fireRange);
+
+    let aimDir = v3.sub(enemyPortal, bot.pos);
+    if (preferredBar) aimDir = v3.sub(preferredBar, bot.pos);
+    if (focusEnemy) aimDir = v3.sub(focusEnemy.pos, bot.pos);
+    aimDir = this.applyAimNoise(aimDir);
+
+    let look = directionToRotation(aimDir);
+    let walkAxes = { x: 0, z: 0 };
+    let grab = false;
+    let aimHeld = false;
+
+    if (bot.phase === "BREACH") {
+      look = directionToRotation(breachExitDirection(arena, bot.currentBreachTeam));
+      walkAxes = {
+        x: Math.max(
+          -1,
+          Math.min(
+            1,
+            Math.sin(this.roamTime * this.personality.breachWeaveSpeed + this.personality.weaveOffset)
+              * this.personality.breachStrafeAmplitude,
+          ),
+        ),
+        z: this.personality.breachForwardBias,
+      };
+    } else if (bot.phase === "FLOATING") {
+      if (preferredBar && v3.dist(bot.pos, preferredBar) <= GRAB_RADIUS * 1.15 && !bot.damage.leftArm) {
+        grab = true;
+      }
+    } else if (bot.phase === "GRABBING") {
+      this.grabDelay = Math.max(0, this.grabDelay - dt);
+      aimHeld = this.grabDelay <= 0 && !bot.damage.frozen && !bot.damage.leftArm;
+    } else if (bot.phase === "AIMING") {
+      this.aimProgress = Math.min(1, this.aimProgress + dt / this.personality.launchChargeSeconds);
+      aimHeld = this.aimProgress < this.releaseThreshold;
+      if (!aimHeld) {
+        this.aimProgress = 0;
+        this.releaseThreshold = this.randomReleaseThreshold();
+      }
+      const targetDir = focusEnemy
+        ? v3.sub(focusEnemy.pos, bot.pos)
+        : v3.sub(enemyPortal, bot.pos);
+      look = directionToRotation(this.applyAimNoise(targetDir));
+    } else if (bot.phase === "FROZEN") {
+      this.aimProgress = 0;
+      this.selectedBar = null;
+    }
+
+    let fire = false;
+    if (!bot.damage.rightArm && firingEnemy && this.fireCooldown <= 0) {
+      fire = true;
+      this.fireCooldown = this.personality.fireCooldown;
+      look = directionToRotation(this.applyAimNoise(v3.sub(firingEnemy.pos, bot.pos)));
+    }
+
+    return {
+      aimHeld,
+      fire,
+      grab,
+      lookPitch: look.pitch,
+      lookYaw: look.yaw,
+      targetBar: preferredBar,
+      walkAxes,
+    };
+  }
+
+  public getLaunchChargeSeconds(): number {
+    return this.personality.launchChargeSeconds;
+  }
+
+  private applyAimNoise(dir: Vec3): Vec3 {
+    if (this.personality.aimNoise <= 1e-4) return dir;
+    return {
+      x: dir.x + Math.sin(this.roamTime * 2.7 + this.personality.weaveOffset) * this.personality.aimNoise,
+      y: dir.y + Math.cos(this.roamTime * 1.9 + this.personality.weaveOffset * 0.7) * this.personality.aimNoise * 0.45,
+      z: dir.z + Math.sin(this.roamTime * 2.1 - this.personality.weaveOffset * 0.4) * this.personality.aimNoise,
+    };
+  }
+
+  private choosePreferredBar(botPos: Vec3, bars: Vec3[], preferredDirection: Vec3): Vec3 | null {
+    const shouldRepath = !this.selectedBar
+      || this.decisionTimer <= 0
+      || v3.dist(botPos, this.selectedBar) <= GRAB_RADIUS * 1.4;
+
+    if (shouldRepath) {
+      this.selectedBar = pickPreferredBar(botPos, bars, preferredDirection, {
+        directionWeight: this.personality.barDirectionWeight,
+        distanceWeight: this.personality.barDistanceWeight,
+        lateralBias: this.personality.barLateralBias,
+        verticalBias: this.personality.barVerticalBias,
+        noiseSeed: this.personality.weaveOffset,
+        pathNoise: this.personality.pathNoise,
+      });
+      this.decisionTimer = this.personality.decisionInterval;
+    }
+
+    return this.selectedBar ? v3.clone(this.selectedBar) : null;
+  }
+
+  private handlePhaseChange(phase: PlayerPhase): void {
+    if (phase === "GRABBING") {
+      this.grabDelay = this.personality.grabDecisionDelay;
+      this.aimProgress = 0;
+      return;
+    }
+
+    if (phase === "AIMING") {
+      this.aimProgress = 0;
+      this.releaseThreshold = this.randomReleaseThreshold();
+      return;
+    }
+
+    if (phase !== "FLOATING") {
+      this.selectedBar = null;
+    }
+  }
+
+  private nextRandom(): number {
+    this.rngState = (this.rngState + 0x6d2b79f5) >>> 0;
+    let t = this.rngState;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  private randomReleaseThreshold(): number {
+    return this.personality.aimReleaseMin
+      + this.nextRandom() * (this.personality.aimReleaseMax - this.personality.aimReleaseMin);
+  }
+}
+
+function createArchetypeProfile(
+  archetype: BotArchetype,
+  seeded: () => number,
+  sideBias: 1 | -1,
+): BotPersonality {
+  const base = {
+    aimNoise: 0.2,
+    aimReleaseMax: 0.88,
+    aimReleaseMin: 0.7,
+    archetype,
+    barDirectionWeight: 3,
+    barDistanceWeight: 1,
+    barLateralBias: sideBias * 0.25,
+    barVerticalBias: 0,
+    breachForwardBias: 1,
+    breachStrafeAmplitude: 0.18,
+    breachWeaveSpeed: 1.6,
+    decisionInterval: 0.4,
+    enemyFocusBias: 0.5,
+    fireCooldown: 0.55,
+    fireRange: 18,
+    grabDecisionDelay: 0.12,
+    launchChargeSeconds: 0.9,
+    pathNoise: 0.08,
+    rngSeed: 0,
+    weaveOffset: seeded() * Math.PI * 2,
+  } satisfies BotPersonality;
+
+  if (archetype === "sprinter") {
+    base.aimNoise = 0.3 + seeded() * 0.12;
+    base.barDistanceWeight = 1.4 + seeded() * 0.4;
+    base.barLateralBias = sideBias * (0.15 + seeded() * 0.3);
+    base.breachStrafeAmplitude = 0.2 + seeded() * 0.12;
+    base.decisionInterval = 0.18 + seeded() * 0.16;
+    base.enemyFocusBias = 0.38 + seeded() * 0.16;
+    base.fireCooldown = 0.42 + seeded() * 0.18;
+    base.fireRange = 15 + seeded() * 2.5;
+    base.grabDecisionDelay = 0.02 + seeded() * 0.08;
+    base.launchChargeSeconds = 0.58 + seeded() * 0.18;
+    base.pathNoise = 0.16 + seeded() * 0.14;
+  } else if (archetype === "hunter") {
+    base.aimNoise = 0.05 + seeded() * 0.08;
+    base.aimReleaseMin = 0.74 + seeded() * 0.06;
+    base.aimReleaseMax = 0.86 + seeded() * 0.08;
+    base.barDirectionWeight = 3.2 + seeded() * 0.7;
+    base.barDistanceWeight = 0.7 + seeded() * 0.35;
+    base.barVerticalBias = -0.18 + seeded() * 0.36;
+    base.breachStrafeAmplitude = 0.08 + seeded() * 0.08;
+    base.decisionInterval = 0.22 + seeded() * 0.18;
+    base.enemyFocusBias = 0.82 + seeded() * 0.18;
+    base.fireCooldown = 0.34 + seeded() * 0.14;
+    base.fireRange = 20 + seeded() * 4;
+    base.grabDecisionDelay = 0.04 + seeded() * 0.1;
+    base.launchChargeSeconds = 0.74 + seeded() * 0.16;
+    base.pathNoise = 0.04 + seeded() * 0.06;
+  } else if (archetype === "drifter") {
+    base.aimNoise = 0.26 + seeded() * 0.24;
+    base.aimReleaseMin = 0.62 + seeded() * 0.06;
+    base.aimReleaseMax = 0.82 + seeded() * 0.1;
+    base.barDirectionWeight = 2.1 + seeded() * 0.55;
+    base.barDistanceWeight = 0.95 + seeded() * 0.4;
+    base.barLateralBias = sideBias * (0.72 + seeded() * 0.4);
+    base.barVerticalBias = -0.45 + seeded() * 0.9;
+    base.breachStrafeAmplitude = 0.44 + seeded() * 0.22;
+    base.breachWeaveSpeed = 1.2 + seeded() * 0.7;
+    base.decisionInterval = 0.38 + seeded() * 0.32;
+    base.enemyFocusBias = 0.22 + seeded() * 0.16;
+    base.fireCooldown = 0.62 + seeded() * 0.22;
+    base.fireRange = 13 + seeded() * 3;
+    base.grabDecisionDelay = 0.12 + seeded() * 0.2;
+    base.launchChargeSeconds = 0.88 + seeded() * 0.26;
+    base.pathNoise = 0.22 + seeded() * 0.18;
+  } else if (archetype === "anchor") {
+    base.aimNoise = 0.1 + seeded() * 0.16;
+    base.aimReleaseMin = 0.78 + seeded() * 0.08;
+    base.aimReleaseMax = 0.9 + seeded() * 0.06;
+    base.barDirectionWeight = 3.6 + seeded() * 0.7;
+    base.barDistanceWeight = 0.45 + seeded() * 0.22;
+    base.barLateralBias = sideBias * (0.06 + seeded() * 0.12);
+    base.barVerticalBias = -0.1 + seeded() * 0.2;
+    base.breachForwardBias = 0.82 + seeded() * 0.1;
+    base.breachStrafeAmplitude = 0.04 + seeded() * 0.08;
+    base.decisionInterval = 0.36 + seeded() * 0.2;
+    base.enemyFocusBias = 0.48 + seeded() * 0.18;
+    base.fireCooldown = 0.44 + seeded() * 0.18;
+    base.fireRange = 18 + seeded() * 3;
+    base.grabDecisionDelay = 0.08 + seeded() * 0.12;
+    base.launchChargeSeconds = 0.92 + seeded() * 0.16;
+    base.pathNoise = 0.02 + seeded() * 0.05;
+  } else {
+    base.aimNoise = 0.48 + seeded() * 0.28;
+    base.aimReleaseMin = 0.58 + seeded() * 0.08;
+    base.aimReleaseMax = 0.84 + seeded() * 0.12;
+    base.barDirectionWeight = 2.05 + seeded() * 0.4;
+    base.barDistanceWeight = 1.1 + seeded() * 0.35;
+    base.barLateralBias = sideBias * (0.28 + seeded() * 0.22);
+    base.barVerticalBias = -0.24 + seeded() * 0.5;
+    base.breachForwardBias = 0.72 + seeded() * 0.16;
+    base.breachStrafeAmplitude = 0.16 + seeded() * 0.14;
+    base.breachWeaveSpeed = 0.95 + seeded() * 0.45;
+    base.decisionInterval = 0.58 + seeded() * 0.34;
+    base.enemyFocusBias = 0.12 + seeded() * 0.22;
+    base.fireCooldown = 0.74 + seeded() * 0.26;
+    base.fireRange = 11 + seeded() * 4;
+    base.grabDecisionDelay = 0.18 + seeded() * 0.28;
+    base.launchChargeSeconds = 1 + seeded() * 0.24;
+    base.pathNoise = 0.16 + seeded() * 0.18;
+  }
+
+  return base;
+}
+
+function hashString(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function sampleBarNoise(bar: Vec3, seed: number): number {
+  const wave = Math.sin(bar.x * 12.9898 + bar.y * 78.233 + bar.z * 37.719 + seed * 0.001);
+  return (wave - Math.floor(wave)) * 2 - 1;
+}

--- a/client/src/match/botBrain.ts
+++ b/client/src/match/botBrain.ts
@@ -5,7 +5,9 @@ import type { Vec3 } from "../../../shared/vec3";
 import { v3 } from "../../../shared/vec3";
 
 const DEFAULT_WORLD_UP = { x: 0, y: 1, z: 0 } as const;
-const MAX_FOCUS_RANGE = 26;
+const MAX_FOCUS_RANGE = 28;
+const ROUTE_REACH_DISTANCE = GRAB_RADIUS * 1.25;
+const BAR_LINK_DISTANCE = 9;
 
 type BotArchetype = "sprinter" | "hunter" | "drifter" | "anchor" | "rookie";
 
@@ -28,6 +30,7 @@ export interface EnemySnapshot {
 export interface BotCommand {
   aimHeld: boolean;
   fire: boolean;
+  fireDirection: Vec3 | null;
   grab: boolean;
   lookPitch: number;
   lookYaw: number;
@@ -63,8 +66,31 @@ export interface BotPersonality {
   grabDecisionDelay: number;
   launchChargeSeconds: number;
   pathNoise: number;
+  routeLengthMax: number;
+  routeLengthMin: number;
   rngSeed: number;
+  shotSpreadBase: number;
   weaveOffset: number;
+}
+
+export interface BarRouteGraph {
+  nodes: Array<{
+    neighbors: number[];
+    pos: Vec3;
+  }>;
+}
+
+export function buildBarGraph(bars: Vec3[]): BarRouteGraph {
+  return {
+    nodes: bars.map((pos, index) => ({
+      pos: v3.clone(pos),
+      neighbors: bars
+        .map((candidate, candidateIndex) => ({ candidate, candidateIndex }))
+        .filter(({ candidateIndex }) => candidateIndex !== index)
+        .filter(({ candidate }) => v3.dist(candidate, pos) <= BAR_LINK_DISTANCE)
+        .map(({ candidateIndex }) => candidateIndex),
+    })),
+  };
 }
 
 export function pickPreferredBar(
@@ -158,26 +184,48 @@ export function createBotPersonality(id: string, team: 0 | 1): BotPersonality {
 
 export class BotBrain {
   private aimProgress = 0;
+  private currentRoute: number[] = [];
   private decisionTimer = 0;
   private fireCooldown = 0;
   private grabDelay = 0;
   private lastPhase: PlayerPhase | null = null;
+  private lastWaypointDistance = Infinity;
   private releaseThreshold = 0;
   private roamTime = 0;
+  private roundRouteLength = 2;
+  private roundSeed = 0;
+  private roundShotSpread = 0;
   private rngState = 0;
-  private selectedBar: Vec3 | null = null;
+  private stuckTimer = 0;
 
   public constructor(
     private readonly personality: BotPersonality = createBotPersonality("bot-default", 0),
   ) {
-    this.rngState = personality.rngSeed >>> 0;
+    this.resetForRound(1);
+  }
+
+  public resetForRound(roundSeed: number): void {
+    this.roundSeed = roundSeed;
+    this.rngState = hashString(`${this.personality.rngSeed}:${roundSeed}`) >>> 0;
+    this.currentRoute = [];
+    this.decisionTimer = 0;
+    this.fireCooldown = 0;
+    this.grabDelay = 0;
+    this.lastPhase = null;
+    this.lastWaypointDistance = Infinity;
     this.releaseThreshold = this.randomReleaseThreshold();
+    this.roundRouteLength = this.personality.routeLengthMin
+      + Math.floor(
+        this.nextRandom() * (this.personality.routeLengthMax - this.personality.routeLengthMin + 1),
+      );
+    this.roundShotSpread = this.personality.shotSpreadBase * (1.1 + this.nextRandom() * 1.35);
+    this.stuckTimer = 0;
   }
 
   public tick(
     bot: BotSnapshot,
     arena: SharedArenaQuery,
-    bars: Vec3[],
+    graph: BarRouteGraph,
     enemies: EnemySnapshot[],
     dt: number,
   ): BotCommand {
@@ -186,31 +234,36 @@ export class BotBrain {
     this.decisionTimer = Math.max(0, this.decisionTimer - dt);
 
     if (bot.phase !== this.lastPhase) {
-      this.handlePhaseChange(bot.phase);
+      this.handlePhaseChange(bot.phase, bot, graph, arena);
       this.lastPhase = bot.phase;
     }
 
+    this.advanceRoute(bot.pos, graph, dt);
+
     const enemyPortal = arena.getBreachRoomCenter((1 - bot.team) as 0 | 1);
-    const preferredBar = this.choosePreferredBar(bot.pos, bars, v3.sub(enemyPortal, bot.pos));
     const focusEnemy = findNearestEnemy(
       bot,
       enemies,
       Math.min(MAX_FOCUS_RANGE, this.personality.fireRange * (0.8 + this.personality.enemyFocusBias)),
     );
     const firingEnemy = findNearestEnemy(bot, enemies, this.personality.fireRange);
+    let routeTarget = this.getRouteTarget(graph);
 
-    let aimDir = v3.sub(enemyPortal, bot.pos);
-    if (preferredBar) aimDir = v3.sub(preferredBar, bot.pos);
-    if (focusEnemy) aimDir = v3.sub(focusEnemy.pos, bot.pos);
-    aimDir = this.applyAimNoise(aimDir);
+    if (this.shouldReplan(bot, routeTarget)) {
+      this.planRoute(bot.pos, enemyPortal, graph);
+      routeTarget = this.getRouteTarget(graph);
+    }
 
-    let look = directionToRotation(aimDir);
+    const movementTarget = this.getMovementTarget(bot, enemyPortal, graph);
+    let lookDir = this.applyAimNoise(v3.sub(movementTarget, bot.pos));
+    let look = directionToRotation(lookDir);
     let walkAxes = { x: 0, z: 0 };
     let grab = false;
     let aimHeld = false;
 
     if (bot.phase === "BREACH") {
-      look = directionToRotation(breachExitDirection(arena, bot.currentBreachTeam));
+      lookDir = breachExitDirection(arena, bot.currentBreachTeam);
+      look = directionToRotation(lookDir);
       walkAxes = {
         x: Math.max(
           -1,
@@ -223,7 +276,7 @@ export class BotBrain {
         z: this.personality.breachForwardBias,
       };
     } else if (bot.phase === "FLOATING") {
-      if (preferredBar && v3.dist(bot.pos, preferredBar) <= GRAB_RADIUS * 1.15 && !bot.damage.leftArm) {
+      if (routeTarget && v3.dist(bot.pos, routeTarget) <= ROUTE_REACH_DISTANCE && !bot.damage.leftArm) {
         grab = true;
       }
     } else if (bot.phase === "GRABBING") {
@@ -236,35 +289,59 @@ export class BotBrain {
         this.aimProgress = 0;
         this.releaseThreshold = this.randomReleaseThreshold();
       }
-      const targetDir = focusEnemy
-        ? v3.sub(focusEnemy.pos, bot.pos)
-        : v3.sub(enemyPortal, bot.pos);
-      look = directionToRotation(this.applyAimNoise(targetDir));
+      const launchTarget = this.getLaunchTarget(bot, enemyPortal, graph);
+      look = directionToRotation(this.applyAimNoise(v3.sub(launchTarget, bot.pos)));
     } else if (bot.phase === "FROZEN") {
       this.aimProgress = 0;
-      this.selectedBar = null;
+      this.currentRoute = [];
     }
 
     let fire = false;
+    let fireDirection: Vec3 | null = null;
     if (!bot.damage.rightArm && firingEnemy && this.fireCooldown <= 0) {
       fire = true;
+      fireDirection = this.sampleFireDirection(v3.sub(firingEnemy.pos, bot.pos), bot.phase);
       this.fireCooldown = this.personality.fireCooldown;
-      look = directionToRotation(this.applyAimNoise(v3.sub(firingEnemy.pos, bot.pos)));
     }
 
     return {
       aimHeld,
       fire,
+      fireDirection,
       grab,
       lookPitch: look.pitch,
       lookYaw: look.yaw,
-      targetBar: preferredBar,
+      targetBar: routeTarget ? v3.clone(routeTarget) : null,
       walkAxes,
     };
   }
 
   public getLaunchChargeSeconds(): number {
     return this.personality.launchChargeSeconds;
+  }
+
+  private advanceRoute(botPos: Vec3, graph: BarRouteGraph, dt: number): void {
+    const routeTarget = this.getRouteTarget(graph);
+    if (!routeTarget) {
+      this.lastWaypointDistance = Infinity;
+      this.stuckTimer = 0;
+      return;
+    }
+
+    const distance = v3.dist(botPos, routeTarget);
+    if (distance <= ROUTE_REACH_DISTANCE) {
+      this.currentRoute.shift();
+      this.lastWaypointDistance = Infinity;
+      this.stuckTimer = 0;
+      return;
+    }
+
+    if (distance >= this.lastWaypointDistance - 0.05) {
+      this.stuckTimer += dt;
+    } else {
+      this.stuckTimer = 0;
+    }
+    this.lastWaypointDistance = distance;
   }
 
   private applyAimNoise(dir: Vec3): Vec3 {
@@ -276,41 +353,75 @@ export class BotBrain {
     };
   }
 
-  private choosePreferredBar(botPos: Vec3, bars: Vec3[], preferredDirection: Vec3): Vec3 | null {
-    const shouldRepath = !this.selectedBar
-      || this.decisionTimer <= 0
-      || v3.dist(botPos, this.selectedBar) <= GRAB_RADIUS * 1.4;
+  private getLaunchTarget(
+    bot: BotSnapshot,
+    enemyPortal: Vec3,
+    graph: BarRouteGraph,
+  ): Vec3 {
+    const routeTarget = this.getRouteTarget(graph);
+    if (routeTarget) return routeTarget;
+    return v3.add(enemyPortal, {
+      x: this.personality.barLateralBias * 4,
+      y: this.personality.barVerticalBias * 2,
+      z: 0,
+    });
+  }
 
-    if (shouldRepath) {
-      this.selectedBar = pickPreferredBar(botPos, bars, preferredDirection, {
+  private getMovementTarget(
+    bot: BotSnapshot,
+    enemyPortal: Vec3,
+    graph: BarRouteGraph,
+  ): Vec3 {
+    const routeTarget = this.getRouteTarget(graph);
+    if (routeTarget) return routeTarget;
+    const fallback = pickPreferredBar(
+      bot.pos,
+      graph.nodes.map((node) => node.pos),
+      v3.sub(enemyPortal, bot.pos),
+      {
         directionWeight: this.personality.barDirectionWeight,
         distanceWeight: this.personality.barDistanceWeight,
         lateralBias: this.personality.barLateralBias,
         verticalBias: this.personality.barVerticalBias,
-        noiseSeed: this.personality.weaveOffset,
+        noiseSeed: this.roundSeed,
         pathNoise: this.personality.pathNoise,
-      });
-      this.decisionTimer = this.personality.decisionInterval;
-    }
-
-    return this.selectedBar ? v3.clone(this.selectedBar) : null;
+      },
+    );
+    return fallback ?? enemyPortal;
   }
 
-  private handlePhaseChange(phase: PlayerPhase): void {
+  private getRouteTarget(graph: BarRouteGraph): Vec3 | null {
+    const nextNode = this.currentRoute[0];
+    if (nextNode === undefined) return null;
+    return graph.nodes[nextNode]?.pos ?? null;
+  }
+
+  private handlePhaseChange(
+    phase: PlayerPhase,
+    bot: BotSnapshot,
+    graph: BarRouteGraph,
+    arena: SharedArenaQuery,
+  ): void {
     if (phase === "GRABBING") {
+      this.advanceRoute(bot.pos, graph, 0);
       this.grabDelay = this.personality.grabDecisionDelay;
       this.aimProgress = 0;
       return;
     }
 
     if (phase === "AIMING") {
+      if (this.currentRoute.length === 0) {
+        const enemyPortal = arena.getBreachRoomCenter((1 - bot.team) as 0 | 1);
+        this.planRoute(bot.pos, enemyPortal, graph);
+      }
       this.aimProgress = 0;
       this.releaseThreshold = this.randomReleaseThreshold();
       return;
     }
 
     if (phase !== "FLOATING") {
-      this.selectedBar = null;
+      this.currentRoute = [];
+      this.stuckTimer = 0;
     }
   }
 
@@ -322,9 +433,87 @@ export class BotBrain {
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   }
 
+  private planRoute(botPos: Vec3, enemyPortal: Vec3, graph: BarRouteGraph): void {
+    if (graph.nodes.length === 0) {
+      this.currentRoute = [];
+      this.decisionTimer = this.personality.decisionInterval;
+      return;
+    }
+
+    const startNode = findNearestBarNode(botPos, graph.nodes.map((node) => node.pos));
+    const targetNode = this.pickRouteDestination(startNode, botPos, enemyPortal, graph);
+    if (targetNode === null) {
+      this.currentRoute = [];
+      this.decisionTimer = this.personality.decisionInterval;
+      return;
+    }
+
+    const path = findShortestPath(graph, startNode, targetNode);
+    this.currentRoute = path.slice(0, this.roundRouteLength);
+    this.decisionTimer = this.personality.decisionInterval;
+    this.stuckTimer = 0;
+    this.lastWaypointDistance = Infinity;
+  }
+
+  private pickRouteDestination(
+    startNode: number | null,
+    botPos: Vec3,
+    enemyPortal: Vec3,
+    graph: BarRouteGraph,
+  ): number | null {
+    let bestIndex: number | null = null;
+    let bestScore = -Infinity;
+    const preferredDirection = v3.sub(enemyPortal, botPos);
+    const preferred = v3.normalize(preferredDirection);
+    const lateralRaw = v3.cross(DEFAULT_WORLD_UP, preferred);
+    const lateral = v3.lengthSq(lateralRaw) > 1e-6
+      ? v3.normalize(lateralRaw)
+      : { x: 1, y: 0, z: 0 };
+
+    for (let i = 0; i < graph.nodes.length; i += 1) {
+      if (i === startNode) continue;
+      const node = graph.nodes[i];
+      const toNode = v3.sub(node.pos, botPos);
+      const distance = v3.length(toNode);
+      if (distance <= 1e-6) continue;
+
+      const normal = v3.normalize(toNode);
+      const directionScore = v3.dot(normal, preferred) * this.personality.barDirectionWeight;
+      const lateralScore = v3.dot(normal, lateral) * this.personality.barLateralBias;
+      const verticalScore = normal.y * this.personality.barVerticalBias;
+      const distanceScore = (1 / Math.max(distance, 0.001)) * this.personality.barDistanceWeight;
+      const routeNoise = (this.nextRandom() * 2 - 1) * this.personality.pathNoise;
+      const score = directionScore + lateralScore + verticalScore + distanceScore + routeNoise;
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+
+    return bestIndex;
+  }
+
   private randomReleaseThreshold(): number {
     return this.personality.aimReleaseMin
       + this.nextRandom() * (this.personality.aimReleaseMax - this.personality.aimReleaseMin);
+  }
+
+  private sampleFireDirection(targetDir: Vec3, phase: PlayerPhase): Vec3 {
+    const spread = this.roundShotSpread
+      + phaseSpreadModifier(phase)
+      + this.personality.shotSpreadBase * (0.2 + this.nextRandom() * 0.95);
+    return jitterDirection(v3.normalize(targetDir), spread, this.nextRandom.bind(this));
+  }
+
+  private shouldReplan(bot: BotSnapshot, routeTarget: Vec3 | null): boolean {
+    if (bot.phase !== "FLOATING" && bot.phase !== "AIMING" && bot.phase !== "GRABBING") {
+      return false;
+    }
+    if (!routeTarget) return true;
+    if (this.decisionTimer <= 0) return true;
+    if (this.stuckTimer >= 1.15) return true;
+    return false;
   }
 }
 
@@ -334,7 +523,7 @@ function createArchetypeProfile(
   sideBias: 1 | -1,
 ): BotPersonality {
   const base = {
-    aimNoise: 0.2,
+    aimNoise: 0.12,
     aimReleaseMax: 0.88,
     aimReleaseMin: 0.7,
     archetype,
@@ -352,24 +541,30 @@ function createArchetypeProfile(
     grabDecisionDelay: 0.12,
     launchChargeSeconds: 0.9,
     pathNoise: 0.08,
+    routeLengthMax: 3,
+    routeLengthMin: 2,
     rngSeed: 0,
+    shotSpreadBase: 0.06,
     weaveOffset: seeded() * Math.PI * 2,
   } satisfies BotPersonality;
 
   if (archetype === "sprinter") {
-    base.aimNoise = 0.3 + seeded() * 0.12;
+    base.aimNoise = 0.16 + seeded() * 0.08;
     base.barDistanceWeight = 1.4 + seeded() * 0.4;
-    base.barLateralBias = sideBias * (0.15 + seeded() * 0.3);
+    base.barLateralBias = sideBias * (0.18 + seeded() * 0.3);
     base.breachStrafeAmplitude = 0.2 + seeded() * 0.12;
     base.decisionInterval = 0.18 + seeded() * 0.16;
-    base.enemyFocusBias = 0.38 + seeded() * 0.16;
+    base.enemyFocusBias = 0.34 + seeded() * 0.18;
     base.fireCooldown = 0.42 + seeded() * 0.18;
     base.fireRange = 15 + seeded() * 2.5;
     base.grabDecisionDelay = 0.02 + seeded() * 0.08;
     base.launchChargeSeconds = 0.58 + seeded() * 0.18;
-    base.pathNoise = 0.16 + seeded() * 0.14;
+    base.pathNoise = 0.12 + seeded() * 0.12;
+    base.routeLengthMin = 2;
+    base.routeLengthMax = 3;
+    base.shotSpreadBase = 0.1 + seeded() * 0.035;
   } else if (archetype === "hunter") {
-    base.aimNoise = 0.05 + seeded() * 0.08;
+    base.aimNoise = 0.04 + seeded() * 0.06;
     base.aimReleaseMin = 0.74 + seeded() * 0.06;
     base.aimReleaseMax = 0.86 + seeded() * 0.08;
     base.barDirectionWeight = 3.2 + seeded() * 0.7;
@@ -382,9 +577,12 @@ function createArchetypeProfile(
     base.fireRange = 20 + seeded() * 4;
     base.grabDecisionDelay = 0.04 + seeded() * 0.1;
     base.launchChargeSeconds = 0.74 + seeded() * 0.16;
-    base.pathNoise = 0.04 + seeded() * 0.06;
+    base.pathNoise = 0.03 + seeded() * 0.04;
+    base.routeLengthMin = 2;
+    base.routeLengthMax = 4;
+    base.shotSpreadBase = 0.04 + seeded() * 0.025;
   } else if (archetype === "drifter") {
-    base.aimNoise = 0.26 + seeded() * 0.24;
+    base.aimNoise = 0.24 + seeded() * 0.2;
     base.aimReleaseMin = 0.62 + seeded() * 0.06;
     base.aimReleaseMax = 0.82 + seeded() * 0.1;
     base.barDirectionWeight = 2.1 + seeded() * 0.55;
@@ -399,9 +597,12 @@ function createArchetypeProfile(
     base.fireRange = 13 + seeded() * 3;
     base.grabDecisionDelay = 0.12 + seeded() * 0.2;
     base.launchChargeSeconds = 0.88 + seeded() * 0.26;
-    base.pathNoise = 0.22 + seeded() * 0.18;
+    base.pathNoise = 0.2 + seeded() * 0.18;
+    base.routeLengthMin = 3;
+    base.routeLengthMax = 4;
+    base.shotSpreadBase = 0.12 + seeded() * 0.05;
   } else if (archetype === "anchor") {
-    base.aimNoise = 0.1 + seeded() * 0.16;
+    base.aimNoise = 0.08 + seeded() * 0.12;
     base.aimReleaseMin = 0.78 + seeded() * 0.08;
     base.aimReleaseMax = 0.9 + seeded() * 0.06;
     base.barDirectionWeight = 3.6 + seeded() * 0.7;
@@ -417,8 +618,11 @@ function createArchetypeProfile(
     base.grabDecisionDelay = 0.08 + seeded() * 0.12;
     base.launchChargeSeconds = 0.92 + seeded() * 0.16;
     base.pathNoise = 0.02 + seeded() * 0.05;
+    base.routeLengthMin = 2;
+    base.routeLengthMax = 3;
+    base.shotSpreadBase = 0.06 + seeded() * 0.03;
   } else {
-    base.aimNoise = 0.48 + seeded() * 0.28;
+    base.aimNoise = 0.42 + seeded() * 0.22;
     base.aimReleaseMin = 0.58 + seeded() * 0.08;
     base.aimReleaseMax = 0.84 + seeded() * 0.12;
     base.barDirectionWeight = 2.05 + seeded() * 0.4;
@@ -435,9 +639,89 @@ function createArchetypeProfile(
     base.grabDecisionDelay = 0.18 + seeded() * 0.28;
     base.launchChargeSeconds = 1 + seeded() * 0.24;
     base.pathNoise = 0.16 + seeded() * 0.18;
+    base.routeLengthMin = 2;
+    base.routeLengthMax = 3;
+    base.shotSpreadBase = 0.15 + seeded() * 0.06;
   }
 
   return base;
+}
+
+function findNearestBarNode(botPos: Vec3, bars: Vec3[]): number | null {
+  let bestIndex: number | null = null;
+  let bestDistance = Infinity;
+
+  for (let i = 0; i < bars.length; i += 1) {
+    const distance = v3.distSq(botPos, bars[i]);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = i;
+    }
+  }
+
+  return bestIndex;
+}
+
+function findShortestPath(
+  graph: BarRouteGraph,
+  startNode: number | null,
+  targetNode: number,
+): number[] {
+  if (startNode === null || startNode === targetNode) return [targetNode];
+
+  const queue = [startNode];
+  const visited = new Set<number>([startNode]);
+  const parent = new Map<number, number | null>([[startNode, null]]);
+
+  while (queue.length > 0) {
+    const current = queue.shift() as number;
+    if (current === targetNode) break;
+
+    for (const neighbor of graph.nodes[current]?.neighbors ?? []) {
+      if (visited.has(neighbor)) continue;
+      visited.add(neighbor);
+      parent.set(neighbor, current);
+      queue.push(neighbor);
+    }
+  }
+
+  if (!parent.has(targetNode)) return [targetNode];
+
+  const path: number[] = [];
+  let current: number | null = targetNode;
+  while (current !== null) {
+    path.push(current);
+    current = parent.get(current) ?? null;
+  }
+  path.reverse();
+  return path.slice(1);
+}
+
+function jitterDirection(
+  dir: Vec3,
+  spread: number,
+  random: () => number,
+): Vec3 {
+  if (spread <= 1e-6) return dir;
+
+  const referenceUp = Math.abs(dir.y) > 0.92 ? { x: 1, y: 0, z: 0 } : DEFAULT_WORLD_UP;
+  const right = v3.normalize(v3.cross(dir, referenceUp));
+  const up = v3.normalize(v3.cross(right, dir));
+  const yawOffset = (random() * 2 - 1) * spread;
+  const pitchOffset = (random() * 2 - 1) * spread * 0.8;
+  return v3.normalize(
+    v3.add(
+      dir,
+      v3.add(v3.scale(right, yawOffset), v3.scale(up, pitchOffset)),
+    ),
+  );
+}
+
+function phaseSpreadModifier(phase: PlayerPhase): number {
+  if (phase === "AIMING") return 0.024;
+  if (phase === "GRABBING") return 0.038;
+  if (phase === "FLOATING") return 0.065;
+  return 0.085;
 }
 
 function hashString(value: string): number {

--- a/client/src/match/localMatch.ts
+++ b/client/src/match/localMatch.ts
@@ -140,13 +140,13 @@ export class LocalMatch {
       this.getTeamActorCount(0),
       query,
       this.roundSeed * 11 + 7,
-    );
+    ).map((slot) => settleSpawnOnFloor(slot, query, 0));
     const team1Slots = generateSpawnPositions(
       1,
       this.getTeamActorCount(1),
       query,
       this.roundSeed * 17 + 13,
-    );
+    ).map((slot) => settleSpawnOnFloor(slot, query, 1));
 
     if (this.config.humanTeam === 0) {
       player.resetForNewRound(arena, team0Slots.shift());
@@ -293,9 +293,9 @@ export class LocalMatch {
     isRoundPlaying: boolean,
   ): SpawnProjectileEvent[] {
     const shots: SpawnProjectileEvent[] = [];
+    const query = new ArenaQueryAdapter(arena);
 
     if (isRoundPlaying && !this.roundResolved) {
-      const query = new ArenaQueryAdapter(arena);
       const enemySnapshots = this.buildEnemySnapshots(player);
       for (const bot of this.bots) {
         this.tickBot(
@@ -308,10 +308,15 @@ export class LocalMatch {
         );
       }
 
-      this.resolveActorOverlap(player);
       this.checkForBreachScore(arena, player);
       this.checkFullFreezeWin(player);
+    } else {
+      for (const bot of this.bots) {
+        this.tickBotPassive(bot, arena, dt);
+      }
     }
+
+    this.resolveActorOverlap(player);
 
     for (const bot of this.bots) {
       bot.avatar.update(bot.phys.pos, bot.damage, bot.phase, bot.rot.yaw, dt, bot.phys.vel.length());
@@ -503,6 +508,9 @@ export class LocalMatch {
   ): void {
     if (bot.phase === "FROZEN") {
       integrateFloating(bot, arena, dt);
+      if (arena.isInBreachRoom(bot.phys.pos, bot.team)) {
+        returnBotToOwnBreach(bot);
+      }
       return;
     }
 
@@ -573,6 +581,36 @@ export class LocalMatch {
     }
   }
 
+  private tickBotPassive(
+    bot: BotState,
+    arena: Arena,
+    dt: number,
+  ): void {
+    switch (bot.phase) {
+      case "BREACH":
+        this.stepBotBreachPhysics(bot, arena, dt);
+        break;
+      case "FLOATING":
+      case "FROZEN":
+        integrateFloating(bot, arena, dt);
+        if (arena.isInBreachRoom(bot.phys.pos, bot.team)) {
+          returnBotToOwnBreach(bot);
+        }
+        break;
+      case "GRABBING":
+      case "AIMING":
+        if (bot.grabbedBarPos) {
+          bot.phys.vel.set(0, 0, 0);
+          bot.phys.pos.copy(bot.grabbedBarPos);
+        } else {
+          bot.phase = "FLOATING";
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
   private updateBotBreach(
     bot: BotState,
     command: ReturnType<BotBrain["tick"]>,
@@ -620,9 +658,7 @@ export class LocalMatch {
     integrateFloating(bot, arena, dt);
 
     if (arena.isInBreachRoom(bot.phys.pos, bot.team)) {
-      bot.currentBreachTeam = bot.team;
-      bot.phase = "BREACH";
-      bot.phys.vel.y = 0;
+      returnBotToOwnBreach(bot);
       return;
     }
 
@@ -633,6 +669,25 @@ export class LocalMatch {
         bot.phase = "GRABBING";
       }
     }
+  }
+
+  private stepBotBreachPhysics(bot: BotState, arena: Arena, dt: number): void {
+    const center = arena.getBreachRoomCenter(bot.currentBreachTeam);
+    const openAxis = arena.getBreachOpenAxis(bot.currentBreachTeam);
+    const openSign = arena.getBreachOpenSign(bot.currentBreachTeam);
+    const yawForwardVec = new THREE.Vector3(-Math.sin(bot.rot.yaw), 0, -Math.cos(bot.rot.yaw));
+    const yawRightVec = new THREE.Vector3(Math.cos(bot.rot.yaw), 0, -Math.sin(bot.rot.yaw));
+
+    integrateBreachRoom(
+      bot.phys,
+      { x: 0, z: 0 },
+      yawForwardVec,
+      yawRightVec,
+      false,
+      isOnBreachGround(bot, center.y),
+      dt,
+    );
+    clampBreachRoom(bot.phys, center, openAxis, openSign, arena.isGoalDoorOpen(bot.currentBreachTeam));
   }
 }
 
@@ -765,6 +820,27 @@ function resetBotsForRound(
     bot.brain.resetForRound(roundSeed * 37 + i * 13 + bot.team);
     bot.avatar.update(bot.phys.pos, bot.damage, bot.phase, bot.rot.yaw, 0, 0);
   }
+}
+
+function returnBotToOwnBreach(bot: BotState): void {
+  bot.currentBreachTeam = bot.team;
+  bot.damage.frozen = false;
+  bot.phase = "BREACH";
+  bot.phys.vel.y = 0;
+}
+
+function settleSpawnOnFloor(
+  spawn: Vec3,
+  query: ArenaQueryAdapter,
+  team: 0 | 1,
+): Vec3 {
+  const center = query.getBreachRoomCenter(team);
+  const floorY = center.y - 3 + PLAYER_RADIUS + 0.08;
+  return {
+    x: spawn.x,
+    y: floorY,
+    z: spawn.z,
+  };
 }
 
 function exitRotation(query: ArenaQueryAdapter, team: 0 | 1): { yaw: number; pitch: number } {

--- a/client/src/match/localMatch.ts
+++ b/client/src/match/localMatch.ts
@@ -1,0 +1,533 @@
+import * as THREE from "three";
+import { BOT_NAMES, GRAB_RADIUS, PLAYER_RADIUS } from "../../../shared/constants";
+import { getSoloBotFill, type SoloMatchConfig } from "../../../shared/match";
+import { classifyHitZone, maxLaunchPower, spawnPosition } from "../../../shared/player-logic";
+import type { EnemyPlayerInfo, FullPlayerInfo, PlayerPhase, DamageState } from "../../../shared/schema";
+import type { Vec3 } from "../../../shared/vec3";
+import { v3 } from "../../../shared/vec3";
+import { Arena } from "../arena/arena";
+import { CameraController } from "../camera";
+import {
+  bounceArena,
+  clampBreachRoom,
+  integrateBreachRoom,
+  integrateZeroG,
+  type PhysicsState,
+} from "../physics";
+import { LocalPlayer } from "../player";
+import { ArenaQueryAdapter } from "./arenaQueryAdapter";
+import { BotBrain, createBotPersonality } from "./botBrain";
+import { buildHudRosters } from "./rosterView";
+import { SimulatedPlayerAvatar } from "./simulatedPlayerAvatar";
+
+const LOCAL_PLAYER_ID = "local-player";
+
+export interface ProjectileActorTarget {
+  active: boolean;
+  id: string;
+  pos: THREE.Vector3;
+  radius: number;
+  team: 0 | 1;
+}
+
+export interface ProjectileHitEvent {
+  direction: THREE.Vector3;
+  impactPoint: THREE.Vector3;
+  ownerId: string;
+  targetId: string;
+}
+
+export interface SpawnProjectileEvent {
+  direction: THREE.Vector3;
+  origin: THREE.Vector3;
+  ownerId: string;
+  team: 0 | 1;
+}
+
+interface BotState {
+  avatar: SimulatedPlayerAvatar;
+  brain: BotBrain;
+  currentBreachTeam: 0 | 1;
+  damage: DamageState;
+  deaths: number;
+  grabbedBarPos: THREE.Vector3 | null;
+  id: string;
+  isBot: true;
+  kills: number;
+  launchPower: number;
+  name: string;
+  phase: PlayerPhase;
+  phys: PhysicsState;
+  rot: { yaw: number; pitch: number };
+  team: 0 | 1;
+}
+
+export class LocalMatch {
+  private bots: BotState[] = [];
+  private config: SoloMatchConfig = { humanName: "You", humanTeam: 0, teamSize: 1 };
+  private score = { team0: 0, team1: 0 };
+
+  public onScore: ((team: 0 | 1, scorerName: string) => void) | null = null;
+
+  public constructor(private scene: THREE.Scene) {}
+
+  public startNewGame(config: SoloMatchConfig): void {
+    this.config = config;
+    this.score = { team0: 0, team1: 0 };
+    this.rebuildBots();
+  }
+
+  public resetForRound(arena: Arena): void {
+    const query = new ArenaQueryAdapter(arena);
+    for (const bot of this.bots) {
+      const spawn = spawnPosition(bot.team, query);
+      bot.currentBreachTeam = bot.team;
+      bot.damage = createDamageState();
+      bot.grabbedBarPos = null;
+      bot.launchPower = 0;
+      bot.phase = "BREACH";
+      bot.phys.pos.set(spawn.x, spawn.y, spawn.z);
+      bot.phys.vel.set(0, 0, 0);
+      bot.rot = exitRotation(query, bot.team);
+      bot.avatar.update(bot.phys.pos, bot.phase, bot.rot.yaw, 0, 0);
+    }
+  }
+
+  public dispose(): void {
+    for (const bot of this.bots) {
+      bot.avatar.dispose(this.scene);
+    }
+    this.bots = [];
+  }
+
+  public tick(
+    dt: number,
+    arena: Arena,
+    player: LocalPlayer,
+    isRoundPlaying: boolean,
+  ): SpawnProjectileEvent[] {
+    const shots: SpawnProjectileEvent[] = [];
+    const query = new ArenaQueryAdapter(arena);
+    const bars = query.getAllBarGrabPoints();
+    const actors = [
+      {
+        id: LOCAL_PLAYER_ID,
+        phase: player.phase,
+        pos: toVec3(player.getPosition()),
+        team: this.config.humanTeam,
+      },
+      ...this.bots.map((bot) => ({
+        id: bot.id,
+        phase: bot.phase,
+        pos: toVec3(bot.phys.pos),
+        team: bot.team,
+      })),
+    ];
+
+    for (const bot of this.bots) {
+      if (isRoundPlaying) {
+        this.tickBot(bot, dt, arena, query, bars, actors, shots);
+      }
+      bot.avatar.update(bot.phys.pos, bot.phase, bot.rot.yaw, dt, bot.phys.vel.length());
+    }
+
+    return shots;
+  }
+
+  public recordHumanScore(team: 0 | 1): void {
+    if (team === 0) this.score.team0 += 1;
+    else this.score.team1 += 1;
+  }
+
+  public getScore(): { team0: number; team1: number } {
+    return { ...this.score };
+  }
+
+  public getHudRosters(player: LocalPlayer): { ownTeam: FullPlayerInfo[]; enemyTeam: EnemyPlayerInfo[] } {
+    const actors = [
+      {
+        id: LOCAL_PLAYER_ID,
+        name: this.config.humanName,
+        team: this.config.humanTeam,
+        isBot: false,
+        kills: player.kills,
+        deaths: player.deaths,
+        phase: player.phase,
+        frozen: player.damage.frozen,
+        ping: 0,
+      },
+      ...this.bots.map((bot) => ({
+        id: bot.id,
+        name: bot.name,
+        team: bot.team,
+        isBot: true,
+        kills: bot.kills,
+        deaths: bot.deaths,
+        phase: bot.phase,
+        frozen: bot.damage.frozen,
+        ping: 0,
+      })),
+    ];
+
+    return buildHudRosters(LOCAL_PLAYER_ID, this.config.humanTeam, actors);
+  }
+
+  public getProjectileTargets(player: LocalPlayer): ProjectileActorTarget[] {
+    return [
+      {
+        active: player.phase !== "RESPAWNING" && !player.damage.frozen,
+        id: LOCAL_PLAYER_ID,
+        pos: player.getPosition().clone(),
+        radius: PLAYER_RADIUS,
+        team: this.config.humanTeam,
+      },
+      ...this.bots.map((bot) => ({
+        active: bot.phase !== "RESPAWNING" && !bot.damage.frozen,
+        id: bot.id,
+        pos: bot.phys.pos.clone(),
+        radius: PLAYER_RADIUS,
+        team: bot.team,
+      })),
+    ];
+  }
+
+  public handleProjectileHit(
+    event: ProjectileHitEvent,
+    player: LocalPlayer,
+    camera: CameraController,
+  ): void {
+    const impulse = event.direction.clone().normalize().multiplyScalar(3);
+    if (event.targetId === LOCAL_PLAYER_ID) {
+      const zone = LocalPlayer.classifyHitZone(
+        event.impactPoint,
+        player.getPosition(),
+        camera.getForward(),
+      );
+      player.applyHit(zone, impulse);
+      return;
+    }
+
+    const bot = this.bots.find((candidate) => candidate.id === event.targetId);
+    if (!bot) return;
+
+    const zone = classifyHitZone(
+      toVec3(event.impactPoint),
+      toVec3(bot.phys.pos),
+      yawForward(bot.rot.yaw),
+    );
+    applyHitToBot(bot, zone, impulse);
+  }
+
+  private rebuildBots(): void {
+    this.dispose();
+
+    const fill = getSoloBotFill(this.config.teamSize, this.config.humanTeam);
+    const makeName = (index: number): string => {
+      const base = BOT_NAMES[index % BOT_NAMES.length];
+      const cycle = Math.floor(index / BOT_NAMES.length);
+      return cycle === 0 ? base : `${base}-${cycle + 1}`;
+    };
+
+    for (let i = 0; i < fill.team0Bots; i += 1) {
+      this.bots.push(createBotState(this.scene, `bot-cyan-${i}`, makeName(i), 0));
+    }
+
+    for (let i = 0; i < fill.team1Bots; i += 1) {
+      const idx = fill.team0Bots + i;
+      this.bots.push(createBotState(this.scene, `bot-magenta-${i}`, makeName(idx), 1));
+    }
+  }
+
+  private tickBot(
+    bot: BotState,
+    dt: number,
+    arena: Arena,
+    query: ArenaQueryAdapter,
+    bars: Vec3[],
+    actors: Array<{ id: string; phase: PlayerPhase; pos: Vec3; team: 0 | 1 }>,
+    shots: SpawnProjectileEvent[],
+  ): void {
+    if (bot.phase === "FROZEN") {
+      integrateFloating(bot, arena, dt);
+      return;
+    }
+
+    const command = bot.brain.tick(
+      {
+        currentBreachTeam: bot.currentBreachTeam,
+        damage: bot.damage,
+        phase: bot.phase,
+        pos: toVec3(bot.phys.pos),
+        rot: bot.rot,
+        team: bot.team,
+      },
+      query,
+      bars,
+      actors.filter((actor) => actor.id !== bot.id && actor.team !== bot.team),
+      dt,
+    );
+
+    bot.rot.yaw = command.lookYaw;
+    bot.rot.pitch = command.lookPitch;
+
+    if (command.fire && !bot.damage.rightArm) {
+      const forward = directionFromRotation(bot.rot.yaw, bot.rot.pitch);
+      shots.push({
+        direction: forward.clone(),
+        origin: bot.phys.pos.clone().addScaledVector(forward, PLAYER_RADIUS + 0.25),
+        ownerId: bot.id,
+        team: bot.team,
+      });
+    }
+
+    switch (bot.phase) {
+      case "BREACH":
+        this.updateBotBreach(bot, command, arena, query, dt);
+        break;
+      case "FLOATING":
+        this.updateBotFloating(bot, command, arena, query, dt);
+        break;
+      case "GRABBING":
+        if (!bot.grabbedBarPos) {
+          bot.phase = "FLOATING";
+          return;
+        }
+        bot.phys.vel.set(0, 0, 0);
+        bot.phys.pos.copy(bot.grabbedBarPos);
+        if (command.aimHeld) {
+          bot.phase = "AIMING";
+          bot.launchPower = 0;
+        }
+        break;
+      case "AIMING":
+        if (!bot.grabbedBarPos) {
+          bot.phase = "FLOATING";
+          return;
+        }
+        bot.phys.vel.set(0, 0, 0);
+        bot.phys.pos.copy(bot.grabbedBarPos);
+        bot.launchPower = Math.min(
+          maxLaunchPower(bot.damage),
+          bot.launchPower + (maxLaunchPower(bot.damage) * dt) / bot.brain.getLaunchChargeSeconds(),
+        );
+        if (!command.aimHeld) {
+          launchBot(bot);
+        }
+        break;
+      default:
+        break;
+    }
+
+    const enemyTeam = (1 - bot.team) as 0 | 1;
+    if (
+      bot.phase === "FLOATING"
+      && !bot.damage.frozen
+      && arena.isGoalDoorOpen(enemyTeam)
+      && arena.isDeepInBreachRoom(bot.phys.pos, enemyTeam, 1.0)
+    ) {
+      bot.currentBreachTeam = enemyTeam;
+      bot.phase = "BREACH";
+      bot.phys.vel.y = 0;
+      bot.kills += 1;
+      if (bot.team === 0) this.score.team0 += 1;
+      else this.score.team1 += 1;
+      this.onScore?.(bot.team, bot.name);
+    }
+  }
+
+  private updateBotBreach(
+    bot: BotState,
+    command: ReturnType<BotBrain["tick"]>,
+    arena: Arena,
+    query: ArenaQueryAdapter,
+    dt: number,
+  ): void {
+    const center = arena.getBreachRoomCenter(bot.currentBreachTeam);
+    const openAxis = arena.getBreachOpenAxis(bot.currentBreachTeam);
+    const openSign = arena.getBreachOpenSign(bot.currentBreachTeam);
+    const yawForwardVec = new THREE.Vector3(-Math.sin(bot.rot.yaw), 0, -Math.cos(bot.rot.yaw));
+    const yawRightVec = new THREE.Vector3(Math.cos(bot.rot.yaw), 0, -Math.sin(bot.rot.yaw));
+
+    integrateBreachRoom(
+      bot.phys,
+      command.walkAxes,
+      yawForwardVec,
+      yawRightVec,
+      false,
+      isOnBreachGround(bot, center.y),
+      dt,
+    );
+    clampBreachRoom(bot.phys, center, openAxis, openSign, arena.isGoalDoorOpen(bot.currentBreachTeam));
+
+    if (
+      command.grab
+      && !bot.damage.leftArm
+      && arena.isGoalDoorOpen(bot.currentBreachTeam)
+    ) {
+      const nearest = query.getNearestBar(toVec3(bot.phys.pos), GRAB_RADIUS);
+      if (nearest) {
+        bot.grabbedBarPos = toThree(nearest.pos);
+        bot.phase = "GRABBING";
+      }
+    }
+
+    if (!arena.isInBreachRoom(bot.phys.pos, bot.currentBreachTeam)) {
+      bot.phase = "FLOATING";
+    }
+  }
+
+  private updateBotFloating(
+    bot: BotState,
+    command: ReturnType<BotBrain["tick"]>,
+    arena: Arena,
+    query: ArenaQueryAdapter,
+    dt: number,
+  ): void {
+    integrateFloating(bot, arena, dt);
+
+    if (arena.isInBreachRoom(bot.phys.pos, bot.team)) {
+      bot.currentBreachTeam = bot.team;
+      bot.phase = "BREACH";
+      bot.phys.vel.y = 0;
+      return;
+    }
+
+    if (command.grab && !bot.damage.leftArm && command.targetBar) {
+      const nearest = query.getNearestBar(toVec3(bot.phys.pos), GRAB_RADIUS);
+      if (nearest) {
+        bot.grabbedBarPos = toThree(nearest.pos);
+        bot.phase = "GRABBING";
+      }
+    }
+  }
+}
+
+function createDamageState(): DamageState {
+  return {
+    frozen: false,
+    leftArm: false,
+    legs: false,
+    rightArm: false,
+  };
+}
+
+function createBotState(scene: THREE.Scene, id: string, name: string, team: 0 | 1): BotState {
+  const personality = createBotPersonality(id, team);
+  return {
+    avatar: new SimulatedPlayerAvatar(scene, team),
+    brain: new BotBrain(personality),
+    currentBreachTeam: team,
+    damage: createDamageState(),
+    deaths: 0,
+    grabbedBarPos: null,
+    id,
+    isBot: true,
+    kills: 0,
+    launchPower: 0,
+    name,
+    phase: "BREACH",
+    phys: { pos: new THREE.Vector3(), vel: new THREE.Vector3() },
+    rot: { yaw: 0, pitch: 0 },
+    team,
+  };
+}
+
+function exitRotation(query: ArenaQueryAdapter, team: 0 | 1): { yaw: number; pitch: number } {
+  const dir = directionToYawPitch(query.getBreachOpenAxis(team), query.getBreachOpenSign(team));
+  return { yaw: dir.yaw, pitch: 0 };
+}
+
+function directionToYawPitch(axis: "x" | "y" | "z", sign: 1 | -1): { yaw: number; pitch: number } {
+  const dir = axis === "x"
+    ? new THREE.Vector3(sign, 0, 0)
+    : axis === "y"
+      ? new THREE.Vector3(0, sign, 0)
+      : new THREE.Vector3(0, 0, sign);
+  return {
+    yaw: Math.atan2(-dir.x, -dir.z),
+    pitch: Math.asin(Math.max(-1, Math.min(1, dir.y))),
+  };
+}
+
+function integrateFloating(bot: BotState, arena: Arena, dt = 0): void {
+  const goalAxis = arena.getBreachOpenAxis(bot.team);
+  const perpAxis: "x" | "z" = goalAxis === "z" ? "x" : "z";
+  const team0FaceSign = (-arena.getBreachOpenSign(0)) as 1 | -1;
+  const team1FaceSign = (-arena.getBreachOpenSign(1)) as 1 | -1;
+  const portalFacesOpen = {
+    positive:
+      (team0FaceSign === 1 && arena.isGoalDoorOpen(0))
+      || (team1FaceSign === 1 && arena.isGoalDoorOpen(1)),
+    negative:
+      (team0FaceSign === -1 && arena.isGoalDoorOpen(0))
+      || (team1FaceSign === -1 && arena.isGoalDoorOpen(1)),
+  };
+
+  integrateZeroG(bot.phys, dt);
+  bounceArena(bot.phys, goalAxis, perpAxis, portalFacesOpen);
+  arena.bounceObstacles(bot.phys);
+}
+
+function isOnBreachGround(bot: BotState, centerY: number): boolean {
+  const floorY = centerY - 3 + PLAYER_RADIUS;
+  return bot.phys.pos.y <= floorY + 0.08;
+}
+
+function directionFromRotation(yaw: number, pitch: number): THREE.Vector3 {
+  const cy = Math.cos(yaw);
+  const sy = Math.sin(yaw);
+  const cp = Math.cos(pitch);
+  const sp = Math.sin(pitch);
+  return new THREE.Vector3(-sy * cp, sp, -cy * cp).normalize();
+}
+
+function launchBot(bot: BotState): void {
+  const forward = directionFromRotation(bot.rot.yaw, bot.rot.pitch);
+  bot.phys.pos.addScaledVector(forward, PLAYER_RADIUS + 0.8);
+  bot.phys.vel.copy(forward).multiplyScalar(bot.launchPower);
+  bot.grabbedBarPos = null;
+  bot.launchPower = 0;
+  bot.phase = "FLOATING";
+}
+
+function applyHitToBot(bot: BotState, zone: ReturnType<typeof classifyHitZone>, impulse: THREE.Vector3): void {
+  bot.phys.vel.add(impulse);
+
+  switch (zone) {
+    case "head":
+    case "body":
+      if (!bot.damage.frozen) {
+        bot.damage.frozen = true;
+        bot.deaths += 1;
+      }
+      bot.phase = "FROZEN";
+      bot.grabbedBarPos = null;
+      break;
+    case "rightArm":
+      bot.damage.rightArm = true;
+      break;
+    case "leftArm":
+      bot.damage.leftArm = true;
+      if (bot.phase === "GRABBING" || bot.phase === "AIMING") {
+        bot.phase = "FLOATING";
+        bot.grabbedBarPos = null;
+      }
+      break;
+    case "legs":
+      bot.damage.legs = true;
+      bot.launchPower = Math.min(bot.launchPower, maxLaunchPower(bot.damage));
+      break;
+  }
+}
+
+function toVec3(vec: THREE.Vector3): Vec3 {
+  return { x: vec.x, y: vec.y, z: vec.z };
+}
+
+function toThree(vec: Vec3): THREE.Vector3 {
+  return new THREE.Vector3(vec.x, vec.y, vec.z);
+}
+
+function yawForward(yaw: number): Vec3 {
+  return v3.normalize({ x: -Math.sin(yaw), y: 0, z: -Math.cos(yaw) });
+}

--- a/client/src/match/localMatch.ts
+++ b/client/src/match/localMatch.ts
@@ -1,7 +1,13 @@
 import * as THREE from "three";
 import { BOT_NAMES, GRAB_RADIUS, PLAYER_RADIUS } from "../../../shared/constants";
 import { getSoloBotFill, type SoloMatchConfig } from "../../../shared/match";
-import { classifyHitZone, maxLaunchPower, spawnPosition } from "../../../shared/player-logic";
+import {
+  classifyHitZone,
+  findFullFreezeWinner,
+  generateSpawnPositions,
+  maxLaunchPower,
+  resolveActorCollisions,
+} from "../../../shared/player-logic";
 import type { EnemyPlayerInfo, FullPlayerInfo, PlayerPhase, DamageState } from "../../../shared/schema";
 import type { Vec3 } from "../../../shared/vec3";
 import { v3 } from "../../../shared/vec3";
@@ -16,7 +22,12 @@ import {
 } from "../physics";
 import { LocalPlayer } from "../player";
 import { ArenaQueryAdapter } from "./arenaQueryAdapter";
-import { BotBrain, createBotPersonality } from "./botBrain";
+import {
+  buildBarGraph,
+  type BarRouteGraph,
+  BotBrain,
+  createBotPersonality,
+} from "./botBrain";
 import { buildHudRosters } from "./rosterView";
 import { SimulatedPlayerAvatar } from "./simulatedPlayerAvatar";
 
@@ -44,6 +55,32 @@ export interface SpawnProjectileEvent {
   team: 0 | 1;
 }
 
+export type LocalMatchEvent =
+  | {
+    type: "hitConfirm";
+    team: 0 | 1;
+  }
+  | {
+    type: "freeze";
+    killerName: string;
+    killerTeam: 0 | 1;
+    victimName: string;
+    victimTeam: 0 | 1;
+  }
+  | {
+    type: "score";
+    scorerName: string;
+    scorerTeam: 0 | 1;
+  }
+  | {
+    type: "roundTie";
+  }
+  | {
+    reason: "breach" | "fullFreeze";
+    type: "roundWin";
+    winningTeam: 0 | 1;
+  };
+
 interface BotState {
   avatar: SimulatedPlayerAvatar;
   brain: BotBrain;
@@ -62,35 +99,65 @@ interface BotState {
   team: 0 | 1;
 }
 
+interface ActorDescriptor {
+  damage: DamageState;
+  id: string;
+  name: string;
+  phase: PlayerPhase;
+  pos: THREE.Vector3;
+  team: 0 | 1;
+}
+
 export class LocalMatch {
+  private barGraph: BarRouteGraph = buildBarGraph([]);
   private bots: BotState[] = [];
   private config: SoloMatchConfig = { humanName: "You", humanTeam: 0, teamSize: 1 };
+  private roundResolved = false;
+  private roundSeed = 0;
   private score = { team0: 0, team1: 0 };
 
-  public onScore: ((team: 0 | 1, scorerName: string) => void) | null = null;
+  public onEvent: ((event: LocalMatchEvent) => void) | null = null;
 
   public constructor(private scene: THREE.Scene) {}
 
   public startNewGame(config: SoloMatchConfig): void {
     this.config = config;
     this.score = { team0: 0, team1: 0 };
+    this.roundResolved = false;
+    this.roundSeed = 0;
     this.rebuildBots();
   }
 
-  public resetForRound(arena: Arena): void {
+  public resetForRound(arena: Arena, player: LocalPlayer): void {
+    this.roundResolved = false;
+    this.roundSeed += 1;
+
     const query = new ArenaQueryAdapter(arena);
-    for (const bot of this.bots) {
-      const spawn = spawnPosition(bot.team, query);
-      bot.currentBreachTeam = bot.team;
-      bot.damage = createDamageState();
-      bot.grabbedBarPos = null;
-      bot.launchPower = 0;
-      bot.phase = "BREACH";
-      bot.phys.pos.set(spawn.x, spawn.y, spawn.z);
-      bot.phys.vel.set(0, 0, 0);
-      bot.rot = exitRotation(query, bot.team);
-      bot.avatar.update(bot.phys.pos, bot.phase, bot.rot.yaw, 0, 0);
+    this.barGraph = buildBarGraph(query.getAllBarGrabPoints());
+
+    const team0Slots = generateSpawnPositions(
+      0,
+      this.getTeamActorCount(0),
+      query,
+      this.roundSeed * 11 + 7,
+    );
+    const team1Slots = generateSpawnPositions(
+      1,
+      this.getTeamActorCount(1),
+      query,
+      this.roundSeed * 17 + 13,
+    );
+
+    if (this.config.humanTeam === 0) {
+      player.resetForNewRound(arena, team0Slots.shift());
+    } else {
+      player.resetForNewRound(arena, team1Slots.shift());
     }
+
+    const team0Bots = this.bots.filter((bot) => bot.team === 0);
+    const team1Bots = this.bots.filter((bot) => bot.team === 1);
+    resetBotsForRound(team0Bots, team0Slots, this.roundSeed, query);
+    resetBotsForRound(team1Bots, team1Slots, this.roundSeed, query);
   }
 
   public dispose(): void {
@@ -98,45 +165,6 @@ export class LocalMatch {
       bot.avatar.dispose(this.scene);
     }
     this.bots = [];
-  }
-
-  public tick(
-    dt: number,
-    arena: Arena,
-    player: LocalPlayer,
-    isRoundPlaying: boolean,
-  ): SpawnProjectileEvent[] {
-    const shots: SpawnProjectileEvent[] = [];
-    const query = new ArenaQueryAdapter(arena);
-    const bars = query.getAllBarGrabPoints();
-    const actors = [
-      {
-        id: LOCAL_PLAYER_ID,
-        phase: player.phase,
-        pos: toVec3(player.getPosition()),
-        team: this.config.humanTeam,
-      },
-      ...this.bots.map((bot) => ({
-        id: bot.id,
-        phase: bot.phase,
-        pos: toVec3(bot.phys.pos),
-        team: bot.team,
-      })),
-    ];
-
-    for (const bot of this.bots) {
-      if (isRoundPlaying) {
-        this.tickBot(bot, dt, arena, query, bars, actors, shots);
-      }
-      bot.avatar.update(bot.phys.pos, bot.phase, bot.rot.yaw, dt, bot.phys.vel.length());
-    }
-
-    return shots;
-  }
-
-  public recordHumanScore(team: 0 | 1): void {
-    if (team === 0) this.score.team0 += 1;
-    else this.score.team1 += 1;
   }
 
   public getScore(): { team0: number; team1: number } {
@@ -196,14 +224,30 @@ export class LocalMatch {
     player: LocalPlayer,
     camera: CameraController,
   ): void {
+    if (this.roundResolved) return;
+
+    const owner = this.getActorMeta(event.ownerId, player);
     const impulse = event.direction.clone().normalize().multiplyScalar(3);
+
     if (event.targetId === LOCAL_PLAYER_ID) {
       const zone = LocalPlayer.classifyHitZone(
         event.impactPoint,
         player.getPosition(),
         camera.getForward(),
       );
-      player.applyHit(zone, impulse);
+      const frozen = player.applyHit(zone, impulse);
+      if (frozen) {
+        if (owner) {
+          this.emitEvent({
+            type: "freeze",
+            killerName: owner.name,
+            killerTeam: owner.team,
+            victimName: this.config.humanName,
+            victimTeam: this.config.humanTeam,
+          });
+        }
+        this.checkFullFreezeWin(player);
+      }
       return;
     }
 
@@ -215,7 +259,201 @@ export class LocalMatch {
       toVec3(bot.phys.pos),
       yawForward(bot.rot.yaw),
     );
-    applyHitToBot(bot, zone, impulse);
+    const frozen = applyHitToBot(bot, zone, impulse);
+    if (event.ownerId === LOCAL_PLAYER_ID) {
+      this.emitEvent({
+        type: "hitConfirm",
+        team: this.config.humanTeam,
+      });
+    }
+    if (frozen) {
+      if (owner) {
+        this.emitEvent({
+          type: "freeze",
+          killerName: owner.name,
+          killerTeam: owner.team,
+          victimName: bot.name,
+          victimTeam: bot.team,
+        });
+      }
+      this.checkFullFreezeWin(player);
+    }
+  }
+
+  public handleRoundTimeout(): void {
+    if (this.roundResolved) return;
+    this.roundResolved = true;
+    this.emitEvent({ type: "roundTie" });
+  }
+
+  public tick(
+    dt: number,
+    arena: Arena,
+    player: LocalPlayer,
+    isRoundPlaying: boolean,
+  ): SpawnProjectileEvent[] {
+    const shots: SpawnProjectileEvent[] = [];
+
+    if (isRoundPlaying && !this.roundResolved) {
+      const query = new ArenaQueryAdapter(arena);
+      const enemySnapshots = this.buildEnemySnapshots(player);
+      for (const bot of this.bots) {
+        this.tickBot(
+          bot,
+          dt,
+          arena,
+          query,
+          enemySnapshots[bot.team],
+          shots,
+        );
+      }
+
+      this.resolveActorOverlap(player);
+      this.checkForBreachScore(arena, player);
+      this.checkFullFreezeWin(player);
+    }
+
+    for (const bot of this.bots) {
+      bot.avatar.update(bot.phys.pos, bot.damage, bot.phase, bot.rot.yaw, dt, bot.phys.vel.length());
+    }
+
+    return shots;
+  }
+
+  private buildEnemySnapshots(player: LocalPlayer): Record<0 | 1, Array<{ id: string; phase: PlayerPhase; pos: Vec3; team: 0 | 1 }>> {
+    const actors = [
+      {
+        id: LOCAL_PLAYER_ID,
+        phase: player.phase,
+        pos: toVec3(player.getPosition()),
+        team: this.config.humanTeam,
+      },
+      ...this.bots.map((bot) => ({
+        id: bot.id,
+        phase: bot.phase,
+        pos: toVec3(bot.phys.pos),
+        team: bot.team,
+      })),
+    ];
+
+    return {
+      0: actors.filter((actor) => actor.team === 1),
+      1: actors.filter((actor) => actor.team === 0),
+    };
+  }
+
+  private checkForBreachScore(arena: Arena, player: LocalPlayer): void {
+    if (this.roundResolved) return;
+
+    const actors = this.getActorsForScore(player);
+    for (const actor of actors) {
+      if (actor.phase !== "FLOATING" || actor.damage.frozen) continue;
+
+      const enemyTeam = (1 - actor.team) as 0 | 1;
+      if (!arena.isGoalDoorOpen(enemyTeam)) continue;
+      if (!arena.isDeepInBreachRoom(actor.pos, enemyTeam, 1.0)) continue;
+
+      if (actor.id === LOCAL_PLAYER_ID) {
+        player.currentBreachTeam = enemyTeam;
+        player.phase = "BREACH";
+        player.phys.vel.y = 0;
+        player.kills += 1;
+      } else {
+        const bot = this.getBot(actor.id);
+        if (!bot) continue;
+        bot.currentBreachTeam = enemyTeam;
+        bot.phase = "BREACH";
+        bot.phys.vel.y = 0;
+        bot.kills += 1;
+      }
+
+      this.awardRoundPoint(actor.team, actor.name, "breach");
+      return;
+    }
+  }
+
+  private checkFullFreezeWin(player: LocalPlayer): void {
+    if (this.roundResolved) return;
+
+    const winner = findFullFreezeWinner([
+      { team: this.config.humanTeam, frozen: player.damage.frozen },
+      ...this.bots.map((bot) => ({ team: bot.team, frozen: bot.damage.frozen })),
+    ]);
+
+    if (winner === null) return;
+    this.roundResolved = true;
+    if (winner === 0) this.score.team0 += 1;
+    else this.score.team1 += 1;
+    this.emitEvent({ type: "roundWin", winningTeam: winner, reason: "fullFreeze" });
+  }
+
+  private awardRoundPoint(team: 0 | 1, scorerName: string, reason: "breach" | "fullFreeze"): void {
+    if (this.roundResolved) return;
+    this.roundResolved = true;
+    if (team === 0) this.score.team0 += 1;
+    else this.score.team1 += 1;
+
+    this.emitEvent({
+      type: "score",
+      scorerName,
+      scorerTeam: team,
+    });
+    this.emitEvent({
+      type: "roundWin",
+      winningTeam: team,
+      reason,
+    });
+  }
+
+  private emitEvent(event: LocalMatchEvent): void {
+    this.onEvent?.(event);
+  }
+
+  private getActorMeta(id: string, player: LocalPlayer): { name: string; team: 0 | 1 } | null {
+    if (id === LOCAL_PLAYER_ID) {
+      return {
+        name: this.config.humanName,
+        team: this.config.humanTeam,
+      };
+    }
+
+    const bot = this.getBot(id);
+    if (!bot) return null;
+    return {
+      name: bot.name,
+      team: bot.team,
+    };
+  }
+
+  private getActorsForScore(player: LocalPlayer): ActorDescriptor[] {
+    return [
+      {
+        id: LOCAL_PLAYER_ID,
+        name: this.config.humanName,
+        team: this.config.humanTeam,
+        damage: player.damage,
+        phase: player.phase,
+        pos: player.getPosition(),
+      },
+      ...this.bots.map((bot) => ({
+        id: bot.id,
+        name: bot.name,
+        team: bot.team,
+        damage: bot.damage,
+        phase: bot.phase,
+        pos: bot.phys.pos,
+      })),
+    ];
+  }
+
+  private getBot(id: string): BotState | undefined {
+    return this.bots.find((candidate) => candidate.id === id);
+  }
+
+  private getTeamActorCount(team: 0 | 1): number {
+    const humanCount = this.config.humanTeam === team ? 1 : 0;
+    const botCount = this.bots.filter((bot) => bot.team === team).length;
+    return humanCount + botCount;
   }
 
   private rebuildBots(): void {
@@ -238,13 +476,29 @@ export class LocalMatch {
     }
   }
 
+  private resolveActorOverlap(player: LocalPlayer): void {
+    resolveActorCollisions([
+      {
+        active: player.phase !== "RESPAWNING",
+        anchored: isAnchored(player.phase),
+        pos: player.getPosition(),
+        radius: PLAYER_RADIUS,
+      },
+      ...this.bots.map((bot) => ({
+        active: bot.phase !== "RESPAWNING",
+        anchored: isAnchored(bot.phase),
+        pos: bot.phys.pos,
+        radius: PLAYER_RADIUS,
+      })),
+    ]);
+  }
+
   private tickBot(
     bot: BotState,
     dt: number,
     arena: Arena,
     query: ArenaQueryAdapter,
-    bars: Vec3[],
-    actors: Array<{ id: string; phase: PlayerPhase; pos: Vec3; team: 0 | 1 }>,
+    enemies: Array<{ id: string; phase: PlayerPhase; pos: Vec3; team: 0 | 1 }>,
     shots: SpawnProjectileEvent[],
   ): void {
     if (bot.phase === "FROZEN") {
@@ -262,16 +516,16 @@ export class LocalMatch {
         team: bot.team,
       },
       query,
-      bars,
-      actors.filter((actor) => actor.id !== bot.id && actor.team !== bot.team),
+      this.barGraph,
+      enemies,
       dt,
     );
 
     bot.rot.yaw = command.lookYaw;
     bot.rot.pitch = command.lookPitch;
 
-    if (command.fire && !bot.damage.rightArm) {
-      const forward = directionFromRotation(bot.rot.yaw, bot.rot.pitch);
+    if (command.fire && !bot.damage.rightArm && command.fireDirection) {
+      const forward = toThree(command.fireDirection).normalize();
       shots.push({
         direction: forward.clone(),
         origin: bot.phys.pos.clone().addScaledVector(forward, PLAYER_RADIUS + 0.25),
@@ -317,22 +571,6 @@ export class LocalMatch {
       default:
         break;
     }
-
-    const enemyTeam = (1 - bot.team) as 0 | 1;
-    if (
-      bot.phase === "FLOATING"
-      && !bot.damage.frozen
-      && arena.isGoalDoorOpen(enemyTeam)
-      && arena.isDeepInBreachRoom(bot.phys.pos, enemyTeam, 1.0)
-    ) {
-      bot.currentBreachTeam = enemyTeam;
-      bot.phase = "BREACH";
-      bot.phys.vel.y = 0;
-      bot.kills += 1;
-      if (bot.team === 0) this.score.team0 += 1;
-      else this.score.team1 += 1;
-      this.onScore?.(bot.team, bot.name);
-    }
   }
 
   private updateBotBreach(
@@ -359,11 +597,7 @@ export class LocalMatch {
     );
     clampBreachRoom(bot.phys, center, openAxis, openSign, arena.isGoalDoorOpen(bot.currentBreachTeam));
 
-    if (
-      command.grab
-      && !bot.damage.leftArm
-      && arena.isGoalDoorOpen(bot.currentBreachTeam)
-    ) {
+    if (command.grab && !bot.damage.leftArm && arena.isGoalDoorOpen(bot.currentBreachTeam)) {
       const nearest = query.getNearestBar(toVec3(bot.phys.pos), GRAB_RADIUS);
       if (nearest) {
         bot.grabbedBarPos = toThree(nearest.pos);
@@ -432,21 +666,38 @@ function createBotState(scene: THREE.Scene, id: string, name: string, team: 0 | 
   };
 }
 
-function exitRotation(query: ArenaQueryAdapter, team: 0 | 1): { yaw: number; pitch: number } {
-  const dir = directionToYawPitch(query.getBreachOpenAxis(team), query.getBreachOpenSign(team));
-  return { yaw: dir.yaw, pitch: 0 };
-}
+function applyHitToBot(
+  bot: BotState,
+  zone: ReturnType<typeof classifyHitZone>,
+  impulse: THREE.Vector3,
+): boolean {
+  bot.phys.vel.add(impulse);
 
-function directionToYawPitch(axis: "x" | "y" | "z", sign: 1 | -1): { yaw: number; pitch: number } {
-  const dir = axis === "x"
-    ? new THREE.Vector3(sign, 0, 0)
-    : axis === "y"
-      ? new THREE.Vector3(0, sign, 0)
-      : new THREE.Vector3(0, 0, sign);
-  return {
-    yaw: Math.atan2(-dir.x, -dir.z),
-    pitch: Math.asin(Math.max(-1, Math.min(1, dir.y))),
-  };
+  switch (zone) {
+    case "head":
+    case "body":
+      if (!bot.damage.frozen) {
+        bot.damage.frozen = true;
+        bot.deaths += 1;
+      }
+      bot.phase = "FROZEN";
+      bot.grabbedBarPos = null;
+      return true;
+    case "rightArm":
+      bot.damage.rightArm = true;
+      return false;
+    case "leftArm":
+      bot.damage.leftArm = true;
+      if (bot.phase === "GRABBING" || bot.phase === "AIMING") {
+        bot.phase = "FLOATING";
+        bot.grabbedBarPos = null;
+      }
+      return false;
+    case "legs":
+      bot.damage.legs = true;
+      bot.launchPower = Math.min(bot.launchPower, maxLaunchPower(bot.damage));
+      return false;
+  }
 }
 
 function integrateFloating(bot: BotState, arena: Arena, dt = 0): void {
@@ -468,17 +719,13 @@ function integrateFloating(bot: BotState, arena: Arena, dt = 0): void {
   arena.bounceObstacles(bot.phys);
 }
 
+function isAnchored(phase: PlayerPhase): boolean {
+  return phase === "GRABBING" || phase === "AIMING";
+}
+
 function isOnBreachGround(bot: BotState, centerY: number): boolean {
   const floorY = centerY - 3 + PLAYER_RADIUS;
   return bot.phys.pos.y <= floorY + 0.08;
-}
-
-function directionFromRotation(yaw: number, pitch: number): THREE.Vector3 {
-  const cy = Math.cos(yaw);
-  const sy = Math.sin(yaw);
-  const cp = Math.cos(pitch);
-  const sp = Math.sin(pitch);
-  return new THREE.Vector3(-sy * cp, sp, -cy * cp).normalize();
 }
 
 function launchBot(bot: BotState): void {
@@ -490,34 +737,48 @@ function launchBot(bot: BotState): void {
   bot.phase = "FLOATING";
 }
 
-function applyHitToBot(bot: BotState, zone: ReturnType<typeof classifyHitZone>, impulse: THREE.Vector3): void {
-  bot.phys.vel.add(impulse);
+function directionFromRotation(yaw: number, pitch: number): THREE.Vector3 {
+  const cy = Math.cos(yaw);
+  const sy = Math.sin(yaw);
+  const cp = Math.cos(pitch);
+  const sp = Math.sin(pitch);
+  return new THREE.Vector3(-sy * cp, sp, -cy * cp).normalize();
+}
 
-  switch (zone) {
-    case "head":
-    case "body":
-      if (!bot.damage.frozen) {
-        bot.damage.frozen = true;
-        bot.deaths += 1;
-      }
-      bot.phase = "FROZEN";
-      bot.grabbedBarPos = null;
-      break;
-    case "rightArm":
-      bot.damage.rightArm = true;
-      break;
-    case "leftArm":
-      bot.damage.leftArm = true;
-      if (bot.phase === "GRABBING" || bot.phase === "AIMING") {
-        bot.phase = "FLOATING";
-        bot.grabbedBarPos = null;
-      }
-      break;
-    case "legs":
-      bot.damage.legs = true;
-      bot.launchPower = Math.min(bot.launchPower, maxLaunchPower(bot.damage));
-      break;
+function resetBotsForRound(
+  bots: BotState[],
+  spawnSlots: Vec3[],
+  roundSeed: number,
+  query: ArenaQueryAdapter,
+): void {
+  for (let i = 0; i < bots.length; i += 1) {
+    const bot = bots[i];
+    const spawn = spawnSlots[i] ?? spawnSlots[spawnSlots.length - 1] ?? { x: 0, y: 0, z: 0 };
+    bot.currentBreachTeam = bot.team;
+    bot.damage = createDamageState();
+    bot.grabbedBarPos = null;
+    bot.launchPower = 0;
+    bot.phase = "BREACH";
+    bot.phys.pos.set(spawn.x, spawn.y, spawn.z);
+    bot.phys.vel.set(0, 0, 0);
+    bot.rot = exitRotation(query, bot.team);
+    bot.brain.resetForRound(roundSeed * 37 + i * 13 + bot.team);
+    bot.avatar.update(bot.phys.pos, bot.damage, bot.phase, bot.rot.yaw, 0, 0);
   }
+}
+
+function exitRotation(query: ArenaQueryAdapter, team: 0 | 1): { yaw: number; pitch: number } {
+  const axis = query.getBreachOpenAxis(team);
+  const sign = query.getBreachOpenSign(team);
+  const dir = axis === "x"
+    ? new THREE.Vector3(sign, 0, 0)
+    : axis === "y"
+      ? new THREE.Vector3(0, sign, 0)
+      : new THREE.Vector3(0, 0, sign);
+  return {
+    yaw: Math.atan2(-dir.x, -dir.z),
+    pitch: Math.asin(Math.max(-1, Math.min(1, dir.y))),
+  };
 }
 
 function toVec3(vec: THREE.Vector3): Vec3 {

--- a/client/src/match/rosterView.ts
+++ b/client/src/match/rosterView.ts
@@ -1,0 +1,56 @@
+import type { EnemyPlayerInfo, FullPlayerInfo, PlayerPhase } from "../../../shared/schema";
+
+export interface RosterActor {
+  id: string;
+  name: string;
+  team: 0 | 1;
+  isBot: boolean;
+  kills: number;
+  deaths: number;
+  phase: PlayerPhase;
+  frozen: boolean;
+  ping?: number;
+}
+
+export interface HudRosters {
+  ownTeam: FullPlayerInfo[];
+  enemyTeam: EnemyPlayerInfo[];
+}
+
+export function buildHudRosters(
+  localActorId: string,
+  localTeam: 0 | 1,
+  actors: RosterActor[],
+): HudRosters {
+  const sorted = [...actors].sort((a, b) => {
+    if (a.id === localActorId) return -1;
+    if (b.id === localActorId) return 1;
+    if (a.team !== b.team) return a.team - b.team;
+    return a.name.localeCompare(b.name);
+  });
+
+  const ownTeam = sorted
+    .filter((actor) => actor.team === localTeam)
+    .map<FullPlayerInfo>((actor) => ({
+      id: actor.id,
+      name: actor.name,
+      frozen: actor.frozen || actor.phase === "FROZEN",
+      kills: actor.kills,
+      deaths: actor.deaths,
+      ping: actor.ping ?? 0,
+      isBot: actor.isBot,
+    }));
+
+  const enemyTeam = sorted
+    .filter((actor) => actor.team !== localTeam)
+    .map<EnemyPlayerInfo>((actor) => ({
+      id: actor.id,
+      name: actor.name,
+      kills: actor.kills,
+      deaths: actor.deaths,
+      ping: actor.ping ?? 0,
+      isBot: actor.isBot,
+    }));
+
+  return { ownTeam, enemyTeam };
+}

--- a/client/src/match/simulatedPlayerAvatar.ts
+++ b/client/src/match/simulatedPlayerAvatar.ts
@@ -9,16 +9,21 @@ import {
   ANIM_STANDING,
   PlayerAnimationController,
 } from "../player/playerAnimationController";
+import { PlayerDamageGlow } from "../player/playerDamageGlow";
 import { applyBarHoldPose } from "../player/playerGrabPose";
+import { ThirdPersonGun } from "../player/playerThirdPersonGun";
 
 export class SimulatedPlayerAvatar {
   private readonly animation = new PlayerAnimationController();
+  private readonly damageGlow: PlayerDamageGlow;
   private disposed = false;
+  private readonly gun = new ThirdPersonGun();
   private readonly materials = new Set<THREE.MeshStandardMaterial>();
   private ready = false;
   private readonly root = new THREE.Group();
 
   public constructor(scene: THREE.Scene, team: 0 | 1) {
+    this.damageGlow = new PlayerDamageGlow(team);
     scene.add(this.root);
 
     void loadAlienRenderClone({ team, variant: "bot" })
@@ -29,6 +34,9 @@ export class SimulatedPlayerAvatar {
         this.root.add(helmet);
         this.animation.registerRig(body, bodyAnimations);
         this.animation.registerRig(helmet, helmetAnimations);
+        this.damageGlow.attachTo(body);
+        this.gun.attachTo(body);
+        this.gun.setVisible(true);
         this.collectMaterials();
         this.ready = true;
       })
@@ -39,6 +47,7 @@ export class SimulatedPlayerAvatar {
 
   public update(
     pos: THREE.Vector3,
+    damage: { frozen: boolean; leftArm: boolean; rightArm: boolean; legs: boolean },
     phase: PlayerPhase,
     yaw: number,
     dt: number,
@@ -47,6 +56,8 @@ export class SimulatedPlayerAvatar {
     this.root.position.copy(pos);
     this.root.rotation.set(0, yaw, 0);
     this.root.visible = phase !== "RESPAWNING";
+    this.gun.setVisible(phase !== "RESPAWNING");
+    this.damageGlow.update(damage, phase, dt);
 
     if (!this.ready) return;
 
@@ -68,6 +79,8 @@ export class SimulatedPlayerAvatar {
 
   public dispose(scene: THREE.Scene): void {
     this.disposed = true;
+    this.damageGlow.dispose();
+    this.gun.dispose();
     scene.remove(this.root);
     for (const material of this.materials) {
       material.dispose();

--- a/client/src/match/simulatedPlayerAvatar.ts
+++ b/client/src/match/simulatedPlayerAvatar.ts
@@ -1,0 +1,116 @@
+import * as THREE from "three";
+import type { PlayerPhase } from "../../../shared/schema";
+import { loadAlienRenderClone } from "../player/alienRenderAsset";
+import {
+  ANIM_DEATH,
+  ANIM_FLOAT,
+  ANIM_IDLE_HOLD,
+  ANIM_RUN_HOLD,
+  ANIM_STANDING,
+  PlayerAnimationController,
+} from "../player/playerAnimationController";
+import { applyBarHoldPose } from "../player/playerGrabPose";
+
+export class SimulatedPlayerAvatar {
+  private readonly animation = new PlayerAnimationController();
+  private disposed = false;
+  private readonly materials = new Set<THREE.MeshStandardMaterial>();
+  private ready = false;
+  private readonly root = new THREE.Group();
+
+  public constructor(scene: THREE.Scene, team: 0 | 1) {
+    scene.add(this.root);
+
+    void loadAlienRenderClone({ team, variant: "bot" })
+      .then(({ body, bodyAnimations, helmet, helmetAnimations }) => {
+        if (this.disposed) return;
+
+        this.root.add(body);
+        this.root.add(helmet);
+        this.animation.registerRig(body, bodyAnimations);
+        this.animation.registerRig(helmet, helmetAnimations);
+        this.collectMaterials();
+        this.ready = true;
+      })
+      .catch((err: unknown) => {
+        console.error("[SimulatedPlayerAvatar] failed to load alien render assets", err);
+      });
+  }
+
+  public update(
+    pos: THREE.Vector3,
+    phase: PlayerPhase,
+    yaw: number,
+    dt: number,
+    moveSpeed: number,
+  ): void {
+    this.root.position.copy(pos);
+    this.root.rotation.set(0, yaw, 0);
+    this.root.visible = phase !== "RESPAWNING";
+
+    if (!this.ready) return;
+
+    const animation = selectAnimation(phase, moveSpeed);
+    this.animation.setTargetAnimation(animation);
+    this.animation.tickMixers(dt);
+
+    if (phase === "GRABBING" || phase === "AIMING") {
+      applyBarHoldPose(this.animation.getRigs());
+      this.animation.resetBreathing();
+    } else if (animation === ANIM_IDLE_HOLD) {
+      this.animation.tickBreathing(dt);
+    } else {
+      this.animation.resetBreathing();
+    }
+
+    this.applyPhaseVisuals(phase);
+  }
+
+  public dispose(scene: THREE.Scene): void {
+    this.disposed = true;
+    scene.remove(this.root);
+    for (const material of this.materials) {
+      material.dispose();
+    }
+    this.materials.clear();
+  }
+
+  private collectMaterials(): void {
+    this.root.traverse((obj) => {
+      if (!(obj instanceof THREE.Mesh)) return;
+      const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
+      for (const material of materials) {
+        if (material instanceof THREE.MeshStandardMaterial) {
+          this.materials.add(material);
+        }
+      }
+    });
+  }
+
+  private applyPhaseVisuals(phase: PlayerPhase): void {
+    for (const material of this.materials) {
+      if (phase === "FROZEN") {
+        material.transparent = true;
+        material.opacity = material.name === "Glass" ? 0.12 : 0.35;
+        material.emissiveIntensity = Math.min(material.emissiveIntensity, 0.08);
+      } else if (material.name === "Glass") {
+        material.transparent = true;
+        material.opacity = 0.22;
+        material.emissiveIntensity = 0;
+      } else {
+        material.transparent = false;
+        material.opacity = 1;
+        material.emissiveIntensity = Math.max(material.emissiveIntensity, 0.42);
+      }
+      material.needsUpdate = true;
+    }
+  }
+}
+
+function selectAnimation(phase: PlayerPhase, moveSpeed: number): string {
+  if (phase === "FROZEN") return ANIM_DEATH;
+  if (phase === "FLOATING") return ANIM_FLOAT;
+  if (phase === "GRABBING" || phase === "AIMING") return ANIM_STANDING;
+  if (phase === "BREACH" && moveSpeed > 0.25) return ANIM_RUN_HOLD;
+  return ANIM_IDLE_HOLD;
+}

--- a/client/src/player/alienRenderAsset.ts
+++ b/client/src/player/alienRenderAsset.ts
@@ -1,0 +1,142 @@
+import * as THREE from "three";
+import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
+import { clone as cloneSkinnedScene } from "three/addons/utils/SkeletonUtils.js";
+import { PLAYER_RADIUS } from "../../../shared/constants";
+
+interface AlienRenderPrototype {
+  body: THREE.Group;
+  bodyAnimations: THREE.AnimationClip[];
+  helmet: THREE.Group;
+  helmetAnimations: THREE.AnimationClip[];
+}
+
+export interface AlienRenderCloneOptions {
+  team: 0 | 1;
+  variant?: "player" | "bot";
+}
+
+export interface AlienRenderClone {
+  body: THREE.Group;
+  bodyAnimations: THREE.AnimationClip[];
+  helmet: THREE.Group;
+  helmetAnimations: THREE.AnimationClip[];
+}
+
+const ALIEN_SCALE = 0.2;
+const ALIEN_OFFSET_Y = -PLAYER_RADIUS * 0.8;
+const ALIEN_OFFSET_Z = 0.3;
+const ALIEN_ROTATION_Y = Math.PI;
+
+let prototypePromise: Promise<AlienRenderPrototype> | null = null;
+
+export function loadAlienRenderClone(options: AlienRenderCloneOptions): Promise<AlienRenderClone> {
+  return loadAlienRenderPrototype().then((prototype) => {
+    const body = cloneRig(prototype.body);
+    const helmet = cloneRig(prototype.helmet);
+
+    applyTeamAccent(body, options.team, options.variant ?? "bot");
+    applyTeamAccent(helmet, options.team, options.variant ?? "bot");
+
+    return {
+      body,
+      bodyAnimations: prototype.bodyAnimations,
+      helmet,
+      helmetAnimations: prototype.helmetAnimations,
+    };
+  });
+}
+
+async function loadAlienRenderPrototype(): Promise<AlienRenderPrototype> {
+  if (!prototypePromise) {
+    prototypePromise = (async () => {
+      const loader = new GLTFLoader();
+      const [bodyGltf, helmetGltf] = await Promise.all([
+        loader.loadAsync("/models/Alien.glb"),
+        loader.loadAsync("/models/Alien_Helmet.glb"),
+      ]);
+
+      const body = bodyGltf.scene;
+      applyAlienTransform(body);
+
+      const helmet = helmetGltf.scene;
+      applyAlienTransform(helmet);
+      configureHelmetGlass(helmet);
+
+      return {
+        body,
+        bodyAnimations: bodyGltf.animations,
+        helmet,
+        helmetAnimations: helmetGltf.animations,
+      };
+    })();
+  }
+
+  return prototypePromise;
+}
+
+function applyAlienTransform(root: THREE.Group): void {
+  root.scale.setScalar(ALIEN_SCALE);
+  root.position.y = ALIEN_OFFSET_Y;
+  root.position.z = ALIEN_OFFSET_Z;
+  root.rotation.y = ALIEN_ROTATION_Y;
+}
+
+function configureHelmetGlass(root: THREE.Group): void {
+  root.traverse((obj) => {
+    if (!(obj instanceof THREE.Mesh)) return;
+    const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
+    for (const material of materials) {
+      if (!(material instanceof THREE.MeshStandardMaterial)) continue;
+      if (material.name !== "Glass") continue;
+      material.transparent = true;
+      material.opacity = 0.22;
+      material.depthWrite = false;
+      material.roughness = 0.12;
+      material.metalness = 0.0;
+    }
+  });
+}
+
+function cloneRig(root: THREE.Group): THREE.Group {
+  const clone = cloneSkinnedScene(root) as THREE.Group;
+
+  clone.traverse((obj) => {
+    if (!(obj instanceof THREE.Mesh)) return;
+    if (Array.isArray(obj.material)) {
+      obj.material = obj.material.map((material) => material.clone());
+      return;
+    }
+    obj.material = obj.material.clone();
+  });
+
+  return clone;
+}
+
+function applyTeamAccent(
+  root: THREE.Group,
+  team: 0 | 1,
+  variant: "player" | "bot",
+): void {
+  const accent = team === 0 ? new THREE.Color("#59d9ff") : new THREE.Color("#ff4fd8");
+  const colorMix = variant === "player"
+    ? team === 0 ? 0.06 : 0.14
+    : team === 0 ? 0.1 : 0.24;
+  const emissiveMix = variant === "player"
+    ? team === 0 ? 0.24 : 0.4
+    : team === 0 ? 0.34 : 0.58;
+
+  root.traverse((obj) => {
+    if (!(obj instanceof THREE.Mesh)) return;
+    const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
+
+    for (const material of materials) {
+      if (!(material instanceof THREE.MeshStandardMaterial)) continue;
+      if (material.name === "Glass") continue;
+
+      material.color = material.color.clone().lerp(accent, colorMix);
+      material.emissive = material.emissive.clone().lerp(accent, emissiveMix);
+      material.emissiveIntensity = Math.max(material.emissiveIntensity, team === 0 ? 0.42 : 0.65);
+      material.needsUpdate = true;
+    }
+  });
+}

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import {
   MAX_LAUNCH_SPEED,
   LEGS_HIT_LAUNCH_FACTOR,
@@ -38,6 +37,7 @@ import {
   applyBarHoldPose,
   measureLeftHandGripOffset,
 } from './playerGrabPose';
+import { loadAlienRenderClone } from './alienRenderAsset';
 import {
   applyFloatArmTilt,
   applyArmRecoil,
@@ -103,60 +103,21 @@ export class LocalPlayer {
 
   public constructor(scene: THREE.Scene) {
     this.mesh = new THREE.Group();
-
-    const loader = new GLTFLoader();
-
-    loader.load(
-      '/models/Alien.glb',
-      (gltf) => {
-        const alien = gltf.scene;
-        alien.scale.setScalar(0.2);
-        alien.position.y = -PLAYER_RADIUS * 0.8;
-        alien.position.z = 0.3;
-        alien.rotation.y = Math.PI;
-
-        const gripLocal = measureLeftHandGripOffset(alien);
+    void loadAlienRenderClone({ team: this.team, variant: 'player' })
+      .then(({ body, bodyAnimations, helmet, helmetAnimations }) => {
+        const gripLocal = measureLeftHandGripOffset(body);
         if (gripLocal) this.leftHandGripLocal.copy(gripLocal);
 
-        this.animation.registerRig(alien, gltf.animations);
-        this.gun.attachTo(alien);
-        this.mesh.add(alien);
-      },
-      undefined,
-      (err) => console.error('[LocalPlayer] failed to load Alien.glb', err),
-    );
+        this.animation.registerRig(body, bodyAnimations);
+        this.gun.attachTo(body);
+        this.mesh.add(body);
 
-    loader.load(
-      '/models/Alien_Helmet.glb',
-      (gltf) => {
-        const helmet = gltf.scene;
-        helmet.scale.setScalar(0.2);
-        helmet.position.y = -PLAYER_RADIUS * 0.8;
-        helmet.position.z = 0.3;
-        helmet.rotation.y = Math.PI;
-
-        // The helmet ships with an opaque "Glass" material. Make only that
-        // material translucent so the dome reads like a visor rather than a
-        // solid black sphere over the player's head.
-        helmet.traverse((obj) => {
-          if (!(obj instanceof THREE.Mesh)) return;
-          const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
-          for (const material of materials) {
-            if (material.name !== 'Glass') continue;
-            material.transparent = true;
-            material.opacity = 0.22;
-            material.depthWrite = false;
-            material.roughness = 0.12;
-            material.metalness = 0.0;
-          }
-        });
-
-        this.animation.registerRig(helmet, gltf.animations);
+        this.animation.registerRig(helmet, helmetAnimations);
         this.mesh.add(helmet);
-      },
-      undefined,
-      (err) => console.error('[LocalPlayer] failed to load Alien_Helmet.glb', err),
-    );
+      })
+      .catch((err: unknown) => {
+        console.error('[LocalPlayer] failed to load alien render assets', err);
+      });
 
     scene.add(this.mesh);
   }

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -183,6 +183,7 @@ export class LocalPlayer {
     integrateZeroG(this.phys, dt);
     bounceArena(this.phys);
     arena.bounceObstacles(this.phys);
+    this.tryReturnToOwnBreach(arena);
   }
 
   private updateBreach(
@@ -255,9 +256,7 @@ export class LocalPlayer {
     arena.bounceObstacles(this.phys);
 
     if (arena.isInBreachRoom(this.phys.pos, this.team)) {
-      this.currentBreachTeam = this.team;
-      this.phase = 'BREACH';
-      this.phys.vel.y = 0;
+      this.returnToOwnBreach();
       return;
     }
 
@@ -341,6 +340,18 @@ export class LocalPlayer {
     this.grabHandGripLocal = null;
     this.grabPoseLocked = false;
     this.phase = 'FLOATING';
+  }
+
+  private tryReturnToOwnBreach(arena: Arena): void {
+    if (!arena.isInBreachRoom(this.phys.pos, this.team)) return;
+    this.returnToOwnBreach();
+  }
+
+  private returnToOwnBreach(): void {
+    this.currentBreachTeam = this.team;
+    this.phase = 'BREACH';
+    this.damage.frozen = false;
+    this.phys.vel.y = 0;
   }
 
   private updateAnimation(input: InputManager, cam: CameraController, dt: number): void {

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -37,6 +37,7 @@ import {
   applyBarHoldPose,
   measureLeftHandGripOffset,
 } from './playerGrabPose';
+import { PlayerDamageGlow } from './playerDamageGlow';
 import { loadAlienRenderClone } from './alienRenderAsset';
 import {
   applyFloatArmTilt,
@@ -79,8 +80,6 @@ export class LocalPlayer {
   public grabbedBarPos: THREE.Vector3 | null = null;
   public currentBreachTeam: 0 | 1 = 0;
 
-  public onRoundWin: ((team: 0 | 1) => void) | null = null;
-
   private respawnTimer = 0;
   private onGround = false;
   private breachJumpAnimationActive = false;
@@ -91,6 +90,7 @@ export class LocalPlayer {
   private grabPoseLocked = false;
 
   private animation = new PlayerAnimationController();
+  private damageGlow = new PlayerDamageGlow(this.team);
   private gun = new ThirdPersonGun();
   private visualQuaternion = new THREE.Quaternion();
   // Tracks the previous frame's animation name so we can detect transitions.
@@ -109,6 +109,7 @@ export class LocalPlayer {
         if (gripLocal) this.leftHandGripLocal.copy(gripLocal);
 
         this.animation.registerRig(body, bodyAnimations);
+        this.damageGlow.attachTo(body);
         this.gun.attachTo(body);
         this.mesh.add(body);
 
@@ -168,6 +169,7 @@ export class LocalPlayer {
         break;
     }
     this.updateAnimation(input, cam, dt);
+    this.damageGlow.update(this.damage, this.phase, dt);
     const visualQuat = this.computeVisualQuaternion(cam, dt);
     if (this.phase === 'GRABBING' || this.phase === 'AIMING') {
       this.lockGripToBar(visualQuat);
@@ -256,18 +258,6 @@ export class LocalPlayer {
       this.currentBreachTeam = this.team;
       this.phase = 'BREACH';
       this.phys.vel.y = 0;
-      return;
-    }
-
-    const enemyTeam = (1 - this.team) as 0 | 1;
-    if (!this.damage.frozen
-      && arena.isGoalDoorOpen(enemyTeam)
-      && arena.isDeepInBreachRoom(this.phys.pos, enemyTeam, 1.0)) {
-      this.currentBreachTeam = enemyTeam;
-      this.phase = 'BREACH';
-      this.phys.vel.y = 0;
-      this.kills++;
-      this.onRoundWin?.(this.team);
       return;
     }
 
@@ -470,7 +460,7 @@ export class LocalPlayer {
     this.phys.pos.copy(this.grabbedBarPos).sub(handOffset);
   }
 
-  public applyHit(zone: HitZone, impulse: THREE.Vector3): void {
+  public applyHit(zone: HitZone, impulse: THREE.Vector3): boolean {
     this.phys.vel.add(impulse);
 
     switch (zone) {
@@ -484,10 +474,10 @@ export class LocalPlayer {
         this.grabbedBarPos = null;
         this.grabHandGripLocal = null;
         this.grabPoseLocked = false;
-        break;
+        return true;
       case 'rightArm':
         this.damage.rightArm = true;
-        break;
+        return false;
       case 'leftArm':
         this.damage.leftArm = true;
         if (this.phase === 'GRABBING' || this.phase === 'AIMING') {
@@ -496,11 +486,11 @@ export class LocalPlayer {
           this.grabHandGripLocal = null;
           this.grabPoseLocked = false;
         }
-        break;
+        return false;
       case 'legs':
         this.damage.legs = true;
         this.launchPower = clamp(this.launchPower, 0, this.maxLaunchPower());
-        break;
+        return false;
     }
   }
 
@@ -512,7 +502,7 @@ export class LocalPlayer {
     return classifyHitZone(impactPoint, playerPos, playerFacing);
   }
 
-  public resetForNewRound(arena: Arena): void {
+  public resetForNewRound(arena: Arena, spawnOverride?: { x: number; y: number; z: number }): void {
     this.damage = {
       frozen: false,
       rightArm: false,
@@ -527,10 +517,12 @@ export class LocalPlayer {
     this.currentBreachTeam = this.team;
     this.phys.vel.set(0, 0, 0);
 
-    const center = arena.getBreachRoomCenter(this.team);
-    const openAxis = arena.getBreachOpenAxis(this.team);
-    const openSign = arena.getBreachOpenSign(this.team);
-    const spawn = computeBreachSpawnPosition(center, openAxis, openSign);
+    const spawn = spawnOverride ?? (() => {
+      const center = arena.getBreachRoomCenter(this.team);
+      const openAxis = arena.getBreachOpenAxis(this.team);
+      const openSign = arena.getBreachOpenSign(this.team);
+      return computeBreachSpawnPosition(center, openAxis, openSign);
+    })();
     this.phys.pos.set(spawn.x, spawn.y, spawn.z);
     this.phase = 'BREACH';
   }

--- a/client/src/player/playerDamageGlow.ts
+++ b/client/src/player/playerDamageGlow.ts
@@ -1,0 +1,144 @@
+import * as THREE from "three";
+import type { DamageState, PlayerPhase } from "../../../shared/schema";
+
+type GlowSlotId =
+  | "frozenCore"
+  | "frozenHead"
+  | "leftArm"
+  | "rightArm"
+  | "leftLeg"
+  | "rightLeg";
+
+interface GlowShell {
+  baseOpacity: number;
+  baseScale: THREE.Vector3;
+  mesh: THREE.Mesh;
+  phaseOffset: number;
+}
+
+interface GlowSlotConfig {
+  baseOpacity: number;
+  baseScale: THREE.Vector3;
+  boneName: string;
+  offset?: THREE.Vector3;
+}
+
+const GLOW_GEOMETRY = new THREE.SphereGeometry(1, 12, 10);
+
+const SLOT_CONFIG: Record<GlowSlotId, GlowSlotConfig> = {
+  frozenCore: {
+    baseOpacity: 0.28,
+    baseScale: new THREE.Vector3(1.5, 1.9, 1.2),
+    boneName: "Torso",
+    offset: new THREE.Vector3(0, 0.08, 0),
+  },
+  frozenHead: {
+    baseOpacity: 0.22,
+    baseScale: new THREE.Vector3(0.85, 0.85, 0.85),
+    boneName: "Neck",
+    offset: new THREE.Vector3(0, 0.14, 0),
+  },
+  leftArm: {
+    baseOpacity: 0.22,
+    baseScale: new THREE.Vector3(0.68, 0.68, 0.68),
+    boneName: "LowerArmL",
+  },
+  rightArm: {
+    baseOpacity: 0.22,
+    baseScale: new THREE.Vector3(0.68, 0.68, 0.68),
+    boneName: "LowerArmR",
+  },
+  leftLeg: {
+    baseOpacity: 0.18,
+    baseScale: new THREE.Vector3(0.82, 0.82, 0.82),
+    boneName: "UpperLegL",
+  },
+  rightLeg: {
+    baseOpacity: 0.18,
+    baseScale: new THREE.Vector3(0.82, 0.82, 0.82),
+    boneName: "UpperLegR",
+  },
+};
+
+export class PlayerDamageGlow {
+  private readonly color = new THREE.Color();
+  private readonly slots = new Map<GlowSlotId, GlowShell>();
+  private time = 0;
+
+  public constructor(team: 0 | 1) {
+    this.color.set(team === 0 ? "#ff4fd8" : "#59d9ff");
+  }
+
+  public attachTo(root: THREE.Group): void {
+    this.dispose();
+
+    (Object.entries(SLOT_CONFIG) as Array<[GlowSlotId, GlowSlotConfig]>).forEach(([id, config], index) => {
+      const bone = root.getObjectByName(config.boneName);
+      if (!bone) return;
+
+      const material = new THREE.MeshBasicMaterial({
+        color: this.color,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        opacity: 0,
+        transparent: true,
+      });
+      const mesh = new THREE.Mesh(GLOW_GEOMETRY, material);
+      mesh.renderOrder = 10;
+      mesh.visible = false;
+      mesh.scale.copy(config.baseScale);
+      mesh.position.copy(config.offset ?? new THREE.Vector3());
+      bone.add(mesh);
+
+      this.slots.set(id, {
+        baseOpacity: config.baseOpacity,
+        baseScale: config.baseScale.clone(),
+        mesh,
+        phaseOffset: index * 0.7,
+      });
+    });
+  }
+
+  public update(damage: DamageState, phase: PlayerPhase, dt: number): void {
+    this.time += dt;
+
+    for (const [id, slot] of this.slots) {
+      const active = phase !== "RESPAWNING" && isSlotActive(id, damage);
+      slot.mesh.visible = active;
+      if (!active) continue;
+
+      const pulse = 0.6 + 0.4 * (0.5 + 0.5 * Math.sin(this.time * 2.4 + slot.phaseOffset));
+      const scalePulse = id.startsWith("frozen") ? 1.05 + pulse * 0.12 : 1.02 + pulse * 0.08;
+      slot.mesh.scale.copy(slot.baseScale).multiplyScalar(scalePulse);
+
+      const material = slot.mesh.material as THREE.MeshBasicMaterial;
+      material.color.copy(this.color);
+      material.opacity = slot.baseOpacity * pulse;
+    }
+  }
+
+  public dispose(): void {
+    for (const slot of this.slots.values()) {
+      if (slot.mesh.parent) {
+        slot.mesh.parent.remove(slot.mesh);
+      }
+      (slot.mesh.material as THREE.Material).dispose();
+    }
+    this.slots.clear();
+  }
+}
+
+function isSlotActive(id: GlowSlotId, damage: DamageState): boolean {
+  switch (id) {
+    case "frozenCore":
+    case "frozenHead":
+      return damage.frozen;
+    case "leftArm":
+      return damage.leftArm;
+    case "rightArm":
+      return damage.rightArm;
+    case "leftLeg":
+    case "rightLeg":
+      return damage.legs;
+  }
+}

--- a/client/src/player/playerThirdPersonGun.ts
+++ b/client/src/player/playerThirdPersonGun.ts
@@ -10,6 +10,8 @@ const THIRD_PERSON_GUN_SCALE = 0.28;
 const DEFAULT_OFFSET = new THREE.Vector3(0.02, 0.03, -0.08);
 const DEFAULT_ROTATION = new THREE.Euler(-17.72, 0.0, 1.31);
 
+let gunPrototypePromise: Promise<THREE.Group> | null = null;
+
 export interface ThirdPersonGunTuningState {
   enabled: boolean;
   offset: THREE.Vector3;
@@ -42,36 +44,32 @@ export class ThirdPersonGun {
       return;
     }
 
-    const loader = new GLTFLoader();
-    loader.load(
-      '/models/Ray Gun.glb',
-      (gltf) => {
-        const gun = gltf.scene;
-        gun.scale.setScalar(THIRD_PERSON_GUN_SCALE);
+    void loadGunPrototype()
+      .then((prototype) => {
+        const gun = prototype.clone(true);
         gun.position.copy(this.offset);
         gun.rotation.copy(this.rotation);
         gun.visible = this.visible;
-
-        gun.traverse((obj) => {
-          if (!(obj instanceof THREE.Mesh)) return;
-          obj.castShadow = true;
-          obj.receiveShadow = true;
-          obj.frustumCulled = false;
-        });
 
         this.muzzleLocal = this.computeMuzzleLocal(gun);
         palm.add(gun);
         this.model = gun;
         this.applyTransform();
-      },
-      undefined,
-      (err) => console.error('[ThirdPersonGun] failed to load Ray Gun.glb', err),
-    );
+      })
+      .catch((err: unknown) => console.error('[ThirdPersonGun] failed to load Ray Gun.glb', err));
   }
 
   public setVisible(visible: boolean): void {
     this.visible = visible;
     if (this.model) this.model.visible = visible;
+  }
+
+  public dispose(): void {
+    if (this.model?.parent) {
+      this.model.parent.remove(this.model);
+    }
+    this.model = null;
+    this.muzzleLocal = null;
   }
 
   public getMuzzleWorldPosition(): THREE.Vector3 | null {
@@ -179,4 +177,24 @@ export class ThirdPersonGun {
       ?? root.children.find((child) => child.name.toLowerCase().includes('muzzle'))
       ?? null;
   }
+}
+
+async function loadGunPrototype(): Promise<THREE.Group> {
+  if (!gunPrototypePromise) {
+    gunPrototypePromise = new GLTFLoader()
+      .loadAsync('/models/Ray Gun.glb')
+      .then((gltf) => {
+        const gun = gltf.scene;
+        gun.scale.setScalar(THIRD_PERSON_GUN_SCALE);
+        gun.traverse((obj) => {
+          if (!(obj instanceof THREE.Mesh)) return;
+          obj.castShadow = true;
+          obj.receiveShadow = true;
+          obj.frustumCulled = false;
+        });
+        return gun;
+      });
+  }
+
+  return gunPrototypePromise;
 }

--- a/client/src/projectile.ts
+++ b/client/src/projectile.ts
@@ -1,6 +1,10 @@
 import * as THREE from 'three';
 import { ARENA_SIZE } from '../../shared/constants';
 
+function teamColor(team: 0 | 1): number {
+  return team === 0 ? 0x00ffff : 0xff00ff;
+}
+
 const BULLET_SPEED    = 50;      // units/s
 const BULLET_LIFETIME = 2.0;     // seconds — max range = 100 units
 const BULLET_RADIUS   = 0.07;
@@ -14,20 +18,20 @@ export class Projectile {
   private vel: THREE.Vector3;
   private age  = 0;
   public  dead = false;
-  private teamColor: number;
 
   public constructor(
     private scene: THREE.Scene,
     origin: THREE.Vector3,
     direction: THREE.Vector3,
-    teamColor: number,
+    private team: 0 | 1,
+    private ownerId: string,
   ) {
-    this.teamColor = teamColor;
     this.vel = direction.clone().normalize().multiplyScalar(BULLET_SPEED);
+    const color = teamColor(team);
 
     // Core bullet mesh
     const geo = new THREE.SphereGeometry(BULLET_RADIUS, 6, 4);
-    const mat = new THREE.MeshBasicMaterial({ color: teamColor });
+    const mat = new THREE.MeshBasicMaterial({ color });
     this.mesh  = new THREE.Mesh(geo, mat);
     this.mesh.position.copy(origin);
     scene.add(this.mesh);
@@ -40,7 +44,7 @@ export class Projectile {
     const trailGeo = new THREE.BufferGeometry();
     trailGeo.setAttribute('position', new THREE.BufferAttribute(this.trailPositions, 3));
     const trailMat = new THREE.LineBasicMaterial({
-      color: teamColor,
+      color,
       transparent: true,
       opacity: 0.45,
     });
@@ -89,7 +93,15 @@ export class Projectile {
   }
 
   public getTeamColor(): number {
-    return this.teamColor;
+    return teamColor(this.team);
+  }
+
+  public getTeam(): 0 | 1 {
+    return this.team;
+  }
+
+  public getOwnerId(): string {
+    return this.ownerId;
   }
 
   public dispose(): void {

--- a/client/src/projectile.ts
+++ b/client/src/projectile.ts
@@ -1,118 +1,167 @@
-import * as THREE from 'three';
-import { ARENA_SIZE } from '../../shared/constants';
+import * as THREE from "three";
+import { ARENA_SIZE } from "../../shared/constants";
 
-function teamColor(team: 0 | 1): number {
-  return team === 0 ? 0x00ffff : 0xff00ff;
-}
+const BULLET_SPEED = 50;
+const BULLET_LIFETIME = 2.0;
+const BULLET_RADIUS = 0.07;
+const TRAIL_SEGMENTS = 8;
 
-const BULLET_SPEED    = 50;      // units/s
-const BULLET_LIFETIME = 2.0;     // seconds — max range = 100 units
-const BULLET_RADIUS   = 0.07;
-const TRAIL_SEGMENTS  = 8;       // points in the tracer tail
+export type ProjectileTrailMode = "full" | "reduced" | "hidden";
+
+const BULLET_GEOMETRY = new THREE.SphereGeometry(BULLET_RADIUS, 6, 4);
+const BULLET_MATERIALS = {
+  0: new THREE.MeshBasicMaterial({ color: 0x00ffff }),
+  1: new THREE.MeshBasicMaterial({ color: 0xff00ff }),
+} satisfies Record<0 | 1, THREE.MeshBasicMaterial>;
+const TRAIL_MATERIALS = {
+  0: new THREE.LineBasicMaterial({ color: 0x00ffff, transparent: true, opacity: 0.45 }),
+  1: new THREE.LineBasicMaterial({ color: 0xff00ff, transparent: true, opacity: 0.45 }),
+} satisfies Record<0 | 1, THREE.LineBasicMaterial>;
 
 export class Projectile {
-  private mesh:  THREE.Mesh;
+  private age = 0;
+  public dead = true;
+  private mesh: THREE.Mesh;
+  private ownerId = "";
+  private previousPosition = new THREE.Vector3();
+  private team: 0 | 1 = 0;
   private trail: THREE.Line;
-  private trailPositions: Float32Array;
+  private trailGeometry: THREE.BufferGeometry;
+  private trailMode: ProjectileTrailMode = "full";
+  private trailPositions = new Float32Array(TRAIL_SEGMENTS * 3);
+  private trailTickAccumulator = 0;
+  private vel = new THREE.Vector3();
 
-  private vel: THREE.Vector3;
-  private age  = 0;
-  public  dead = false;
+  public constructor(private readonly scene: THREE.Scene) {
+    this.mesh = new THREE.Mesh(BULLET_GEOMETRY, BULLET_MATERIALS[0]);
+    this.mesh.visible = false;
 
-  public constructor(
-    private scene: THREE.Scene,
-    origin: THREE.Vector3,
-    direction: THREE.Vector3,
-    private team: 0 | 1,
-    private ownerId: string,
-  ) {
-    this.vel = direction.clone().normalize().multiplyScalar(BULLET_SPEED);
-    const color = teamColor(team);
-
-    // Core bullet mesh
-    const geo = new THREE.SphereGeometry(BULLET_RADIUS, 6, 4);
-    const mat = new THREE.MeshBasicMaterial({ color });
-    this.mesh  = new THREE.Mesh(geo, mat);
-    this.mesh.position.copy(origin);
-    scene.add(this.mesh);
-
-    // Tracer tail
-    this.trailPositions = new Float32Array(TRAIL_SEGMENTS * 3);
-    for (let i = 0; i < TRAIL_SEGMENTS * 3; i++) {
-      this.trailPositions[i] = origin.getComponent(i % 3);
-    }
-    const trailGeo = new THREE.BufferGeometry();
-    trailGeo.setAttribute('position', new THREE.BufferAttribute(this.trailPositions, 3));
-    const trailMat = new THREE.LineBasicMaterial({
-      color,
-      transparent: true,
-      opacity: 0.45,
-    });
-    this.trail = new THREE.Line(trailGeo, trailMat);
-    scene.add(this.trail);
+    this.trailGeometry = new THREE.BufferGeometry();
+    this.trailGeometry.setAttribute("position", new THREE.BufferAttribute(this.trailPositions, 3));
+    this.trail = new THREE.Line(this.trailGeometry, TRAIL_MATERIALS[0]);
+    this.trail.visible = false;
   }
 
-  /** Returns true when the bullet should be removed. */
+  public reset(
+    origin: THREE.Vector3,
+    direction: THREE.Vector3,
+    team: 0 | 1,
+    ownerId: string,
+  ): void {
+    this.team = team;
+    this.ownerId = ownerId;
+    this.dead = false;
+    this.age = 0;
+    this.trailMode = "full";
+    this.trailTickAccumulator = 0;
+    this.vel.copy(direction).normalize().multiplyScalar(BULLET_SPEED);
+
+    this.mesh.material = BULLET_MATERIALS[team];
+    this.mesh.position.copy(origin);
+    this.previousPosition.copy(origin);
+    this.mesh.visible = true;
+    if (!this.mesh.parent) {
+      this.scene.add(this.mesh);
+    }
+
+    this.trail.material = TRAIL_MATERIALS[team];
+    this.trail.visible = true;
+    if (!this.trail.parent) {
+      this.scene.add(this.trail);
+    }
+
+    for (let i = 0; i < TRAIL_SEGMENTS; i += 1) {
+      this.trailPositions[i * 3] = origin.x;
+      this.trailPositions[i * 3 + 1] = origin.y;
+      this.trailPositions[i * 3 + 2] = origin.z;
+    }
+    (this.trailGeometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+  }
+
   public update(dt: number): void {
     if (this.dead) return;
+
     this.age += dt;
     if (this.age > BULLET_LIFETIME) {
       this.dispose();
       return;
     }
 
+    this.previousPosition.copy(this.mesh.position);
     this.mesh.position.addScaledVector(this.vel, dt);
 
-    // Bounce off solid arena walls, pass through portal openings
     const limit = ARENA_SIZE / 2;
-    for (const ax of ['x', 'y', 'z'] as const) {
-      const hi = limit;
-      const lo = -limit;
-      if (this.mesh.position[ax] > hi || this.mesh.position[ax] < lo) {
-        // Bounce off wall — die instead of reflecting (cleaner feel)
+    for (const axis of ["x", "y", "z"] as const) {
+      if (this.mesh.position[axis] > limit || this.mesh.position[axis] < -limit) {
         this.dispose();
         return;
       }
     }
 
-    // Scroll trail back: shift older segments toward tail, put current pos at head
-    for (let i = TRAIL_SEGMENTS - 1; i > 0; i--) {
-      this.trailPositions[i * 3]     = this.trailPositions[(i - 1) * 3];
-      this.trailPositions[i * 3 + 1] = this.trailPositions[(i - 1) * 3 + 1];
-      this.trailPositions[i * 3 + 2] = this.trailPositions[(i - 1) * 3 + 2];
-    }
-    this.trailPositions[0] = this.mesh.position.x;
-    this.trailPositions[1] = this.mesh.position.y;
-    this.trailPositions[2] = this.mesh.position.z;
-    (this.trail.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
-  }
-
-  /** World position of the bullet this frame. */
-  public getPosition(): THREE.Vector3 {
-    return this.mesh.position;
-  }
-
-  public getTeamColor(): number {
-    return teamColor(this.team);
-  }
-
-  public getTeam(): 0 | 1 {
-    return this.team;
+    this.updateTrail(dt);
   }
 
   public getOwnerId(): string {
     return this.ownerId;
   }
 
+  public getPosition(): THREE.Vector3 {
+    return this.mesh.position;
+  }
+
+  public getPreviousPosition(): THREE.Vector3 {
+    return this.previousPosition;
+  }
+
+  public getTeam(): 0 | 1 {
+    return this.team;
+  }
+
+  public getTeamColor(): number {
+    return this.team === 0 ? 0x00ffff : 0xff00ff;
+  }
+
+  public setTrailMode(mode: ProjectileTrailMode): void {
+    this.trailMode = mode;
+    this.trail.visible = !this.dead && mode !== "hidden";
+  }
+
   public dispose(): void {
     if (this.dead) return;
     this.dead = true;
-    this.scene.remove(this.mesh);
-    this.mesh.geometry.dispose();
-    (this.mesh.material as THREE.Material).dispose();
-    this.scene.remove(this.trail);
-    this.trail.geometry.dispose();
-    (this.trail.material as THREE.Material).dispose();
+    this.mesh.visible = false;
+    this.trail.visible = false;
+    if (this.mesh.parent) {
+      this.scene.remove(this.mesh);
+    }
+    if (this.trail.parent) {
+      this.scene.remove(this.trail);
+    }
+  }
+
+  private updateTrail(dt: number): void {
+    if (this.trailMode === "hidden") {
+      this.trail.visible = false;
+      return;
+    }
+
+    this.trail.visible = true;
+    if (this.trailMode === "reduced") {
+      this.trailTickAccumulator += dt;
+      if (this.trailTickAccumulator < 1 / 30) {
+        return;
+      }
+      this.trailTickAccumulator = 0;
+    }
+
+    for (let i = TRAIL_SEGMENTS - 1; i > 0; i -= 1) {
+      this.trailPositions[i * 3] = this.trailPositions[(i - 1) * 3];
+      this.trailPositions[i * 3 + 1] = this.trailPositions[(i - 1) * 3 + 1];
+      this.trailPositions[i * 3 + 2] = this.trailPositions[(i - 1) * 3 + 2];
+    }
+    this.trailPositions[0] = this.mesh.position.x;
+    this.trailPositions[1] = this.mesh.position.y;
+    this.trailPositions[2] = this.mesh.position.z;
+    (this.trailGeometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
   }
 }
-

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -31,6 +31,8 @@ export interface HudState {
  */
 export class HUD {
   private view: HudElements;
+  private hitConfirmTeam: 0 | 1 = 0;
+  private hitConfirmTimer = 0;
 
   // Typewriter state — only active during the very first countdown
   private isFirstRound = true;
@@ -53,6 +55,11 @@ export class HUD {
     this.view.roundEnd.style.display = 'none';
   }
 
+  public triggerHitConfirm(team: 0 | 1): void {
+    this.hitConfirmTeam = team;
+    this.hitConfirmTimer = 0.14;
+  }
+
   public update(state: HudState): void {
     // Track phase transitions to detect first-round vs subsequent rounds
     if (state.phase !== this.prevPhase) {
@@ -65,6 +72,7 @@ export class HUD {
     this.renderScore(state.score);
     this.renderCountdown(state.phase, state.countdown);
     this.renderObjectiveTypewriter(state.phase, state.dt, state.team);
+    this.renderCrosshair(state.dt);
     this.renderBreachIndicator(state.inBreach);
     this.renderGrabPrompt(state.playerPhase, state.nearBar, state.damage);
     this.renderPowerBar(state.playerPhase, state.launchPower, state.maxLaunchPower);
@@ -83,6 +91,23 @@ export class HUD {
     } else {
       this.view.countdown.style.display = 'none';
     }
+  }
+
+  private renderCrosshair(dt: number): void {
+    this.hitConfirmTimer = Math.max(0, this.hitConfirmTimer - dt);
+    const pulse = this.hitConfirmTimer > 0 ? this.hitConfirmTimer / 0.14 : 0;
+    const glowColor = this.hitConfirmTeam === 0 ? '#00ffff' : '#ff00ff';
+    const scale = 1 + pulse * 0.5;
+    const size = 6 + pulse * 2;
+
+    this.view.crosshair.style.width = `${size.toFixed(2)}px`;
+    this.view.crosshair.style.height = `${size.toFixed(2)}px`;
+    this.view.crosshair.style.transform = `translate(-50%,-50%) scale(${scale.toFixed(3)})`;
+    this.view.crosshair.style.background = pulse > 0 ? glowColor : '#ffffff';
+    this.view.crosshair.style.opacity = pulse > 0 ? '1' : '0.85';
+    this.view.crosshair.style.boxShadow = pulse > 0
+      ? `0 0 ${12 + pulse * 10}px ${glowColor}`
+      : '0 0 8px rgba(255,255,255,0.3)';
   }
 
   private renderObjectiveTypewriter(phase: GamePhase, dt: number, team: 0 | 1): void {

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -1,7 +1,7 @@
-import type { DamageState, FullPlayerInfo, EnemyPlayerInfo } from '../../../shared/schema';
+import type { DamageState, EnemyPlayerInfo, FullPlayerInfo } from '../../../shared/schema';
+import { isTouchDevice } from '../platform';
 import { createHudView, type HudElements } from './hud/hudView';
 import { buildScoreboardHtml } from './hud/scoreboard';
-import { isTouchDevice } from '../platform';
 
 const IS_MOBILE = isTouchDevice();
 
@@ -11,6 +11,7 @@ export interface HudState {
   score: { team0: number; team1: number };
   phase: GamePhase;
   countdown: number;
+  roundTimeRemaining: number;
   playerPhase: string;
   launchPower: number;
   maxLaunchPower: number;
@@ -24,23 +25,16 @@ export interface HudState {
   team: 0 | 1;
 }
 
-/**
- * HUD controller: owns the rendered HUD view and maps gameplay state into
- * DOM updates. Per-frame state (typewriter progress, phase tracking) is kept
- * here; everything else is derived from the incoming HudState each tick.
- */
 export class HUD {
   private view: HudElements;
   private hitConfirmTeam: 0 | 1 = 0;
   private hitConfirmTimer = 0;
-
-  // Typewriter state — only active during the very first countdown
   private isFirstRound = true;
   private prevPhase: GamePhase = 'LOBBY';
   private typewriterTimer = 0;
   private typewriterIdx = 0;
   private static readonly OBJECTIVE_TEXT =
-    'Objective — Breach Enemy Portal or Freeze them ALL';
+    'Objective - Breach Enemy Portal or Freeze them ALL';
 
   public constructor() {
     this.view = createHudView();
@@ -61,7 +55,6 @@ export class HUD {
   }
 
   public update(state: HudState): void {
-    // Track phase transitions to detect first-round vs subsequent rounds
     if (state.phase !== this.prevPhase) {
       if (this.prevPhase === 'ROUND_END' && state.phase === 'COUNTDOWN') {
         this.isFirstRound = false;
@@ -69,7 +62,8 @@ export class HUD {
       this.prevPhase = state.phase;
     }
 
-    this.renderScore(state.score);
+    this.renderScore(state.phase, state.score);
+    this.renderRoundTimer(state.phase, state.roundTimeRemaining);
     this.renderCountdown(state.phase, state.countdown);
     this.renderObjectiveTypewriter(state.phase, state.dt, state.team);
     this.renderCrosshair(state.dt);
@@ -80,8 +74,28 @@ export class HUD {
     this.renderScoreboard(state.tabHeld, state.ownTeam, state.enemyTeam);
   }
 
-  private renderScore(score: { team0: number; team1: number }): void {
-    this.view.score.textContent = `${score.team0}  —  ${score.team1}`;
+  private renderScore(
+    phase: GamePhase,
+    score: { team0: number; team1: number },
+  ): void {
+    const show = phase !== 'LOBBY';
+    this.view.scoreWrap.style.display = show ? 'flex' : 'none';
+    if (!show) return;
+
+    this.view.score.textContent = `${score.team0}  -  ${score.team1}`;
+    this.view.scoreTeam0.style.opacity = '1';
+    this.view.scoreTeam1.style.opacity = '1';
+  }
+
+  private renderRoundTimer(phase: GamePhase, roundTimeRemaining: number): void {
+    const show = phase === 'COUNTDOWN' || phase === 'PLAYING';
+    this.view.roundTimer.style.display = show ? 'block' : 'none';
+    if (!show) return;
+
+    const totalSeconds = Math.max(0, Math.ceil(roundTimeRemaining));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    this.view.roundTimer.textContent = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
   }
 
   private renderCountdown(phase: GamePhase, countdown: number): void {
@@ -113,25 +127,22 @@ export class HUD {
   private renderObjectiveTypewriter(phase: GamePhase, dt: number, team: 0 | 1): void {
     const el = this.view.objective;
     if (this.isFirstRound && phase === 'COUNTDOWN') {
-      // Team color: inverted against the same-colored portal/energy wall behind the text.
-      // Dark backdrop + bright team-tint text ensures contrast regardless of background glow.
-      const textColor  = team === 0 ? '#aaffff' : '#ffaaff';
-      const glowColor  = team === 0 ? '#00ffff' : '#ff00ff';
-      // Dark complement of the team hue so the background blocks the glow bleed
+      const textColor = team === 0 ? '#aaffff' : '#ffaaff';
+      const glowColor = team === 0 ? '#00ffff' : '#ff00ff';
       const backdropBg = team === 0 ? 'rgba(0,8,8,0.72)' : 'rgba(8,0,8,0.72)';
 
-      el.style.color      = textColor;
+      el.style.color = textColor;
       el.style.textShadow = `0 0 12px ${glowColor}`;
       el.style.background = backdropBg;
-      el.style.padding    = '4px 14px';
+      el.style.padding = '4px 14px';
       el.style.borderRadius = '4px';
       el.style.display = 'block';
 
       this.typewriterTimer += dt;
-      const CHARS_PER_SEC = 20;
+      const charsPerSecond = 20;
       this.typewriterIdx = Math.min(
         HUD.OBJECTIVE_TEXT.length,
-        Math.floor(this.typewriterTimer * CHARS_PER_SEC),
+        Math.floor(this.typewriterTimer * charsPerSecond),
       );
       el.textContent = HUD.OBJECTIVE_TEXT.slice(0, this.typewriterIdx);
     } else if (phase === 'PLAYING') {
@@ -157,10 +168,9 @@ export class HUD {
     let show = false;
 
     if (playerPhase === 'AIMING') {
-      // On mobile the vertical power bar is sufficient — skip text prompt.
       if (!IS_MOBILE) {
         show = true;
-        promptText = '↓ Pull mouse to charge power  ·  Release [SPACE] to launch';
+        promptText = 'Pull mouse down to charge power - release [SPACE] to launch';
         el.style.fontSize = '14px';
         el.style.color = '#ffff88';
         el.style.textShadow = '0 0 8px #ffaa00';
@@ -168,8 +178,8 @@ export class HUD {
     } else if (playerPhase === 'GRABBING') {
       show = true;
       promptText = IS_MOBILE
-        ? 'Hold LAUNCH & drag ↓ to charge'
-        : 'Hold [SPACE] to aim  ·  [E] to release bar';
+        ? 'Hold LAUNCH and drag down to charge'
+        : 'Hold [SPACE] to aim - [E] to release bar';
       el.style.fontSize = IS_MOBILE ? '13px' : '15px';
       el.style.color = '#aaffff';
       el.style.textShadow = '0 0 8px #00ffff';
@@ -179,7 +189,6 @@ export class HUD {
       && !damage.leftArm
       && !damage.frozen
     ) {
-      // On mobile the GRAB button appears instead; skip this text.
       if (!IS_MOBILE) {
         show = true;
         promptText = '[E]  GRAB BAR';
@@ -198,28 +207,27 @@ export class HUD {
     launchPower: number,
     maxLaunchPower: number,
   ): void {
-    // On mobile the MobileControls vertical bar handles power display.
     if (IS_MOBILE) {
       this.view.powerWrap.style.display = 'none';
       return;
     }
+
     const showBar = playerPhase === 'GRABBING' || playerPhase === 'AIMING';
     this.view.powerWrap.style.display = showBar ? 'block' : 'none';
 
     const pct = maxLaunchPower > 0 ? (launchPower / maxLaunchPower) * 100 : 0;
     this.view.powerBar.style.width = `${pct.toFixed(1)}%`;
     this.view.powerLabel.textContent = `POWER  ${Math.round(pct)}%`;
-    // Green → yellow → red as power grows.
     const hue = 120 - pct * 1.2;
     this.view.powerBar.style.background = `hsl(${hue},90%,55%)`;
   }
 
   private renderDamage(damage: DamageState): void {
     const parts: string[] = [];
-    if (damage.frozen) parts.push('⬛ FROZEN');
-    if (damage.leftArm) parts.push('🦾 LEFT ARM — NO GRAB');
-    if (damage.rightArm) parts.push('🦾 RIGHT ARM — NO FIRE');
-    if (damage.legs) parts.push('🦵 LEGS — REDUCED POWER');
+    if (damage.frozen) parts.push('FROZEN');
+    if (damage.leftArm) parts.push('LEFT ARM - NO GRAB');
+    if (damage.rightArm) parts.push('RIGHT ARM - NO FIRE');
+    if (damage.legs) parts.push('LEGS - REDUCED POWER');
     this.view.damage.innerHTML = parts.join('<br>');
   }
 

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -5,13 +5,46 @@
  * self-contained (no global stylesheet dependency).
  */
 const HUD_MARKUP = `
+  <div id="hud-score-wrap" style="
+    position:absolute;left:50%;top:18px;
+    transform:translateX(-50%);
+    display:flex;flex-direction:column;align-items:center;gap:6px;
+  ">
+    <div id="hud-score-row" style="
+      display:flex;align-items:center;gap:14px;
+    ">
+      <div id="hud-score-team0" style="
+        width:16px;height:16px;border-radius:50%;
+        background:radial-gradient(circle, rgba(170,255,255,0.95) 0%, rgba(0,255,255,0.85) 34%, rgba(0,255,255,0.15) 72%, rgba(0,255,255,0) 100%);
+        box-shadow:0 0 14px rgba(0,255,255,0.85), inset 0 0 6px rgba(255,255,255,0.6);
+        border:1px solid rgba(170,255,255,0.9);
+      "></div>
+
+      <div id="hud-score" style="
+        font-size:20px;letter-spacing:0.08em;
+        text-shadow:0 0 10px rgba(0,255,255,0.5);
+      ">0 - 0</div>
+
+      <div id="hud-score-team1" style="
+        width:16px;height:16px;border-radius:50%;
+        background:radial-gradient(circle, rgba(255,200,250,0.95) 0%, rgba(255,0,255,0.85) 34%, rgba(255,0,255,0.15) 72%, rgba(255,0,255,0) 100%);
+        box-shadow:0 0 14px rgba(255,0,255,0.8), inset 0 0 6px rgba(255,255,255,0.55);
+        border:1px solid rgba(255,200,250,0.9);
+      "></div>
+    </div>
+
+    <div id="hud-round-timer" style="
+      display:none;font-size:15px;letter-spacing:0.18em;
+      color:#d8f7ff;text-shadow:0 0 10px rgba(0,255,255,0.35);
+    ">02:00</div>
+  </div>
+
   <div id="hud-countdown" style="
     display:none;position:absolute;left:50%;top:38%;
     transform:translate(-50%,-50%);font-size:90px;font-weight:bold;
     color:#fff;text-shadow:0 0 40px #00ffff;letter-spacing:0.05em;
   ">10</div>
 
-  <!-- First-round objective typewriter (shown only during first countdown) -->
   <div id="hud-objective" style="
     display:none;position:absolute;left:50%;top:58%;
     transform:translateX(-50%);font-size:16px;letter-spacing:3px;
@@ -26,17 +59,11 @@ const HUD_MARKUP = `
     box-shadow:0 0 8px rgba(255,255,255,0.3);
   "></div>
 
-  <div id="hud-score" style="
-    position:absolute;left:50%;top:18px;
-    transform:translateX(-50%);font-size:20px;letter-spacing:0.08em;
-    text-shadow:0 0 10px rgba(0,255,255,0.5);
-  ">0 — 0</div>
-
   <div id="hud-breach" style="
     display:none;position:absolute;bottom:22px;left:50%;
     transform:translateX(-50%);font-size:13px;color:#88ddff;opacity:0.75;
     white-space:nowrap;
-  ">▼ BREACH ROOM — GRAVITY ACTIVE ▼</div>
+  ">BREACH ROOM - GRAVITY ACTIVE</div>
 
   <div id="hud-grab" style="
     display:none;position:absolute;left:50%;bottom:28%;
@@ -61,7 +88,7 @@ const HUD_MARKUP = `
 
   <div id="hud-round-end" style="
     display:none;position:absolute;inset:0;
-    display:none;align-items:center;justify-content:center;
+    align-items:center;justify-content:center;
     background:rgba(0,0,0,0.6);font-size:52px;
     letter-spacing:0.08em;text-shadow:0 0 30px #fff;
   "></div>
@@ -77,10 +104,14 @@ const HUD_MARKUP = `
 
 export interface HudElements {
   root: HTMLDivElement;
+  scoreWrap: HTMLDivElement;
   countdown: HTMLDivElement;
   objective: HTMLDivElement;
   crosshair: HTMLDivElement;
   score: HTMLDivElement;
+  scoreTeam0: HTMLDivElement;
+  scoreTeam1: HTMLDivElement;
+  roundTimer: HTMLDivElement;
   breach: HTMLDivElement;
   grab: HTMLDivElement;
   powerWrap: HTMLDivElement;
@@ -112,10 +143,14 @@ export function createHudView(): HudElements {
 
   return {
     root,
+    scoreWrap: q('hud-score-wrap'),
     countdown: q('hud-countdown'),
     objective: q('hud-objective'),
     crosshair: q('hud-crosshair'),
     score: q('hud-score'),
+    scoreTeam0: q('hud-score-team0'),
+    scoreTeam1: q('hud-score-team1'),
+    roundTimer: q('hud-round-timer'),
     breach: q('hud-breach'),
     grab: q('hud-grab'),
     powerWrap: q('hud-power-wrap'),

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -23,6 +23,7 @@ const HUD_MARKUP = `
     position:absolute;left:50%;top:50%;
     transform:translate(-50%,-50%);
     width:6px;height:6px;border-radius:50%;background:#fff;opacity:0.85;
+    box-shadow:0 0 8px rgba(255,255,255,0.3);
   "></div>
 
   <div id="hud-score" style="
@@ -78,6 +79,7 @@ export interface HudElements {
   root: HTMLDivElement;
   countdown: HTMLDivElement;
   objective: HTMLDivElement;
+  crosshair: HTMLDivElement;
   score: HTMLDivElement;
   breach: HTMLDivElement;
   grab: HTMLDivElement;
@@ -112,6 +114,7 @@ export function createHudView(): HudElements {
     root,
     countdown: q('hud-countdown'),
     objective: q('hud-objective'),
+    crosshair: q('hud-crosshair'),
     score: q('hud-score'),
     breach: q('hud-breach'),
     grab: q('hud-grab'),

--- a/client/src/render/hud/scoreboard.ts
+++ b/client/src/render/hud/scoreboard.ts
@@ -1,41 +1,44 @@
-import type { EnemyPlayerInfo, FullPlayerInfo } from '../../../../shared/schema';
+import type { EnemyPlayerInfo, FullPlayerInfo } from "../../../../shared/schema";
 
-/**
- * Build the inner HTML for the TAB-held scoreboard. Extracted as a pure
- * string builder so the HUD controller can stay focused on show/hide
- * orchestration.
- */
+function renderName(name: string, isBot: boolean): string {
+  return isBot
+    ? `${name} <span style="color:#88aacc;font-size:10px;">BOT</span>`
+    : name;
+}
+
 export function buildScoreboardHtml(own: FullPlayerInfo[], enemy: EnemyPlayerInfo[]): string {
   const header = (cols: string[]) =>
-    `<tr style="color:#88aacc;border-bottom:1px solid #334;">${cols.map((c) => `<th style="padding:2px 10px;text-align:left;">${c}</th>`).join('')}</tr>`;
+    `<tr style="color:#88aacc;border-bottom:1px solid #334;">${cols.map((col) => `<th style="padding:2px 10px;text-align:left;">${col}</th>`).join("")}</tr>`;
 
-  const ownRows = own.map((p) =>
+  const ownRows = own.map((player) =>
     `<tr>
-      <td style="padding:2px 10px;">${p.name}</td>
-      <td style="padding:2px 10px;color:${p.frozen ? '#ff5555' : '#55ff55'}">${p.frozen ? 'FROZEN' : 'ACTIVE'}</td>
-      <td style="padding:2px 10px;">${p.kills}</td>
-      <td style="padding:2px 10px;">${p.deaths}</td>
-      <td style="padding:2px 10px;">${p.ping}ms</td>
-    </tr>`).join('');
+      <td style="padding:2px 10px;">${renderName(player.name, player.isBot)}</td>
+      <td style="padding:2px 10px;color:${player.frozen ? "#ff5555" : "#55ff55"}">${player.frozen ? "FROZEN" : "ACTIVE"}</td>
+      <td style="padding:2px 10px;">${player.kills}</td>
+      <td style="padding:2px 10px;">${player.deaths}</td>
+      <td style="padding:2px 10px;">${player.ping}ms</td>
+    </tr>`
+  ).join("");
 
-  const enemyRows = enemy.map((p) =>
+  const enemyRows = enemy.map((player) =>
     `<tr>
-      <td style="padding:2px 10px;">${p.name}</td>
-      <td style="padding:2px 10px;">—</td>
-      <td style="padding:2px 10px;">${p.kills}</td>
-      <td style="padding:2px 10px;">${p.deaths}</td>
-      <td style="padding:2px 10px;">${p.ping}ms</td>
-    </tr>`).join('');
+      <td style="padding:2px 10px;">${renderName(player.name, player.isBot)}</td>
+      <td style="padding:2px 10px;">-</td>
+      <td style="padding:2px 10px;">${player.kills}</td>
+      <td style="padding:2px 10px;">${player.deaths}</td>
+      <td style="padding:2px 10px;">${player.ping}ms</td>
+    </tr>`
+  ).join("");
 
   return `<table style="width:100%;border-collapse:collapse;">
     <thead>
-      <tr><th colspan="5" style="color:#00ffff;font-size:14px;padding:4px 10px;text-align:left;">▲ OWN TEAM</th></tr>
-      ${header(['Name', 'Status', 'K', 'D', 'Ping'])}
+      <tr><th colspan="5" style="color:#00ffff;font-size:14px;padding:4px 10px;text-align:left;">OWN TEAM</th></tr>
+      ${header(["Name", "Status", "K", "D", "Ping"])}
     </thead>
     <tbody>${ownRows}</tbody>
     <thead>
-      <tr><th colspan="5" style="color:#ff55ff;font-size:14px;padding:8px 10px 4px;text-align:left;">▼ ENEMY TEAM</th></tr>
-      ${header(['Name', '', 'K', 'D', 'Ping'])}
+      <tr><th colspan="5" style="color:#ff55ff;font-size:14px;padding:8px 10px 4px;text-align:left;">ENEMY TEAM</th></tr>
+      ${header(["Name", "", "K", "D", "Ping"])}
     </thead>
     <tbody>${enemyRows}</tbody>
   </table>`;

--- a/client/src/ui/kill-feed.ts
+++ b/client/src/ui/kill-feed.ts
@@ -1,0 +1,65 @@
+export class KillFeed {
+  private container: HTMLDivElement;
+
+  public constructor() {
+    this.container = document.createElement("div");
+    Object.assign(this.container.style, {
+      position: "fixed",
+      top: "60px",
+      right: "16px",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "flex-end",
+      gap: "4px",
+      pointerEvents: "none",
+      zIndex: "100",
+      fontFamily: "monospace",
+      fontSize: "13px",
+    });
+    document.body.appendChild(this.container);
+  }
+
+  public addKill(killerName: string, killerTeam: 0 | 1, victimName: string, victimTeam: 0 | 1): void {
+    const entry = document.createElement("div");
+    const killerColor = killerTeam === 0 ? "#00ffff" : "#ff00ff";
+    const victimColor = victimTeam === 0 ? "#00ffff" : "#ff00ff";
+
+    entry.innerHTML =
+      `<span style="color:${killerColor};text-shadow:0 0 6px ${killerColor}">${killerName}</span>`
+      + `<span style="color:#888;margin:0 6px">froze</span>`
+      + `<span style="color:${victimColor};text-shadow:0 0 6px ${victimColor}">${victimName}</span>`;
+
+    Object.assign(entry.style, {
+      background: "rgba(0,0,0,0.55)",
+      border: "1px solid #333",
+      borderRadius: "4px",
+      padding: "2px 8px",
+      transition: "opacity 0.5s ease",
+      opacity: "1",
+    });
+
+    this.container.appendChild(entry);
+    setTimeout(() => { entry.style.opacity = "0"; }, 3500);
+    setTimeout(() => { entry.remove(); }, 4000);
+  }
+
+  public addScore(scorerName: string, scorerTeam: 0 | 1): void {
+    const color = scorerTeam === 0 ? "#00ffff" : "#ff00ff";
+    const entry = document.createElement("div");
+    entry.innerHTML =
+      `<span style="color:${color};text-shadow:0 0 8px ${color};font-weight:bold">${scorerName} BREACHED!</span>`;
+
+    Object.assign(entry.style, {
+      background: "rgba(0,0,0,0.65)",
+      border: `1px solid ${color}`,
+      borderRadius: "4px",
+      padding: "3px 10px",
+      transition: "opacity 0.5s ease",
+      opacity: "1",
+    });
+
+    this.container.appendChild(entry);
+    setTimeout(() => { entry.style.opacity = "0"; }, 4500);
+    setTimeout(() => { entry.remove(); }, 5000);
+  }
+}

--- a/client/src/ui/menu.ts
+++ b/client/src/ui/menu.ts
@@ -1,7 +1,14 @@
 import { createMenuView, injectMenuStyle, type MenuElements } from './menu/menuView';
 import { isTouchDevice } from '../platform';
+import { isMatchTeamSize, type MatchTeamSize } from '../../../shared/match';
 
 const STORAGE_KEY = 'orbital_player_name';
+const MATCH_SIZE_STORAGE_KEY = 'orbital_match_size';
+
+export interface PlaySelection {
+  name: string;
+  teamSize: MatchTeamSize;
+}
 
 /**
  * MainMenu controller: injects the style once, mounts/unmounts the view
@@ -12,7 +19,7 @@ export class MainMenu {
   private menu: MenuElements | null = null;
   private styleEl: HTMLStyleElement | null = null;
 
-  public onPlay: (() => void) | null = null;
+  public onPlay: ((selection: PlaySelection) => void) | null = null;
 
   public show(): void {
     this.hide();
@@ -21,12 +28,19 @@ export class MainMenu {
     }
 
     const savedName = localStorage.getItem(STORAGE_KEY) ?? '';
-    const elements = createMenuView(savedName);
+    const savedSize = Number(localStorage.getItem(MATCH_SIZE_STORAGE_KEY) ?? '1');
+    const elements = createMenuView(
+      savedName,
+      isMatchTeamSize(savedSize) ? savedSize : 1,
+    );
     this.menu = elements;
 
     elements.nameInput.addEventListener('input', () => {
       const v = elements.nameInput.value.trim();
       if (v) localStorage.setItem(STORAGE_KEY, v);
+    });
+    elements.matchSizeSelect.addEventListener('change', () => {
+      localStorage.setItem(MATCH_SIZE_STORAGE_KEY, elements.matchSizeSelect.value);
     });
     // Skip auto-focus on mobile to avoid unwanted virtual keyboard on load
     if (!isTouchDevice()) {
@@ -34,8 +48,8 @@ export class MainMenu {
     }
 
     elements.playButton.addEventListener('click', () => {
-      this.saveName();
-      this.fadeOut(() => this.onPlay?.());
+      const selection = this.saveSelection();
+      this.fadeOut(() => this.onPlay?.(selection));
     });
   }
 
@@ -64,8 +78,13 @@ export class MainMenu {
     this.styleEl = null;
   }
 
-  private saveName(): void {
+  private saveSelection(): PlaySelection {
     const name = this.menu?.nameInput.value.trim();
-    if (name) localStorage.setItem(STORAGE_KEY, name);
+    const matchSizeValue = Number(this.menu?.matchSizeSelect.value ?? '1');
+    const teamSize = isMatchTeamSize(matchSizeValue) ? matchSizeValue : 1;
+    const finalName = name || 'Pilot';
+    localStorage.setItem(STORAGE_KEY, finalName);
+    localStorage.setItem(MATCH_SIZE_STORAGE_KEY, String(teamSize));
+    return { name: finalName, teamSize };
   }
 }

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -1,4 +1,5 @@
 import { isTouchDevice } from '../../platform';
+import type { MatchTeamSize } from '../../../../shared/match';
 
 /**
  * Main menu DOM view: injects the stylesheet on first use, builds the
@@ -178,6 +179,7 @@ export interface MenuElements {
   container: HTMLDivElement;
   root: HTMLElement;
   nameInput: HTMLInputElement;
+  matchSizeSelect: HTMLSelectElement;
   playButton: HTMLButtonElement;
 }
 
@@ -188,7 +190,7 @@ export function injectMenuStyle(): HTMLStyleElement {
   return style;
 }
 
-export function createMenuView(savedName: string): MenuElements {
+export function createMenuView(savedName: string, matchSize: MatchTeamSize): MenuElements {
   const mobile = isTouchDevice();
   const controlsHtml = mobile
     ? `Drag screen to look &nbsp;&middot;&nbsp; Left stick walks in gravity room<br>
@@ -223,6 +225,16 @@ export function createMenuView(savedName: string): MenuElements {
           autocomplete="off" inputmode="${mobile ? 'text' : 'text'}" />
       </div>
 
+      <div class="menu-section">
+        <div class="menu-label">Solo Match Size</div>
+        <select class="menu-input" id="menu-match-size" aria-label="Solo match size">
+          <option value="1" ${matchSize === 1 ? 'selected' : ''}>1v1 Skirmish</option>
+          <option value="5" ${matchSize === 5 ? 'selected' : ''}>5v5 Squad Clash</option>
+          <option value="10" ${matchSize === 10 ? 'selected' : ''}>10v10 Arena Rush</option>
+          <option value="20" ${matchSize === 20 ? 'selected' : ''}>20v20 Zero-G War</option>
+        </select>
+      </div>
+
       <div class="menu-divider"></div>
 
       <div class="menu-section">
@@ -240,6 +252,7 @@ export function createMenuView(savedName: string): MenuElements {
     container,
     root: container.querySelector<HTMLElement>('#menu-root')!,
     nameInput: container.querySelector<HTMLInputElement>('#menu-name')!,
+    matchSizeSelect: container.querySelector<HTMLSelectElement>('#menu-match-size')!,
     playButton: container.querySelector<HTMLButtonElement>('#btn-play')!,
   };
 }

--- a/docs/AI_BOTS_IMPLEMENTATION_PLAN.md
+++ b/docs/AI_BOTS_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,65 @@
+# AI Bots Implementation Plan
+
+This branch implements the local solo-with-bots phase and deliberately stops short of online multiplayer.
+
+---
+
+## Goals
+
+- Keep `PLAY SOLO` local-only
+- Support `1v1`, `5v5`, `10v10`, and `20v20` from the main menu
+- Fill remaining slots with bots, with the human fixed to Team Cyan
+- Add transport-neutral helpers that can be reused by the later Colyseus branch
+- Keep networking placeholder code unchanged on this branch
+
+---
+
+## Implemented Shape
+
+### Match Flow
+
+- Main menu now includes a solo match-size selector
+- Starting a game creates a local match config and fills rosters with bots
+- Each new round regenerates the arena, resets the human player, and resets all bots
+- Team score is tracked locally across rounds
+
+### Bot Runtime
+
+- Bots are rendered as lightweight non-human actors
+- Bot decision logic handles:
+  - bar selection toward the enemy portal
+  - grab -> aim -> launch flow
+  - breach-room walking toward the exit
+  - simple enemy targeting and shooting
+- Projectile hits now resolve against actors as well as geometry
+
+### Shared Reuse Surface
+
+- `shared/match.ts`: solo match-size and bot-fill helpers
+- `shared/player-logic.ts`: hit classification, damage application, launch-power, spawn helpers
+- `shared/vec3.ts`: plain vector math
+
+These are intentionally transport-neutral so the future server/client multiplayer work can adopt them without importing Three.js scene code.
+
+---
+
+## Non-Goals For This Branch
+
+- No room browser
+- No matchmaking
+- No Colyseus dependencies
+- No online lobby flow
+- No reconnect or deployment hardening
+
+---
+
+## Validation
+
+Current branch validation after implementation:
+
+- `npm test`
+- `.\client\node_modules\.bin\tsc.cmd -p client/tsconfig.json --noEmit`
+- `.\server\node_modules\.bin\tsc.cmd -p server/tsconfig.json --noEmit`
+- `cd client && npm run build`
+
+All of the above pass on this branch.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,102 +1,82 @@
-# Orbital Breach — Architecture Reference
+# Orbital Breach Architecture
 
-Post-refactor module map (as of `project-refactor`, commit `db5e8eb`).
-Each entry lists a module's **single responsibility** and its key exports.
-See `CLAUDE.md` for invariants, gotchas, and session workflow.
+This document describes the post-AI-bots branch structure.
 
 ---
 
-## Client — `client/src/`
+## Client
 
-### `game/` — game orchestration
-
-| File | Responsibility | Key export |
-|---|---|---|
-| `gameApp.ts` | Top-level `App` class; owns every subsystem, runs the 60fps loop | `App` |
-| `roundController.ts` | LOBBY→COUNTDOWN→PLAYING→ROUND_END state machine + timer | `RoundController` |
-| `projectileSystem.ts` | Visual projectile list: spawn, tick, cull, dispose | `ProjectileSystem` |
-| `weaponFire.ts` | Pure shot construction from camera + player state | `buildShotFromCamera` |
-| `cameraYawFromBreach.ts` | Pure yaw angle when spawning into a breach room | `cameraYawFacingBreachOpening` |
-| `gunTuneOverlay.ts` | Dev DOM overlay for third-person gun (feature flag gated) | `GunTuneOverlay` |
-
-`gameApp.ts` is the only file that imports from all other subsystems. Nothing else
-should import across subsystem boundaries (e.g. `player/` must not import from `game/`).
-
-### `player/` — local player model
-
-| File | Responsibility | Key export |
-|---|---|---|
-| `localPlayer.ts` | `LocalPlayer` facade — 6-phase state machine, physics integration | `LocalPlayer` |
-| `playerTypes.ts` | Shared type definitions | `HitZone`, `PoseBoneName`, `AnimatedRig` |
-| `playerAnimationController.ts` | AnimationMixer crossfades: idle, run, jump, grab, death | `PlayerAnimationController` |
-| `playerCombat.ts` | Hit-zone classification from bone name | `classifyHitZone` (pure) |
-| `playerGrabPose.ts` | Bar-hold bone Euler offsets + grip measurement | `applyBarHoldPose`, `measureLeftHandGripOffset` |
-| `playerThirdPersonGun.ts` | Third-person gun rig: attach, muzzle position, tuning | `ThirdPersonGun` |
-| `playerSpawn.ts` | Player reset for new rounds | `resetForNewRound` |
-
-`client/src/player.ts` is a thin re-export: `export { LocalPlayer } from './player/localPlayer'`.
-
-### `arena/` — arena geometry
-
-| File | Responsibility | Key export |
-|---|---|---|
-| `arena.ts` | Arena facade: layout, obstacles, portals, bars, walls | `Arena` |
-| `breachRoomQueries.ts` | Point-in-room tests for win condition & gravity switch | `isInBreachRoom`, `isDeepInBreachRoom` (pure, tested) |
-| `breachWalls.ts` | Build 5-wall enclosure for a breach room | `buildBreachWalls` (pure) |
-| `obstacleCollision.ts` | AABB bounce for floating obstacles | `bounceAgainstBoxes` (pure) |
-| `portalBars.ts` | Place grab bars on arena side of each portal opening | `placePortalArenaBars` |
-
-### `render/hud/` — HUD DOM
-
-| File | Responsibility | Key export |
-|---|---|---|
-| `hudView.ts` | Inject HUD DOM once; return typed element refs | `createHudView`, `HudElements` |
-| `scoreboard.ts` | Build scoreboard HTML string from player lists | `buildScoreboardHtml` (pure) |
-| `../hud.ts` | HUD controller: map `HudState` → DOM updates every frame | `HUD`, `HudState` |
-
-### `ui/menu/` — main menu
-
-| File | Responsibility | Key export |
-|---|---|---|
-| `menuView.ts` | Inject menu DOM + CSS animations; return element refs | `createMenuView`, `MenuElements` |
-| `../menu.ts` | Menu controller: show/hide/fadeOut/onPlay | `MainMenu` |
-
----
-
-## Server — `server/src/`
-
-### `net/` — network transport
-
-| File | Responsibility | Key export |
-|---|---|---|
-| `wsServer.ts` | Boot WebSocket server; route connection/message/close/error | `startWsServer` |
-| `messageCodec.ts` | Wire-format adapters between raw WS frames and typed objects | `parseClientMsg`, `sendState`, `sendEvent` |
-
-`server/src/index.ts` is a 15-line bootstrap — `Room` + `startWsServer` + log.
-All domain logic stays in `room.ts` / `sim.ts`; `wsServer.ts` contains no game state.
-
----
-
-## Shared — `shared/`
+### `client/src/game`
 
 | File | Responsibility |
 |---|---|
-| `arena-gen.ts` | `generateArenaLayout(seed)` — deterministic Mulberry32 RNG, symmetric obstacles (tested) |
-| `schema.ts` | Message types contract between client and server — change both sides atomically |
-| `constants.ts` | All numeric tuning values (FIRE_RATE, GRAB_RADIUS, TICK_RATE, …) |
-| `physics.ts` | `applyShotSpread` and shared physics math |
-| `player-logic.ts` | Shared movement/phase helpers used by both client and server |
-| `vec3.ts` | Lightweight Vec3 math with no Three.js dependency |
+| `gameApp.ts` | Main loop, menu start flow, round resets, HUD sync, projectile updates |
+| `projectileSystem.ts` | Visual projectiles plus nearest-hit resolution against obstacles, portal barriers, and actors |
+| `projectileActorCollision.ts` | Pure segment-vs-sphere collision helper for actor hits |
+| `weaponFire.ts` | Build human shot origin and direction from the camera and gun model |
+| `roundController.ts` | Countdown and round-end timing |
+
+### `client/src/match`
+
+| File | Responsibility |
+|---|---|
+| `localMatch.ts` | Local solo match authority for bot fill, bot state, scoring, and roster building |
+| `botBrain.ts` | Bot navigation and combat decisions |
+| `arenaQueryAdapter.ts` | Adapter from Three.js arena queries to transport-neutral shared helpers |
+| `rosterView.ts` | Pure HUD roster shaping for own team vs enemy team |
+| `simulatedPlayerAvatar.ts` | Lightweight non-human actor rendering |
+
+### `client/src/player`
+
+| File | Responsibility |
+|---|---|
+| `localPlayer.ts` | Human-controlled player movement, bar grabbing, launching, damage, and breach scoring |
+| `playerCombat.ts` | Pure hit-zone classification used by human-facing logic |
+| `playerSpawn.ts` | Breach-room spawn helpers |
+
+### `client/src/arena`
+
+| File | Responsibility |
+|---|---|
+| `arena.ts` | Arena facade for layout loading, obstacle collision, breach-room queries, portal barriers, and bar lookup |
+| `breachRoomQueries.ts` | Pure breach-room inside/depth checks |
+| `obstacleCollision.ts` | Pure obstacle bounce helper |
+
+### `client/src/ui` and `client/src/render`
+
+| File | Responsibility |
+|---|---|
+| `ui/menu.ts` / `ui/menu/menuView.ts` | Main menu controller and DOM view, including solo match-size selection |
+| `render/hud.ts` | HUD orchestration |
+| `render/hud/scoreboard.ts` | Pure scoreboard HTML builder with bot labels |
 
 ---
 
-## Key invariants — never change without understanding the consequences
+## Shared
 
-| Invariant | Location | Why it matters |
-|---|---|---|
-| `InputManager.consumeFire()` — LMB + fire-rate cooldown | `client/src/input.ts` | Previous charge-based attempts broke shooting entirely |
-| `player.phase = 'BREACH'` on portal entry (not FLOATING) | `player/localPlayer.ts` | Triggers gravity camera mode; stays FLOATING = camera never switches |
-| `cam.setZeroGMode(phase !== 'BREACH')` runs every frame | `game/gameApp.ts` | Must execute before `consumeMouseDelta` each tick |
-| `input.setAimingMode(active)` diverts `mouseDy → aimDy` | `client/src/input.ts` | Mouse Y = charge aim power during AIMING phase |
-| `TICK_RATE = 20 Hz` | `shared/constants.ts` | Changing it requires updating interpolation buffer delay |
-| `shared/schema.ts` is the client↔server contract | `shared/schema.ts` | Must update both sides atomically |
+| File | Responsibility |
+|---|---|
+| `shared/match.ts` | Solo match-size types and bot-fill helpers |
+| `shared/player-logic.ts` | Transport-neutral hit classification, launch-power calculation, and breach spawn logic |
+| `shared/vec3.ts` | Lightweight vector math with no Three.js dependency |
+| `shared/schema.ts` | Shared player/game types used by both local solo and future multiplayer work |
+| `shared/constants.ts` | Shared tuning values and bot-name pool |
+
+---
+
+## Server
+
+The current `server/` directory still represents placeholder transport infrastructure on this branch:
+
+- `server/src/net/wsServer.ts` and `server/src/net/messageCodec.ts` stay transport-only
+- `server/src/room.ts` and `server/src/sim.ts` are not expanded to power the bot phase
+- The later Colyseus lobby migration is intentionally deferred to the separate multiplayer branch
+
+---
+
+## Branch Intent
+
+- `feature/add-ai-bots`: local-only solo match flow with reusable shared gameplay helpers
+- `feature/add-colyseus-multiplayer`: future lobby-first online transport branch, refreshed from `staging` after AI bots merge
+
+The important boundary is that gameplay helpers can be shared later, but this branch does not introduce online room flow, matchmaking, or Colyseus dependencies.

--- a/docs/COLYSEUS_MULTIPLAYER_IMPLEMENTATION_PLAN.md
+++ b/docs/COLYSEUS_MULTIPLAYER_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,74 @@
+# Colyseus Multiplayer Implementation Plan
+
+This document is intentionally planning-only on `feature/add-ai-bots`. The actual implementation belongs on `feature/add-colyseus-multiplayer` after that branch is refreshed from `staging`.
+
+---
+
+## First Milestone
+
+Deliver one working Colyseus lobby room that can:
+
+- join a room
+- show roster
+- ready up
+- switch teams
+- optionally fill with bots
+- count down into a match
+- run a round
+- return to lobby-ready state after round end
+
+This phase does not need room browsing, public matchmaking, reconnect polish, or deployment hardening.
+
+---
+
+## Required Architectural Direction
+
+- Replace the placeholder WebSocket client/server path with Colyseus on the multiplayer branch only
+- Keep local solo mode as a separate offline path
+- Adapt Colyseus room state to shared gameplay helpers instead of re-embedding game rules in transport code
+- Reuse the AI-bot branch pieces where possible:
+  - `shared/match.ts`
+  - `shared/player-logic.ts`
+  - `shared/vec3.ts`
+  - bot logic concepts from `client/src/match/botBrain.ts`
+  - lightweight non-human actor rendering patterns from `client/src/match/simulatedPlayerAvatar.ts`
+
+---
+
+## Planned Work Items
+
+### Client
+
+- Replace `client/src/net/client.ts` stub with a Colyseus-backed implementation
+- Introduce client room join/leave lifecycle
+- Map Colyseus room state into HUD roster, score, countdown, and actor updates
+- Keep `PLAY SOLO` offline and separate from online room creation/joining
+
+### Server
+
+- Add Colyseus server dependency and room bootstrap
+- Build a lobby-capable room state model
+- Host team assignment, ready state, bot fill, countdown, and round transitions there
+- Move authoritative match state behind the room layer rather than raw WebSocket handlers
+
+### Shared Contracts
+
+- Introduce Colyseus room state classes or schemas for:
+  - lobby members
+  - team assignment
+  - room phase
+  - score
+  - actor snapshots
+  - round events
+
+Do not treat the current raw WebSocket DTOs as the long-term primary contract.
+
+---
+
+## Done Definition For The Future Branch
+
+- One room can host a full lobby-to-match-to-round-end flow
+- Solo offline mode still works
+- Bots can be added without duplicating gameplay rules
+- Client and server typechecks pass
+- Regression tests cover lobby transitions and offline solo start

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -34,6 +34,20 @@ export const ZERO_G_PORTAL_GRAVITY  = 1.5;
 export const COUNTDOWN_SECONDS      = 5;
 export const ROUND_END_DELAY        = 5;     // seconds before new round starts
 
+// Solo bot roster
+export const BOT_NAMES = [
+  'UNIT-7',
+  'GHOST-3',
+  'NOVA-5',
+  'DRIFT-1',
+  'ECHO-9',
+  'RIFT-2',
+  'LANCER-4',
+  'ORBIT-6',
+  'VOID-8',
+  'PULSE-0',
+] as const;
+
 // Obstacles
 export const OBSTACLE_MIN           = 14;
 export const OBSTACLE_MAX           = 22;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -33,6 +33,7 @@ export const ZERO_G_PORTAL_GRAVITY  = 1.5;
 // Game flow
 export const COUNTDOWN_SECONDS      = 5;
 export const ROUND_END_DELAY        = 5;     // seconds before new round starts
+export const ROUND_DURATION_SECONDS = 120;   // hard cap so every round ends
 
 // Solo bot roster
 export const BOT_NAMES = [

--- a/shared/match.ts
+++ b/shared/match.ts
@@ -1,0 +1,34 @@
+export const MATCH_TEAM_SIZES = [1, 5, 10, 20] as const;
+
+export type MatchTeamSize = (typeof MATCH_TEAM_SIZES)[number];
+
+export interface SoloMatchConfig {
+  humanName: string;
+  humanTeam: 0 | 1;
+  teamSize: MatchTeamSize;
+}
+
+export interface SoloBotFill {
+  team0Bots: number;
+  team1Bots: number;
+  totalBots: number;
+  totalPlayers: number;
+}
+
+export function isMatchTeamSize(value: number): value is MatchTeamSize {
+  return MATCH_TEAM_SIZES.includes(value as MatchTeamSize);
+}
+
+export function getSoloBotFill(
+  teamSize: MatchTeamSize,
+  humanTeam: 0 | 1 = 0,
+): SoloBotFill {
+  const team0Bots = teamSize - (humanTeam === 0 ? 1 : 0);
+  const team1Bots = teamSize - (humanTeam === 1 ? 1 : 0);
+  return {
+    team0Bots,
+    team1Bots,
+    totalBots: team0Bots + team1Bots,
+    totalPlayers: teamSize * 2,
+  };
+}

--- a/shared/player-logic.ts
+++ b/shared/player-logic.ts
@@ -2,6 +2,7 @@ import type { DamageState, PlayerPhase } from "./schema";
 import {
   BREACH_ROOM_D,
   BREACH_ROOM_H,
+  BREACH_ROOM_W,
   LEGS_HIT_LAUNCH_FACTOR,
   MAX_LAUNCH_SPEED,
   PLAYER_RADIUS,
@@ -20,6 +21,7 @@ export interface SharedArenaQuery {
   getBreachRoomCenter(team: 0 | 1): Vec3;
   getBreachOpenAxis(team: 0 | 1): "x" | "y" | "z";
   getBreachOpenSign(team: 0 | 1): 1 | -1;
+  getAllBarGrabPoints(): Vec3[];
   isGoalDoorOpen(team: 0 | 1): boolean;
   isInBreachRoom(pos: Vec3, team: 0 | 1): boolean;
   isDeepInBreachRoom(pos: Vec3, team: 0 | 1, depth: number): boolean;
@@ -33,6 +35,18 @@ export interface SharedPlayerState {
   launchPower: number;
   phase: PlayerPhase;
   vel: Vec3;
+}
+
+export interface FreezeCheckActor {
+  frozen: boolean;
+  team: 0 | 1;
+}
+
+export interface CollisionBody {
+  active?: boolean;
+  anchored?: boolean;
+  pos: Vec3;
+  radius: number;
 }
 
 export function classifyHitZone(
@@ -107,4 +121,240 @@ export function spawnPosition(
   const pos = { x: center.x, y: floorY, z: center.z };
   pos[openAxis] -= openSign * backOffset;
   return pos;
+}
+
+export function generateSpawnPositions(
+  team: 0 | 1,
+  count: number,
+  arena: Pick<SharedArenaQuery, "getBreachRoomCenter" | "getBreachOpenAxis" | "getBreachOpenSign">,
+  seed = 0,
+): Vec3[] {
+  if (count <= 0) return [];
+
+  const center = arena.getBreachRoomCenter(team);
+  const openAxis = arena.getBreachOpenAxis(team);
+  const openSign = arena.getBreachOpenSign(team);
+  const backDir = -openSign;
+  const rng = createSeededRandom(seed || team + 1);
+
+  const widthAxis: "x" | "z" = openAxis === "x" ? "z" : "x";
+  const usableWidth = BREACH_ROOM_W - PLAYER_RADIUS * 2 - 0.04;
+  const usableDepth = BREACH_ROOM_D - PLAYER_RADIUS * 2 - 0.08;
+  const widthHalf = usableWidth / 2;
+  const depthHalf = usableDepth / 2;
+  const minSpacing = PLAYER_RADIUS * 2 + 0.04;
+  const floorY = center.y - BREACH_ROOM_H / 2 + PLAYER_RADIUS + 0.08;
+  const ceilingY = center.y + BREACH_ROOM_H / 2 - PLAYER_RADIUS - 0.08;
+  const slots: Vec3[] = [];
+
+  let attempts = 0;
+  while (slots.length < count && attempts < 12000) {
+    attempts += 1;
+
+    const pos = { x: center.x, y: floorY, z: center.z };
+    pos[widthAxis] = center[widthAxis] + lerp(-widthHalf, widthHalf, rng());
+    pos.y = lerp(floorY, ceilingY, Math.pow(rng(), 0.92));
+    const localDepth = depthHalf - usableDepth * Math.pow(rng(), 0.78);
+    pos[openAxis] = center[openAxis] + localDepth * backDir;
+
+    if (slots.every((slot) => v3.dist(slot, pos) >= minSpacing)) {
+      slots.push(pos);
+    }
+  }
+
+  if (slots.length < count) {
+    const fallback = createSpawnLattice(
+      count - slots.length,
+      center,
+      openAxis,
+      widthAxis,
+      widthHalf,
+      depthHalf,
+      floorY,
+      ceilingY,
+      backDir,
+      minSpacing,
+    );
+    for (const slot of fallback) {
+      if (slots.every((existing) => v3.dist(existing, slot) >= minSpacing * 0.98)) {
+        slots.push(slot);
+      }
+      if (slots.length >= count) break;
+    }
+  }
+
+  relaxSpawnSlots(slots, openAxis, widthAxis, center, widthHalf, depthHalf, floorY, ceilingY, backDir, minSpacing);
+  return slots.slice(0, count);
+}
+
+export function findFullFreezeWinner(actors: FreezeCheckActor[]): 0 | 1 | null {
+  const team0 = actors.filter((actor) => actor.team === 0);
+  const team1 = actors.filter((actor) => actor.team === 1);
+  if (team0.length === 0 || team1.length === 0) return null;
+
+  const team0Frozen = team0.every((actor) => actor.frozen);
+  const team1Frozen = team1.every((actor) => actor.frozen);
+  if (team0Frozen === team1Frozen) return null;
+  return team0Frozen ? 1 : 0;
+}
+
+export function resolveActorCollisions(
+  actors: CollisionBody[],
+  iterations = 2,
+): boolean {
+  let moved = false;
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    for (let i = 0; i < actors.length; i += 1) {
+      const actor = actors[i];
+      if (actor.active === false) continue;
+
+      for (let j = i + 1; j < actors.length; j += 1) {
+        const other = actors[j];
+        if (other.active === false) continue;
+
+        const delta = v3.sub(other.pos, actor.pos);
+        const minDistance = actor.radius + other.radius;
+        const distSq = v3.lengthSq(delta);
+        if (distSq >= minDistance * minDistance) continue;
+
+        const normal = distSq > 1e-8
+          ? v3.scale(delta, 1 / Math.sqrt(distSq))
+          : fallbackCollisionNormal(i, j);
+        const distance = distSq > 1e-8 ? Math.sqrt(distSq) : 0;
+        const overlap = minDistance - distance;
+
+        let actorWeight = actor.anchored ? 0 : 1;
+        let otherWeight = other.anchored ? 0 : 1;
+        if (actorWeight + otherWeight <= 0) {
+          actorWeight = 1;
+          otherWeight = 1;
+        }
+
+        const actorPush = overlap * (actorWeight / (actorWeight + otherWeight));
+        const otherPush = overlap * (otherWeight / (actorWeight + otherWeight));
+
+        actor.pos.x -= normal.x * actorPush;
+        actor.pos.y -= normal.y * actorPush;
+        actor.pos.z -= normal.z * actorPush;
+
+        other.pos.x += normal.x * otherPush;
+        other.pos.y += normal.y * otherPush;
+        other.pos.z += normal.z * otherPush;
+        moved = true;
+      }
+    }
+  }
+
+  return moved;
+}
+
+function fallbackCollisionNormal(i: number, j: number): Vec3 {
+  const angle = ((i + 1) * 17 + (j + 1) * 31) * 0.37;
+  return {
+    x: Math.cos(angle),
+    y: 0,
+    z: Math.sin(angle),
+  };
+}
+
+function clampValue(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function relaxSpawnSlots(
+  slots: Vec3[],
+  depthAxis: "x" | "y" | "z",
+  widthAxis: "x" | "z",
+  center: Vec3,
+  widthHalf: number,
+  depthHalf: number,
+  floorY: number,
+  ceilingY: number,
+  backDir: number,
+  minSpacing: number,
+): void {
+  if (slots.length <= 1) return;
+
+  for (let iteration = 0; iteration < 16; iteration += 1) {
+    resolveActorCollisions(
+      slots.map((pos) => ({
+        pos,
+        radius: minSpacing / 2,
+      })),
+      1,
+    );
+
+    for (const slot of slots) {
+      const lateral = clampValue(slot[widthAxis] - center[widthAxis], -widthHalf, widthHalf);
+      const depth = clampValue((slot[depthAxis] - center[depthAxis]) * backDir, -depthHalf, depthHalf);
+      slot[widthAxis] = center[widthAxis] + lateral;
+      slot[depthAxis] = center[depthAxis] + depth * backDir;
+      slot.y = clampValue(slot.y, floorY, ceilingY);
+    }
+  }
+}
+
+function createSpawnLattice(
+  count: number,
+  center: Vec3,
+  depthAxis: "x" | "y" | "z",
+  widthAxis: "x" | "z",
+  widthHalf: number,
+  depthHalf: number,
+  floorY: number,
+  ceilingY: number,
+  backDir: number,
+  minSpacing: number,
+): Vec3[] {
+  const heightSpan = Math.max(0, ceilingY - floorY);
+  const positions: Vec3[] = [];
+  const widthStep = minSpacing;
+  const heightStep = minSpacing * 0.92;
+  const depthStep = minSpacing * 0.86;
+
+  for (let layer = 0; positions.length < count; layer += 1) {
+    const localDepth = Math.min(depthHalf, depthHalf - layer * depthStep);
+    if (localDepth < -depthHalf) break;
+
+    for (let row = 0; positions.length < count; row += 1) {
+      const y = floorY + row * heightStep;
+      if (y > ceilingY + 1e-6) break;
+
+      const rowShift = row % 2 === 0 ? 0 : widthStep * 0.5;
+      for (let col = 0; positions.length < count; col += 1) {
+        const x = -widthHalf + col * widthStep + rowShift;
+        if (x > widthHalf + 1e-6) break;
+
+        const pos = { x: center.x, y, z: center.z };
+        pos[widthAxis] = center[widthAxis] + x;
+        pos[depthAxis] = center[depthAxis] + localDepth * backDir;
+        positions.push(pos);
+      }
+    }
+  }
+
+  return positions;
+}
+
+function lerp(min: number, max: number, t: number): number {
+  return min + (max - min) * t;
+}
+
+function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffleInPlace<T>(items: T[], rng: () => number): void {
+  for (let i = items.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [items[i], items[j]] = [items[j], items[i]];
+  }
 }

--- a/shared/player-logic.ts
+++ b/shared/player-logic.ts
@@ -1,0 +1,110 @@
+import type { DamageState, PlayerPhase } from "./schema";
+import {
+  BREACH_ROOM_D,
+  BREACH_ROOM_H,
+  LEGS_HIT_LAUNCH_FACTOR,
+  MAX_LAUNCH_SPEED,
+  PLAYER_RADIUS,
+} from "./constants";
+import type { Vec3 } from "./vec3";
+import { v3 } from "./vec3";
+
+export type HitZone = "head" | "body" | "rightArm" | "leftArm" | "legs";
+
+export interface BarGrabPoint {
+  pos: Vec3;
+  normal?: Vec3;
+}
+
+export interface SharedArenaQuery {
+  getBreachRoomCenter(team: 0 | 1): Vec3;
+  getBreachOpenAxis(team: 0 | 1): "x" | "y" | "z";
+  getBreachOpenSign(team: 0 | 1): 1 | -1;
+  isGoalDoorOpen(team: 0 | 1): boolean;
+  isInBreachRoom(pos: Vec3, team: 0 | 1): boolean;
+  isDeepInBreachRoom(pos: Vec3, team: 0 | 1, depth: number): boolean;
+  getNearestBar(pos: Vec3, radius: number): BarGrabPoint | null;
+}
+
+export interface SharedPlayerState {
+  damage: DamageState;
+  deaths: number;
+  grabbedBarPos: Vec3 | null;
+  launchPower: number;
+  phase: PlayerPhase;
+  vel: Vec3;
+}
+
+export function classifyHitZone(
+  impactPoint: Vec3,
+  playerPos: Vec3,
+  playerFacing: Vec3,
+): HitZone {
+  const local = v3.sub(impactPoint, playerPos);
+  const yRel = local.y / PLAYER_RADIUS;
+
+  if (yRel > 0.55) return "head";
+  if (yRel > -0.2) {
+    const worldUp = { x: 0, y: 1, z: 0 };
+    const right = v3.normalize(v3.cross(playerFacing, worldUp));
+    const xProj = v3.dot(local, right);
+    if (xProj > 0.4) return "rightArm";
+    if (xProj < -0.4) return "leftArm";
+    return "body";
+  }
+  return "legs";
+}
+
+export function maxLaunchPower(damage: DamageState): number {
+  return damage.legs
+    ? MAX_LAUNCH_SPEED * LEGS_HIT_LAUNCH_FACTOR
+    : MAX_LAUNCH_SPEED;
+}
+
+export function applyHit(
+  state: SharedPlayerState,
+  zone: HitZone,
+  impulse: Vec3,
+): boolean {
+  state.vel = v3.add(state.vel, impulse);
+
+  switch (zone) {
+    case "head":
+    case "body":
+      if (!state.damage.frozen) {
+        state.damage.frozen = true;
+        state.deaths += 1;
+      }
+      state.phase = "FROZEN";
+      state.grabbedBarPos = null;
+      return true;
+    case "rightArm":
+      state.damage.rightArm = true;
+      return false;
+    case "leftArm":
+      state.damage.leftArm = true;
+      if (state.phase === "GRABBING" || state.phase === "AIMING") {
+        state.phase = "FLOATING";
+        state.grabbedBarPos = null;
+      }
+      return false;
+    case "legs":
+      state.damage.legs = true;
+      state.launchPower = Math.min(state.launchPower, maxLaunchPower(state.damage));
+      return false;
+  }
+}
+
+export function spawnPosition(
+  team: 0 | 1,
+  arena: Pick<SharedArenaQuery, "getBreachRoomCenter" | "getBreachOpenAxis" | "getBreachOpenSign">,
+): Vec3 {
+  const center = arena.getBreachRoomCenter(team);
+  const openAxis = arena.getBreachOpenAxis(team);
+  const openSign = arena.getBreachOpenSign(team);
+  const floorY = center.y - BREACH_ROOM_H / 2 + PLAYER_RADIUS + 0.1;
+  const backOffset = BREACH_ROOM_D / 2 - PLAYER_RADIUS - 0.5;
+  const pos = { x: center.x, y: floorY, z: center.z };
+  pos[openAxis] -= openSign * backOffset;
+  return pos;
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -47,6 +47,7 @@ export interface PlayerNetState {
   kills:     number;   // breaches scored
   deaths:    number;   // times frozen
   connected: boolean;  // false = ghost body (disconnected player still floating)
+  isBot?:    boolean;
 }
 
 // --- Score ---
@@ -87,6 +88,7 @@ export interface FullPlayerInfo {
   kills:  number;
   deaths: number;
   ping:   number;
+  isBot:  boolean;
 }
 
 export interface EnemyPlayerInfo {
@@ -96,6 +98,7 @@ export interface EnemyPlayerInfo {
   kills:  number;
   deaths: number;
   ping:   number;
+  isBot:  boolean;
 }
 
 export interface TabListMsg {

--- a/shared/vec3.ts
+++ b/shared/vec3.ts
@@ -1,0 +1,68 @@
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export const v3 = {
+  zero(): Vec3 {
+    return { x: 0, y: 0, z: 0 };
+  },
+
+  clone(a: Vec3): Vec3 {
+    return { x: a.x, y: a.y, z: a.z };
+  },
+
+  add(a: Vec3, b: Vec3): Vec3 {
+    return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+  },
+
+  sub(a: Vec3, b: Vec3): Vec3 {
+    return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+  },
+
+  scale(a: Vec3, s: number): Vec3 {
+    return { x: a.x * s, y: a.y * s, z: a.z * s };
+  },
+
+  addScaled(a: Vec3, b: Vec3, s: number): Vec3 {
+    return { x: a.x + b.x * s, y: a.y + b.y * s, z: a.z + b.z * s };
+  },
+
+  dot(a: Vec3, b: Vec3): number {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+  },
+
+  cross(a: Vec3, b: Vec3): Vec3 {
+    return {
+      x: a.y * b.z - a.z * b.y,
+      y: a.z * b.x - a.x * b.z,
+      z: a.x * b.y - a.y * b.x,
+    };
+  },
+
+  lengthSq(a: Vec3): number {
+    return a.x * a.x + a.y * a.y + a.z * a.z;
+  },
+
+  length(a: Vec3): number {
+    return Math.sqrt(v3.lengthSq(a));
+  },
+
+  normalize(a: Vec3): Vec3 {
+    const len = v3.length(a);
+    if (len <= 1e-10) return { x: 0, y: 0, z: 0 };
+    return { x: a.x / len, y: a.y / len, z: a.z / len };
+  },
+
+  distSq(a: Vec3, b: Vec3): number {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    const dz = a.z - b.z;
+    return dx * dx + dy * dy + dz * dz;
+  },
+
+  dist(a: Vec3, b: Vec3): number {
+    return Math.sqrt(v3.distSq(a, b));
+  },
+};

--- a/tests/botBrain.test.ts
+++ b/tests/botBrain.test.ts
@@ -1,5 +1,50 @@
 import { describe, expect, it } from "vitest";
-import { createBotPersonality, pickPreferredBar } from "../client/src/match/botBrain";
+import {
+  BotBrain,
+  buildBarGraph,
+  createBotPersonality,
+  pickPreferredBar,
+  type BotPersonality,
+} from "../client/src/match/botBrain";
+
+const TEST_ARENA = {
+  getAllBarGrabPoints: () => [],
+  getBreachOpenAxis: () => "z" as const,
+  getBreachOpenSign: (team: 0 | 1) => (team === 0 ? -1 : 1) as 1 | -1,
+  getBreachRoomCenter: (team: 0 | 1) => ({ x: 0, y: 0, z: team === 0 ? -16 : 16 }),
+  getNearestBar: () => null,
+  isDeepInBreachRoom: () => false,
+  isGoalDoorOpen: () => true,
+  isInBreachRoom: () => false,
+};
+
+function createTestPersonality(): BotPersonality {
+  return {
+    aimNoise: 0,
+    aimReleaseMax: 0.8,
+    aimReleaseMin: 0.7,
+    archetype: "hunter",
+    barDirectionWeight: 3,
+    barDistanceWeight: 1,
+    barLateralBias: 0.4,
+    barVerticalBias: 0,
+    breachForwardBias: 1,
+    breachStrafeAmplitude: 0.1,
+    breachWeaveSpeed: 1,
+    decisionInterval: 0.25,
+    enemyFocusBias: 0.8,
+    fireCooldown: 0.2,
+    fireRange: 30,
+    grabDecisionDelay: 0.05,
+    launchChargeSeconds: 0.8,
+    pathNoise: 0.15,
+    routeLengthMax: 3,
+    routeLengthMin: 2,
+    rngSeed: 99,
+    shotSpreadBase: 0.08,
+    weaveOffset: 0,
+  };
+}
 
 describe("pickPreferredBar", () => {
   it("prefers bars aligned with the portal direction", () => {
@@ -59,5 +104,60 @@ describe("createBotPersonality", () => {
         && first.launchChargeSeconds === second.launchChargeSeconds
         && first.barLateralBias === second.barLateralBias,
     ).toBe(false);
+  });
+});
+
+describe("BotBrain", () => {
+  it("plans a route through bars while floating", () => {
+    const graph = buildBarGraph([
+      { x: -6, y: 0, z: -4 },
+      { x: -2, y: 0, z: -9 },
+      { x: 2, y: 0, z: -13 },
+      { x: 6, y: 0, z: -18 },
+    ]);
+    const brain = new BotBrain(createTestPersonality());
+    brain.resetForRound(12);
+
+    const command = brain.tick(
+      {
+        currentBreachTeam: 0,
+        damage: { frozen: false, leftArm: false, rightArm: false, legs: false },
+        phase: "FLOATING",
+        pos: { x: 0, y: 0, z: 0 },
+        rot: { yaw: 0, pitch: 0 },
+        team: 0,
+      },
+      TEST_ARENA,
+      graph,
+      [],
+      0.16,
+    );
+
+    expect(command.targetBar).not.toBeNull();
+    expect(command.grab).toBe(false);
+  });
+
+  it("reseeds shot spread between rounds while keeping the same bot identity", () => {
+    const graph = buildBarGraph([{ x: 0, y: 0, z: -8 }]);
+    const brain = new BotBrain(createTestPersonality());
+    const bot = {
+      currentBreachTeam: 0 as const,
+      damage: { frozen: false, leftArm: false, rightArm: false, legs: false },
+      phase: "FLOATING" as const,
+      pos: { x: 0, y: 0, z: 0 },
+      rot: { yaw: 0, pitch: 0 },
+      team: 0 as const,
+    };
+    const enemies = [{ id: "enemy", phase: "FLOATING" as const, pos: { x: 0, y: 0, z: -12 }, team: 1 as const }];
+
+    brain.resetForRound(1);
+    const first = brain.tick(bot, TEST_ARENA, graph, enemies, 0.16);
+
+    brain.resetForRound(2);
+    const second = brain.tick(bot, TEST_ARENA, graph, enemies, 0.16);
+
+    expect(first.fireDirection).not.toBeNull();
+    expect(second.fireDirection).not.toBeNull();
+    expect(first.fireDirection).not.toEqual(second.fireDirection);
   });
 });

--- a/tests/botBrain.test.ts
+++ b/tests/botBrain.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { createBotPersonality, pickPreferredBar } from "../client/src/match/botBrain";
+
+describe("pickPreferredBar", () => {
+  it("prefers bars aligned with the portal direction", () => {
+    const choice = pickPreferredBar(
+      { x: 0, y: 0, z: 0 },
+      [
+        { x: -4, y: 0, z: 0 },
+        { x: 0, y: 0, z: -6 },
+        { x: 0, y: 0, z: 4 },
+      ],
+      { x: 0, y: 0, z: -1 },
+    );
+
+    expect(choice).toEqual({ x: 0, y: 0, z: -6 });
+  });
+
+  it("can bias different bots toward different lanes", () => {
+    const leftChoice = pickPreferredBar(
+      { x: 0, y: 0, z: 0 },
+      [
+        { x: -4, y: 0, z: -8 },
+        { x: 4, y: 0, z: -8 },
+      ],
+      { x: 0, y: 0, z: -1 },
+      { lateralBias: -2 },
+    );
+    const rightChoice = pickPreferredBar(
+      { x: 0, y: 0, z: 0 },
+      [
+        { x: -4, y: 0, z: -8 },
+        { x: 4, y: 0, z: -8 },
+      ],
+      { x: 0, y: 0, z: -1 },
+      { lateralBias: 2 },
+    );
+
+    expect(leftChoice).not.toBeNull();
+    expect(rightChoice).not.toBeNull();
+    expect(leftChoice).not.toEqual(rightChoice);
+  });
+});
+
+describe("createBotPersonality", () => {
+  it("is deterministic for the same bot id", () => {
+    const first = createBotPersonality("bot-magenta-3", 1);
+    const second = createBotPersonality("bot-magenta-3", 1);
+
+    expect(first).toEqual(second);
+  });
+
+  it("creates materially different behavior profiles across bots", () => {
+    const first = createBotPersonality("bot-cyan-0", 0);
+    const second = createBotPersonality("bot-cyan-1", 0);
+
+    expect(
+      first.archetype === second.archetype
+        && first.launchChargeSeconds === second.launchChargeSeconds
+        && first.barLateralBias === second.barLateralBias,
+    ).toBe(false);
+  });
+});

--- a/tests/localMatch.test.ts
+++ b/tests/localMatch.test.ts
@@ -22,6 +22,7 @@ interface FakePlayer {
   kills: number;
   phase: "BREACH" | "FLOATING" | "FROZEN";
   phys: { vel: THREE.Vector3 };
+  resetForNewRound: ReturnType<typeof vi.fn>;
   team: 0 | 1;
   applyHit: ReturnType<typeof vi.fn>;
   getPosition: () => THREE.Vector3;
@@ -35,6 +36,7 @@ function createFakePlayer(team: 0 | 1 = 0): FakePlayer {
     kills: 0,
     phase: "BREACH",
     phys: { vel: new THREE.Vector3() },
+    resetForNewRound: vi.fn(),
     team,
     applyHit: vi.fn(() => false),
     getPosition: () => new THREE.Vector3(0, 0, 0),
@@ -114,6 +116,29 @@ describe("LocalMatch", () => {
       },
     ]);
     expect(match.getScore()).toEqual({ team0: 0, team1: 0 });
+  });
+
+  it("normalizes round spawn slots onto the breach-room floor", () => {
+    const player = createFakePlayer();
+    const arena = {
+      getAllBarGrabPoints: () => [],
+      getBreachOpenAxis: () => "x" as const,
+      getBreachOpenSign: (team: 0 | 1) => (team === 0 ? -1 : 1) as 1 | -1,
+      getBreachRoomCenter: (team: 0 | 1) => new THREE.Vector3(team === 0 ? -18 : 18, 0, 0),
+      getNearestBar: () => null,
+      isDeepInBreachRoom: () => false,
+      isGoalDoorOpen: () => false,
+      isInBreachRoom: () => true,
+    };
+
+    match.resetForRound(arena as never, player as never);
+
+    const playerSpawn = player.resetForNewRound.mock.calls[0]?.[1];
+    const bots = (match as unknown as { bots: Array<{ phys: { pos: THREE.Vector3 } }> }).bots;
+
+    expect(playerSpawn).toBeDefined();
+    expect(playerSpawn.y).toBeCloseTo(-2.12, 4);
+    expect(bots.every((bot) => Math.abs(bot.phys.pos.y + 2.12) < 1e-4)).toBe(true);
   });
 
   it("emits a score event for breach wins", () => {

--- a/tests/localMatch.test.ts
+++ b/tests/localMatch.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as THREE from "three";
+
+vi.mock("../client/src/match/simulatedPlayerAvatar", () => ({
+  SimulatedPlayerAvatar: class {
+    public constructor() {}
+    public dispose(): void {}
+    public update(): void {}
+  },
+}));
+
+vi.mock("../client/src/player", () => ({
+  LocalPlayer: class {},
+}));
+
+import { LocalMatch, type LocalMatchEvent } from "../client/src/match/localMatch";
+
+interface FakePlayer {
+  currentBreachTeam: 0 | 1;
+  damage: { frozen: boolean; leftArm: boolean; rightArm: boolean; legs: boolean };
+  deaths: number;
+  kills: number;
+  phase: "BREACH" | "FLOATING" | "FROZEN";
+  phys: { vel: THREE.Vector3 };
+  team: 0 | 1;
+  applyHit: ReturnType<typeof vi.fn>;
+  getPosition: () => THREE.Vector3;
+}
+
+function createFakePlayer(team: 0 | 1 = 0): FakePlayer {
+  return {
+    currentBreachTeam: team,
+    damage: { frozen: false, leftArm: false, rightArm: false, legs: false },
+    deaths: 0,
+    kills: 0,
+    phase: "BREACH",
+    phys: { vel: new THREE.Vector3() },
+    team,
+    applyHit: vi.fn(() => false),
+    getPosition: () => new THREE.Vector3(0, 0, 0),
+  };
+}
+
+describe("LocalMatch", () => {
+  let events: LocalMatchEvent[];
+  let match: LocalMatch;
+
+  beforeEach(() => {
+    events = [];
+    match = new LocalMatch(new THREE.Scene());
+    match.onEvent = (event) => events.push(event);
+    match.startNewGame({
+      humanName: "Pilot",
+      humanTeam: 0,
+      teamSize: 1,
+    });
+  });
+
+  it("awards an immediate round win when the last enemy is frozen", () => {
+    const player = createFakePlayer();
+    const enemyBot = (match as unknown as { bots: Array<{ id: string; name: string; phys: { pos: THREE.Vector3 } }> }).bots[0];
+
+    match.handleProjectileHit(
+      {
+        direction: new THREE.Vector3(1, 0, 0),
+        impactPoint: enemyBot.phys.pos.clone(),
+        ownerId: "local-player",
+        targetId: enemyBot.id,
+      },
+      player as never,
+      {} as never,
+    );
+
+    expect(events).toEqual([
+      {
+        type: "hitConfirm",
+        team: 0,
+      },
+      {
+        type: "freeze",
+        killerName: "Pilot",
+        killerTeam: 0,
+        victimName: enemyBot.name,
+        victimTeam: 1,
+      },
+      {
+        type: "roundWin",
+        winningTeam: 0,
+        reason: "fullFreeze",
+      },
+    ]);
+    expect(match.getScore()).toEqual({ team0: 1, team1: 0 });
+  });
+
+  it("emits a hit confirm when the local player lands a non-freezing hit", () => {
+    const player = createFakePlayer();
+    const enemyBot = (match as unknown as { bots: Array<{ id: string; phys: { pos: THREE.Vector3 } }> }).bots[0];
+
+    match.handleProjectileHit(
+      {
+        direction: new THREE.Vector3(1, 0, 0),
+        impactPoint: enemyBot.phys.pos.clone().add(new THREE.Vector3(0, -0.7, 0)),
+        ownerId: "local-player",
+        targetId: enemyBot.id,
+      },
+      player as never,
+      {} as never,
+    );
+
+    expect(events).toEqual([
+      {
+        type: "hitConfirm",
+        team: 0,
+      },
+    ]);
+    expect(match.getScore()).toEqual({ team0: 0, team1: 0 });
+  });
+
+  it("emits a score event for breach wins", () => {
+    (match as unknown as { awardRoundPoint: (team: 0 | 1, scorerName: string, reason: "breach" | "fullFreeze") => void })
+      .awardRoundPoint(0, "Pilot", "breach");
+
+    expect(events).toEqual([
+      {
+        type: "score",
+        scorerName: "Pilot",
+        scorerTeam: 0,
+      },
+      {
+        type: "roundWin",
+        winningTeam: 0,
+        reason: "breach",
+      },
+    ]);
+    expect(match.getScore()).toEqual({ team0: 1, team1: 0 });
+  });
+
+  it("emits a tie without awarding points on timeout", () => {
+    match.handleRoundTimeout();
+    match.handleRoundTimeout();
+
+    expect(events).toEqual([{ type: "roundTie" }]);
+    expect(match.getScore()).toEqual({ team0: 0, team1: 0 });
+  });
+});

--- a/tests/match.test.ts
+++ b/tests/match.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { getSoloBotFill } from "../shared/match";
+import { buildHudRosters } from "../client/src/match/rosterView";
+
+describe("getSoloBotFill", () => {
+  it("fills a 1v1 skirmish with one enemy bot", () => {
+    expect(getSoloBotFill(1, 0)).toEqual({
+      team0Bots: 0,
+      team1Bots: 1,
+      totalBots: 1,
+      totalPlayers: 2,
+    });
+  });
+
+  it("fills larger formats around the human on team 0", () => {
+    expect(getSoloBotFill(5, 0)).toEqual({
+      team0Bots: 4,
+      team1Bots: 5,
+      totalBots: 9,
+      totalPlayers: 10,
+    });
+    expect(getSoloBotFill(10, 0).totalBots).toBe(19);
+    expect(getSoloBotFill(20, 0).totalBots).toBe(39);
+  });
+});
+
+describe("buildHudRosters", () => {
+  it("keeps the local player first and preserves bot labels", () => {
+    const rosters = buildHudRosters("local-player", 0, [
+      {
+        id: "bot-1",
+        name: "UNIT-7",
+        team: 1,
+        isBot: true,
+        kills: 0,
+        deaths: 1,
+        phase: "FLOATING",
+        frozen: false,
+        ping: 0,
+      },
+      {
+        id: "local-player",
+        name: "Pilot",
+        team: 0,
+        isBot: false,
+        kills: 2,
+        deaths: 0,
+        phase: "BREACH",
+        frozen: false,
+        ping: 0,
+      },
+      {
+        id: "bot-2",
+        name: "NOVA-5",
+        team: 0,
+        isBot: true,
+        kills: 1,
+        deaths: 0,
+        phase: "FROZEN",
+        frozen: true,
+        ping: 0,
+      },
+    ]);
+
+    expect(rosters.ownTeam[0]).toMatchObject({ id: "local-player", isBot: false });
+    expect(rosters.ownTeam[1]).toMatchObject({ id: "bot-2", isBot: true, frozen: true });
+    expect(rosters.enemyTeam[0]).toMatchObject({ id: "bot-1", isBot: true });
+  });
+});

--- a/tests/playerLogic.test.ts
+++ b/tests/playerLogic.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { classifyHitZone, applyHit, maxLaunchPower, spawnPosition } from "../shared/player-logic";
+import { MAX_LAUNCH_SPEED, LEGS_HIT_LAUNCH_FACTOR } from "../shared/constants";
+
+describe("classifyHitZone", () => {
+  const playerPos = { x: 0, y: 0, z: 0 };
+  const facing = { x: 0, y: 0, z: -1 };
+
+  it("classifies head and legs hits", () => {
+    expect(classifyHitZone({ x: 0, y: 0.8, z: 0 }, playerPos, facing)).toBe("head");
+    expect(classifyHitZone({ x: 0, y: -0.4, z: 0 }, playerPos, facing)).toBe("legs");
+  });
+
+  it("classifies right arm hits relative to facing", () => {
+    expect(classifyHitZone({ x: 0.5, y: 0.1, z: 0 }, playerPos, facing)).toBe("rightArm");
+  });
+});
+
+describe("maxLaunchPower", () => {
+  it("drops launch power after leg damage", () => {
+    expect(maxLaunchPower({ frozen: false, leftArm: false, rightArm: false, legs: false })).toBe(MAX_LAUNCH_SPEED);
+    expect(maxLaunchPower({ frozen: false, leftArm: false, rightArm: false, legs: true })).toBe(
+      MAX_LAUNCH_SPEED * LEGS_HIT_LAUNCH_FACTOR,
+    );
+  });
+});
+
+describe("applyHit", () => {
+  it("freezes a player on body hits and clears grab state", () => {
+    const state = {
+      damage: { frozen: false, leftArm: false, rightArm: false, legs: false },
+      deaths: 0,
+      grabbedBarPos: { x: 1, y: 2, z: 3 },
+      launchPower: 5,
+      phase: "AIMING" as const,
+      vel: { x: 0, y: 0, z: 0 },
+    };
+
+    const killed = applyHit(state, "body", { x: 1, y: 0, z: 0 });
+    expect(killed).toBe(true);
+    expect(state.phase).toBe("FROZEN");
+    expect(state.damage.frozen).toBe(true);
+    expect(state.grabbedBarPos).toBeNull();
+    expect(state.deaths).toBe(1);
+  });
+});
+
+describe("spawnPosition", () => {
+  it("spawns a player at the back of their breach room for round reset", () => {
+    const pos = spawnPosition(0, {
+      getBreachRoomCenter: () => ({ x: 23, y: 0, z: 0 }),
+      getBreachOpenAxis: () => "x",
+      getBreachOpenSign: () => -1,
+    });
+
+    expect(pos.x).toBeGreaterThan(23);
+    expect(pos.y).toBeGreaterThan(-3);
+  });
+});

--- a/tests/playerLogic.test.ts
+++ b/tests/playerLogic.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { classifyHitZone, applyHit, maxLaunchPower, spawnPosition } from "../shared/player-logic";
+import {
+  classifyHitZone,
+  applyHit,
+  generateSpawnPositions,
+  maxLaunchPower,
+  resolveActorCollisions,
+  spawnPosition,
+} from "../shared/player-logic";
 import { MAX_LAUNCH_SPEED, LEGS_HIT_LAUNCH_FACTOR } from "../shared/constants";
 
 describe("classifyHitZone", () => {
@@ -55,5 +62,49 @@ describe("spawnPosition", () => {
 
     expect(pos.x).toBeGreaterThan(23);
     expect(pos.y).toBeGreaterThan(-3);
+  });
+});
+
+describe("generateSpawnPositions", () => {
+  it("scatters a full 20-player team without overlap", () => {
+    const slots = generateSpawnPositions(0, 20, {
+      getBreachRoomCenter: () => ({ x: 12, y: 0, z: -6 }),
+      getBreachOpenAxis: () => "x",
+      getBreachOpenSign: () => -1,
+    }, 1234);
+
+    expect(slots).toHaveLength(20);
+
+    for (let i = 0; i < slots.length; i += 1) {
+      for (let j = i + 1; j < slots.length; j += 1) {
+        const dx = slots[i].x - slots[j].x;
+        const dy = slots[i].y - slots[j].y;
+        const dz = slots[i].z - slots[j].z;
+        const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        expect(distance).toBeGreaterThanOrEqual(1.6);
+      }
+    }
+  });
+});
+
+describe("resolveActorCollisions", () => {
+  it("separates overlapping bodies and keeps anchored bodies nearly fixed", () => {
+    const bodies = [
+      {
+        anchored: true,
+        pos: { x: 0, y: 0, z: 0 },
+        radius: 0.8,
+      },
+      {
+        pos: { x: 0.3, y: 0, z: 0 },
+        radius: 0.8,
+      },
+    ];
+
+    const moved = resolveActorCollisions(bodies, 2);
+
+    expect(moved).toBe(true);
+    expect(bodies[0].pos.x).toBeCloseTo(0, 4);
+    expect(bodies[1].pos.x).toBeGreaterThanOrEqual(1.59);
   });
 });

--- a/tests/projectileActorCollision.test.ts
+++ b/tests/projectileActorCollision.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { segmentSphereHitPoint } from "../client/src/game/projectileActorCollision";
+
+describe("segmentSphereHitPoint", () => {
+  it("finds the first hit point on a player sphere", () => {
+    const hit = segmentSphereHitPoint(
+      new THREE.Vector3(-2, 0, 0),
+      new THREE.Vector3(2, 0, 0),
+      new THREE.Vector3(0, 0, 0),
+      1,
+    );
+
+    expect(hit?.x).toBeCloseTo(-1, 5);
+    expect(hit?.y).toBeCloseTo(0, 5);
+    expect(hit?.z).toBeCloseTo(0, 5);
+  });
+
+  it("returns null when the segment misses", () => {
+    const hit = segmentSphereHitPoint(
+      new THREE.Vector3(-2, 3, 0),
+      new THREE.Vector3(2, 3, 0),
+      new THREE.Vector3(0, 0, 0),
+      1,
+    );
+
+    expect(hit).toBeNull();
+  });
+});

--- a/tests/roundController.test.ts
+++ b/tests/roundController.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { COUNTDOWN_SECONDS, ROUND_DURATION_SECONDS } from "../shared/constants";
+import { RoundController } from "../client/src/game/roundController";
+
+describe("RoundController", () => {
+  it("starts the round timer only after countdown ends", () => {
+    const round = new RoundController();
+    const onTimeout = vi.fn();
+    round.onRoundTimeout = onTimeout;
+
+    round.startCountdown();
+    round.tick(COUNTDOWN_SECONDS);
+
+    expect(round.getPhase()).toBe("PLAYING");
+    expect(round.getRoundTimeRemaining()).toBe(ROUND_DURATION_SECONDS);
+
+    round.tick(ROUND_DURATION_SECONDS);
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(round.getRoundTimeRemaining()).toBe(0);
+  });
+
+  it("resets the playing timer when a new round countdown begins", () => {
+    const round = new RoundController();
+
+    round.startCountdown();
+    round.tick(COUNTDOWN_SECONDS);
+    round.tick(30);
+    expect(round.getRoundTimeRemaining()).toBe(ROUND_DURATION_SECONDS - 30);
+
+    round.startCountdown();
+    expect(round.getPhase()).toBe("COUNTDOWN");
+    expect(round.getRoundTimeRemaining()).toBe(ROUND_DURATION_SECONDS);
+  });
+});


### PR DESCRIPTION
## What changed
- adds the solo AI bots phase to the release branch, including local match simulation, roster-aware HUD updates, bot routing, shared gameplay helpers, and the implementation docs under `docs/`
- promotes the bot visual/gameplay polish pass: shared alien+pistol bot rendering, kill feed, hit confirm, freeze glow, full-freeze wins, round timeout handling, and improved projectile FX performance
- includes the latest staging fixes for breach-floor bot spawns, passive bot simulation outside active play, thaw-on-home-breach, hidden lobby score, visible 2-minute round clock, and team-colored score ornaments

## Why
- this promotes the completed and validated solo AI bots milestone from `staging` toward `main` so multiplayer work can continue from a stable release baseline

## Validation
- `npx vitest run` (`68/68`)
- client TypeScript check
- server TypeScript check
- `npm run build` in `client`

## Notes
- client build still reports the existing Vite large-chunk warning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added solo play mode with AI bot opponents in multiple match sizes (1v1, 5v5, 10v10, 20v20).
  * Added match-size selector to the main menu.
  * Added round timer to HUD.
  * Added hit-confirmation visual feedback (crosshair pulse).
  * Added damage glow effects on players when hit.
  * Bot names now display in scoreboard.

* **Documentation**
  * Updated README with solo bot mode details and local setup validation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->