### PR TITLE
feat: frontend upgrade — command-console design, briefing lobby, debrief screen, tutorial mode

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -28,6 +28,7 @@ import { buildShotFromCamera } from "./weaponFire";
 import { NetClient } from "../net/client";
 import { MultiplayerLobby } from "../ui/multiplayerLobby";
 import type { PlaySelection } from "../ui/menu";
+import { DebriefScreen, type DebriefData, type DebriefPlayer } from "../ui/debrief";
 
 const PLAYER_UPDATE_RATE = 0.05; // 20hz
 
@@ -36,6 +37,7 @@ export class App {
   private onlineGameActive = false;
   private matchOver = false;
   private helpVisible = false;
+  private lastSoloSelection: PlaySelection | null = null;
   private matchEndHandle: ReturnType<typeof setTimeout> | null = null;
   private playerUpdateTimer = 0;
   private latestOnlineSnapshot: MultiplayerRoomSnapshot | null = null;
@@ -54,6 +56,7 @@ export class App {
   private lastTime = 0;
   private match: LocalMatch;
   private menu: MainMenu;
+  private debrief = new DebriefScreen();
   private multiplayer = new MultiplayerLobby();
   private onlineMatch: OnlineMatch;
   private readonly mobile = isTouchDevice();
@@ -123,6 +126,15 @@ export class App {
     };
     this.sessionMenu.onSettingsChange = (settings) => {
       this.applySessionSettings(settings);
+    };
+
+    this.debrief.onMainMenu = () => this.returnToMenuFromSolo();
+    this.debrief.onPlayAgain = () => {
+      if (this.lastSoloSelection) {
+        this.startSoloMatch(this.lastSoloSelection);
+      } else {
+        this.returnToMenuFromSolo();
+      }
     };
 
     this.net.onStateChange = (snapshot) => {
@@ -718,8 +730,6 @@ export class App {
     winningTeam: 0 | 1,
     finalScore: { team0: number; team1: number },
   ): void {
-    // onRoundWin already ran and scheduled the next round via round.endRound();
-    // override that so we show the match result and go back to menu instead.
     this.matchOver = true;
     this.round.cancelPendingRestart();
     const label = winningTeam === 0 ? "CYAN" : "MAGENTA";
@@ -729,12 +739,59 @@ export class App {
     if (this.matchEndHandle) clearTimeout(this.matchEndHandle);
     this.matchEndHandle = setTimeout(() => {
       this.matchEndHandle = null;
-      this.returnToMenuFromSolo();
+      this.showSoloDebrief(winningTeam, finalScore);
     }, MATCH_END_DELAY * 1000);
+  }
+
+  private showSoloDebrief(
+    winningTeam: 0 | 1,
+    finalScore: { team0: number; team1: number },
+  ): void {
+    const rosters = this.match.getHudRosters(this.player);
+    const playerTeam = this.player.team;
+    const enemyTeam = (1 - playerTeam) as 0 | 1;
+
+    const ownPlayers: DebriefPlayer[] = rosters.ownTeam.map((p) => ({
+      id: p.id,
+      name: p.name,
+      team: playerTeam,
+      breaches: p.kills,
+      frozen: p.deaths,
+      isBot: p.isBot,
+      isSelf: p.id === "local-player",
+    }));
+    const enemyPlayers: DebriefPlayer[] = rosters.enemyTeam.map((p) => ({
+      id: p.id,
+      name: p.name,
+      team: enemyTeam,
+      breaches: p.kills,
+      frozen: p.deaths,
+      isBot: p.isBot,
+      isSelf: false,
+    }));
+
+    const teamSize = this.lastSoloSelection?.teamSize ?? 1;
+    const sizeLabelMap: Record<number, string> = {
+      1: "1v1 Duel", 2: "2v2 Duos", 5: "5v5 Squads", 10: "10v10 Rush", 20: "20v20 War",
+    };
+
+    const debriefData: DebriefData = {
+      winningTeam,
+      score: finalScore,
+      players: [...ownPlayers, ...enemyPlayers],
+      playerTeam,
+      matchLabel: `${sizeLabelMap[teamSize] ?? "Solo"} · ${finalScore.team0} – ${finalScore.team1}`,
+    };
+
+    this.hud.setVisible(false);
+    this.hud.hideRoundEnd();
+    this.killFeed.setVisible(false);
+    this.debrief.show(debriefData);
   }
 
   private returnToMenuFromSolo(): void {
     this.closeSessionMenu();
+    this.debrief.hide();
     this.appMode = "menu";
     this.matchOver = false;
     this.projectiles.clear();
@@ -830,6 +887,8 @@ export class App {
   }
 
   private startSoloMatch(selection: PlaySelection): void {
+    this.lastSoloSelection = selection;
+    this.debrief.hide();
     this.appMode = "solo";
     this.matchOver = false;
     this.onlineBreachReported = false;

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -35,6 +35,7 @@ export class App {
   private appMode: "menu" | "solo" | "online" = "menu";
   private onlineGameActive = false;
   private matchOver = false;
+  private helpVisible = false;
   private matchEndHandle: ReturnType<typeof setTimeout> | null = null;
   private playerUpdateTimer = 0;
   private latestOnlineSnapshot: MultiplayerRoomSnapshot | null = null;
@@ -261,6 +262,9 @@ export class App {
     this.menu.onPlayOnline = (selection) => {
       void this.startOnlineLobby(selection);
     };
+    this.menu.onPlayTutorial = (selection) => {
+      this.startTutorialMatch(selection);
+    };
 
     requestAnimationFrame((timestamp) => this.loop(timestamp));
   }
@@ -277,6 +281,10 @@ export class App {
       } else if (this.appMode !== "menu") {
         this.openSessionMenu();
       }
+    }
+
+    if (this.input.consumeHelpPressed() && this.appMode !== "menu") {
+      this.helpVisible = !this.helpVisible;
     }
 
     if (this.appMode === "solo") {
@@ -609,6 +617,7 @@ export class App {
         phase: this.player.phase,
         team: this.player.team,
       }),
+      helpVisible: this.helpVisible,
       dt,
       team: this.player.team,
     });
@@ -667,6 +676,7 @@ export class App {
         phase: this.player.phase,
         team: this.player.team,
       }),
+      helpVisible: this.helpVisible,
       dt,
       team: this.player.team,
     });
@@ -814,10 +824,16 @@ export class App {
 
   // ── Solo match start ────────────────────────────────────────────────────────
 
+  private startTutorialMatch(selection: PlaySelection): void {
+    this.tutorial.forceRestart();
+    this.startSoloMatch({ ...selection, teamSize: 1, noBots: true });
+  }
+
   private startSoloMatch(selection: PlaySelection): void {
     this.appMode = "solo";
     this.matchOver = false;
     this.onlineBreachReported = false;
+    this.helpVisible = false;
     this.tutorial.beginRun();
     if (this.matchEndHandle) {
       clearTimeout(this.matchEndHandle);
@@ -833,6 +849,7 @@ export class App {
       humanName: selection.name,
       humanTeam: 0,
       teamSize: selection.teamSize,
+      noBots: selection.noBots,
     });
 
     if (this.mobile) {

--- a/client/src/input.ts
+++ b/client/src/input.ts
@@ -14,6 +14,7 @@ export class InputManager {
   private gunTuneResetPressed = false;
   private gunTunePrintPressed = false;
   private menuTogglePressed = false;
+  private helpPressed = false;
 
   // Mobile touch input state
   private touchLookDx = 0;
@@ -33,6 +34,7 @@ export class InputManager {
       if (e.code === 'KeyP' && !e.repeat) this.gunTuneTogglePressed = true;
       if (e.code === 'Enter' && !e.repeat) this.gunTunePrintPressed = true;
       if (e.code === 'Escape' && !e.repeat) this.menuTogglePressed = true;
+      if (e.code === 'KeyH'   && !e.repeat) this.helpPressed = true;
       // Only intercept navigation/delete keys when focus is NOT in a text field,
       // so the Call Sign input and other fields retain normal keyboard behaviour.
       const tag = (document.activeElement as HTMLElement | null)?.tagName ?? '';
@@ -263,6 +265,12 @@ export class InputManager {
     const v = this.menuTogglePressed;
     this.menuTogglePressed = false;
     return v;
+  }
+
+  public consumeHelpPressed(): boolean {
+    const v = this.helpPressed;
+    this.helpPressed = false;
+    return v && !this.uiBlocked;
   }
 
   public getGunTuneAxes(): {

--- a/client/src/match/localMatch.ts
+++ b/client/src/match/localMatch.ts
@@ -507,6 +507,8 @@ export class LocalMatch {
   private rebuildBots(): void {
     this.dispose();
 
+    if (this.config.noBots) return;
+
     const fill = getSoloBotFill(this.config.teamSize, this.config.humanTeam);
     const makeName = (index: number): string => {
       const base = BOT_NAMES[index % BOT_NAMES.length];

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -24,6 +24,7 @@ export interface HudState {
   ownTeam: FullPlayerInfo[];
   enemyTeam: EnemyPlayerInfo[];
   tutorialPrompt: TutorialPrompt | null;
+  helpVisible: boolean;
   dt: number;
   team: 0 | 1;
 }
@@ -79,6 +80,7 @@ export class HUD {
     this.renderDamage(state.damage);
     this.renderTutorial(state.phase, state.tutorialPrompt, state.team);
     this.renderScoreboard(state.tabHeld, state.ownTeam, state.enemyTeam, state.showPing, state.team);
+    this.view.help.classList.toggle("ob-help-visible", state.helpVisible);
   }
 
   private renderScore(

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -40,18 +40,18 @@ const HUD_MARKUP = `
 `;
 
 const HUD_CSS = `
-  @import url('https://fonts.googleapis.com/css2?family=Oxanium:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300&family=JetBrains+Mono:wght@300;400;500&display=swap');
 
   .ob-hud-root {
-    --hud-cyan: #74f5ff;
-    --hud-cyan-soft: rgba(116, 245, 255, 0.14);
-    --hud-magenta: #ff82ef;
-    --hud-magenta-soft: rgba(255, 130, 239, 0.16);
-    --hud-text: #f3fdff;
-    --hud-muted: #9db8c8;
-    --hud-panel: rgba(5, 12, 18, 0.74);
-    --hud-panel-strong: rgba(3, 9, 14, 0.9);
-    --hud-panel-border: rgba(130, 232, 255, 0.18);
+    --hud-cyan: oklch(0.82 0.15 210);
+    --hud-cyan-soft: oklch(0.82 0.15 210 / 0.14);
+    --hud-magenta: oklch(0.72 0.25 330);
+    --hud-magenta-soft: oklch(0.72 0.25 330 / 0.22);
+    --hud-text: #e8ecf4;
+    --hud-muted: #9aa5b8;
+    --hud-panel: rgba(7, 10, 18, 0.76);
+    --hud-panel-strong: rgba(7, 10, 18, 0.92);
+    --hud-panel-border: rgba(210, 220, 240, 0.16);
     --hud-shadow: 0 18px 44px rgba(0, 0, 0, 0.34);
     position: fixed;
     inset: 0;
@@ -59,7 +59,7 @@ const HUD_CSS = `
     pointer-events: none;
     user-select: none;
     color: var(--hud-text);
-    font-family: "Oxanium", sans-serif;
+    font-family: "Cormorant Garamond", serif;
   }
 
   .ob-hud-root * {
@@ -120,20 +120,21 @@ const HUD_CSS = `
 
   .ob-score-value {
     min-width: 112px;
-    font-size: 25px;
-    font-weight: 700;
-    letter-spacing: 0.2em;
+    font-family: "Cormorant Garamond", serif;
+    font-size: 26px;
+    font-weight: 400;
+    letter-spacing: 0.22em;
     text-align: center;
     text-transform: uppercase;
-    text-shadow: 0 0 18px rgba(116, 245, 255, 0.25);
+    text-shadow: 0 0 18px oklch(0.82 0.15 210 / 0.25);
   }
 
   .ob-round-timer {
     display: none;
     padding: 7px 13px 6px;
-    border-radius: 999px;
-    color: #d7f9ff;
-    font-family: "Space Mono", monospace;
+    border-radius: 4px;
+    color: #e8ecf4;
+    font-family: "JetBrains Mono", monospace;
     font-size: 13px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
@@ -145,10 +146,11 @@ const HUD_CSS = `
     left: 50%;
     top: 38%;
     transform: translate(-50%, -50%);
+    font-family: "Cormorant Garamond", serif;
     font-size: 92px;
-    font-weight: 700;
+    font-weight: 300;
     letter-spacing: 0.08em;
-    text-shadow: 0 0 40px rgba(116, 245, 255, 0.9);
+    text-shadow: 0 0 40px oklch(0.82 0.15 210 / 0.9);
   }
 
   .ob-objective {
@@ -159,10 +161,11 @@ const HUD_CSS = `
     transform: translate(-50%, -50%);
     max-width: min(620px, 82vw);
     padding: 10px 16px;
-    border-radius: 999px;
-    font-size: 13px;
-    font-weight: 600;
-    letter-spacing: 0.24em;
+    border-radius: 4px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    font-weight: 400;
+    letter-spacing: 0.22em;
     line-height: 1.45;
     text-align: center;
     text-transform: uppercase;
@@ -226,7 +229,7 @@ const HUD_CSS = `
   .ob-power-label {
     margin-top: 7px;
     color: #e3fbff;
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 11px;
     letter-spacing: 0.12em;
     text-align: center;
@@ -251,7 +254,7 @@ const HUD_CSS = `
     min-height: 32px;
     padding: 6px 10px;
     border-radius: 999px;
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.08em;
@@ -302,7 +305,7 @@ const HUD_CSS = `
 
   .ob-tutorial__eyebrow {
     color: var(--hud-muted);
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 10px;
     font-weight: 700;
     letter-spacing: 0.18em;
@@ -311,9 +314,10 @@ const HUD_CSS = `
 
   .ob-tutorial__title {
     margin-top: 6px;
-    font-size: 19px;
-    font-weight: 700;
-    letter-spacing: 0.04em;
+    font-family: "Cormorant Garamond", serif;
+    font-size: 22px;
+    font-weight: 400;
+    letter-spacing: 0.06em;
   }
 
   .ob-tutorial__body {
@@ -367,7 +371,7 @@ const HUD_CSS = `
     justify-content: space-between;
     gap: 12px;
     color: var(--hud-muted);
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 11px;
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -413,7 +417,7 @@ const HUD_CSS = `
   .ob-scoreboard__subtitle {
     margin-top: 2px;
     color: var(--hud-muted);
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 10px;
     letter-spacing: 0.16em;
     text-transform: uppercase;
@@ -421,7 +425,7 @@ const HUD_CSS = `
 
   .ob-scoreboard__summary {
     color: var(--hud-muted);
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 10px;
     letter-spacing: 0.14em;
     text-align: right;
@@ -436,7 +440,7 @@ const HUD_CSS = `
   .ob-scoreboard__table thead th {
     padding: 10px 16px;
     color: var(--hud-muted);
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 10px;
     font-weight: 700;
     letter-spacing: 0.14em;
@@ -459,7 +463,7 @@ const HUD_CSS = `
     width: 1%;
     white-space: nowrap;
     text-align: center;
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
   }
 
   .ob-scoreboard__name {
@@ -481,7 +485,7 @@ const HUD_CSS = `
     height: 20px;
     padding: 0 7px;
     border-radius: 999px;
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 9px;
     font-weight: 700;
     letter-spacing: 0.1em;
@@ -508,7 +512,7 @@ const HUD_CSS = `
     height: 26px;
     padding: 0 10px;
     border-radius: 999px;
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 10px;
     font-weight: 700;
     letter-spacing: 0.1em;
@@ -536,7 +540,7 @@ const HUD_CSS = `
   .ob-scoreboard__empty {
     padding: 18px 16px 20px;
     color: var(--hud-muted);
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 12px;
     letter-spacing: 0.12em;
     text-align: center;

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -37,6 +37,25 @@ const HUD_MARKUP = `
 
   <div id="hud-round-end" class="ob-round-end"></div>
   <div id="hud-tab" class="ob-scoreboard-overlay"></div>
+
+  <div id="hud-help" class="ob-help-overlay">
+    <div class="ob-help-panel">
+      <div class="ob-help-header">
+        <div class="ob-help-title">Controls</div>
+        <div class="ob-help-close">[H] Close</div>
+      </div>
+      <div class="ob-help-grid">
+        <div class="ob-help-row"><span class="ob-help-key">LMB</span><span class="ob-help-desc">Freeze shot</span></div>
+        <div class="ob-help-row"><span class="ob-help-key">E</span><span class="ob-help-desc">Grab bar</span></div>
+        <div class="ob-help-row"><span class="ob-help-key">Space + Mouse ↕</span><span class="ob-help-desc">Aim launch power</span></div>
+        <div class="ob-help-row"><span class="ob-help-key">Space release</span><span class="ob-help-desc">Slingshot into zero-G</span></div>
+        <div class="ob-help-row"><span class="ob-help-key">Tab</span><span class="ob-help-desc">Scoreboard</span></div>
+        <div class="ob-help-row"><span class="ob-help-key">Esc</span><span class="ob-help-desc">Session menu</span></div>
+        <div class="ob-help-row"><span class="ob-help-key">V</span><span class="ob-help-desc">Third-person toggle</span></div>
+        <div class="ob-help-row ob-help-row--goal">Float through the enemy portal to breach and score</div>
+      </div>
+    </div>
+  </div>
 `;
 
 const HUD_CSS = `
@@ -663,6 +682,86 @@ const HUD_CSS = `
     }
   }
 
+  /* ── HELP OVERLAY ── */
+  .ob-help-overlay {
+    position: absolute;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 80;
+    pointer-events: auto;
+  }
+  .ob-help-overlay.ob-help-visible {
+    display: flex;
+  }
+  .ob-help-panel {
+    background: rgba(7, 10, 18, 0.97);
+    border: 1px solid rgba(210, 220, 240, 0.16);
+    padding: 24px 28px;
+    min-width: 320px;
+    max-width: min(480px, 92vw);
+  }
+  .ob-help-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 18px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid rgba(210, 220, 240, 0.08);
+  }
+  .ob-help-title {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 24px;
+    font-weight: 300;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #e8ecf4;
+  }
+  .ob-help-close {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 9px;
+    letter-spacing: 0.12em;
+    color: var(--hud-muted);
+    text-transform: uppercase;
+  }
+  .ob-help-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .ob-help-row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+  .ob-help-key {
+    min-width: 120px;
+    padding: 4px 8px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(210, 220, 240, 0.1);
+    color: var(--hud-cyan);
+    text-align: center;
+    flex-shrink: 0;
+    font-size: 9px;
+  }
+  .ob-help-desc {
+    color: var(--hud-muted);
+  }
+  .ob-help-row--goal {
+    margin-top: 6px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(210, 220, 240, 0.06);
+    color: var(--hud-magenta);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .ob-score-pill,
     .ob-round-timer,
@@ -708,6 +807,7 @@ export interface HudElements {
   tutorialBody: HTMLDivElement;
   roundEnd: HTMLDivElement;
   tab: HTMLDivElement;
+  help: HTMLDivElement;
 }
 
 export function createHudView(): HudElements {
@@ -742,5 +842,6 @@ export function createHudView(): HudElements {
     tutorialBody: q("hud-tutorial-body"),
     roundEnd: q("hud-round-end"),
     tab: q("hud-tab"),
+    help: q("hud-help"),
   };
 }

--- a/client/src/render/hud/tutorial.ts
+++ b/client/src/render/hud/tutorial.ts
@@ -59,6 +59,14 @@ export class FirstTimeTutorial {
 
   public constructor(private storage: StorageLike = resolveStorage()) {}
 
+  public forceRestart(): void {
+    this.storage.setItem(FIRST_TIME_TUTORIAL_STORAGE_KEY, "");
+    this.active = true;
+    this.stepIndex = 0;
+    this.attachedLastFrame = false;
+    this.shotFired = false;
+  }
+
   public beginRun(): void {
     if (this.isCompleted()) {
       this.active = false;

--- a/client/src/ui/debrief.ts
+++ b/client/src/ui/debrief.ts
@@ -1,0 +1,341 @@
+import { injectDesignTokens } from "./designTokens";
+
+export interface DebriefPlayer {
+  id: string;
+  name: string;
+  team: 0 | 1;
+  breaches: number;
+  frozen: number;
+  isBot: boolean;
+  isSelf: boolean;
+}
+
+export interface DebriefData {
+  winningTeam: 0 | 1 | null;
+  score: { team0: number; team1: number };
+  players: DebriefPlayer[];
+  playerTeam: 0 | 1;
+  matchLabel: string;
+}
+
+const CSS = `
+  .ob-debrief-root {
+    position: fixed; inset: 0; z-index: 450;
+    display: none; align-items: center; justify-content: center; padding: 18px;
+    background:
+      radial-gradient(circle at top, rgba(18, 41, 64, 0.82), rgba(4, 8, 18, 0.96) 55%, rgba(0, 0, 0, 0.99));
+    color: #e8ecf4;
+    font-family: "Cormorant Garamond", serif;
+  }
+  .ob-debrief-root * { box-sizing: border-box; }
+  .ob-debrief-root.ob-debrief-visible { display: flex; }
+
+  .ob-debrief-wrap {
+    width: min(1100px, 94vw);
+    max-height: calc(100vh - 36px);
+    overflow: auto;
+    display: grid;
+    gap: 22px;
+  }
+
+  /* ── Score head ── */
+  .ob-debrief-head {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 20px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid rgba(210, 220, 240, 0.08);
+  }
+  .ob-debrief-team-score { text-align: center; }
+  .ob-debrief-team-score .ob-ds-name {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px; letter-spacing: 5px;
+    color: #9aa5b8; text-transform: uppercase;
+  }
+  .ob-debrief-team-score .ob-ds-num {
+    font-size: 96px; font-weight: 300; line-height: 0.9;
+  }
+  .ob-debrief-team-score.ob-win  .ob-ds-num { color: oklch(0.82 0.15 210); text-shadow: 0 0 40px oklch(0.82 0.15 210 / 0.2); }
+  .ob-debrief-team-score.ob-loss .ob-ds-num { color: #57637a; }
+
+  .ob-debrief-verdict {
+    font-size: 38px; letter-spacing: 0.1em; text-align: center; white-space: nowrap;
+  }
+  .ob-debrief-verdict .ob-dv-sub {
+    display: block;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px; letter-spacing: 4px;
+    color: #57637a; margin-top: 8px; text-transform: uppercase;
+  }
+
+  /* ── Main grid ── */
+  .ob-debrief-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 18px;
+    align-items: start;
+  }
+
+  .ob-debrief-panel {
+    border: 1px solid rgba(210, 220, 240, 0.16);
+    background: rgba(7, 10, 18, 0.55);
+    backdrop-filter: blur(10px);
+    padding: 20px 22px;
+  }
+  .ob-debrief-panel-head {
+    display: flex; justify-content: space-between; align-items: center;
+    font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 4px;
+    color: #57637a; text-transform: uppercase;
+    padding-bottom: 12px; margin-bottom: 16px;
+    border-bottom: 1px solid rgba(210, 220, 240, 0.08);
+  }
+  .ob-debrief-panel-head h3 {
+    margin: 0; font-weight: 400; color: #9aa5b8; font-size: 10px; letter-spacing: 4px;
+  }
+  .ob-debrief-panel-head h3 .ob-dph-idx { color: oklch(0.82 0.15 210); }
+
+  /* ── Stats table ── */
+  .ob-stats-table {
+    width: 100%; border-collapse: collapse;
+    font-family: "JetBrains Mono", monospace; font-size: 11px;
+  }
+  .ob-stats-table th, .ob-stats-table td {
+    text-align: left; padding: 10px 12px;
+    border-bottom: 1px solid rgba(210, 220, 240, 0.06);
+    letter-spacing: 2px;
+  }
+  .ob-stats-table th {
+    font-size: 9px; color: #57637a; letter-spacing: 3px;
+    font-weight: 400; text-transform: uppercase;
+  }
+  .ob-stats-table td { color: #9aa5b8; }
+  .ob-stats-table td.ob-pname {
+    color: #e8ecf4;
+    font-family: "Cormorant Garamond", serif;
+    font-size: 15px; letter-spacing: 0.04em;
+  }
+  .ob-stats-table tr:hover td { background: rgba(255,255,255,0.03); color: #e8ecf4; }
+  .ob-t-cyan    td.ob-pname::before,
+  .ob-t-magenta td.ob-pname::before {
+    content: ""; display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+    margin-right: 10px; vertical-align: middle;
+  }
+  .ob-t-cyan    td.ob-pname::before { background: oklch(0.82 0.15 210); }
+  .ob-t-magenta td.ob-pname::before { background: oklch(0.72 0.25 330); }
+  .ob-stats-table .ob-self td { color: #e8ecf4; }
+  .ob-stats-table .ob-self td.ob-pname { font-weight: 500; }
+
+  /* ── Awards ── */
+  .ob-awards { display: grid; gap: 10px; }
+  .ob-award {
+    border: 1px solid rgba(210, 220, 240, 0.08);
+    padding: 14px 16px;
+    background: rgba(7, 10, 18, 0.45);
+    display: grid; gap: 3px;
+    transition: border-color 0.22s, background 0.22s;
+  }
+  .ob-award:hover { border-color: oklch(0.82 0.15 210); background: rgba(24, 52, 82, 0.3); }
+  .ob-award-key {
+    font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 3px;
+    color: #57637a; text-transform: uppercase;
+  }
+  .ob-award-val { font-size: 20px; letter-spacing: 0.04em; color: #e8ecf4; }
+  .ob-award-note {
+    font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 2px;
+    color: oklch(0.82 0.15 210); margin-top: 2px;
+  }
+
+  /* ── Action buttons ── */
+  .ob-debrief-actions { display: flex; gap: 12px; margin-top: 10px; }
+  .ob-debrief-btn {
+    flex: 1; position: relative;
+    padding: 15px 20px;
+    background: rgba(7, 10, 18, 0.55); backdrop-filter: blur(8px);
+    border: 1px solid rgba(210, 220, 240, 0.16); color: #e8ecf4;
+    font-family: "JetBrains Mono", monospace; font-size: 10px; letter-spacing: 5px;
+    text-transform: uppercase; cursor: pointer;
+    transition: border-color 0.22s, background 0.22s, transform 0.2s;
+    display: flex; align-items: center; justify-content: center; gap: 10px;
+  }
+  .ob-debrief-btn:hover { border-color: rgba(210,220,240,0.3); background: rgba(20,30,50,0.7); transform: translateY(-1px); }
+  .ob-debrief-btn--primary { border-color: oklch(0.82 0.15 210 / 0.28); }
+  .ob-debrief-btn--primary:hover { border-color: oklch(0.82 0.15 210); color: oklch(0.9 0.1 210); }
+
+  @media (max-width: 900px) {
+    .ob-debrief-grid { grid-template-columns: 1fr; }
+    .ob-debrief-head { grid-template-columns: 1fr; gap: 12px; text-align: center; }
+  }
+`;
+
+let styleInjected = false;
+function injectStyle(): void {
+  if (styleInjected) return;
+  styleInjected = true;
+  const style = document.createElement("style");
+  style.textContent = CSS;
+  document.head.appendChild(style);
+}
+
+function rating(breaches: number, frozen: number): string {
+  const r = (breaches * 3) / (frozen + 1);
+  if (r >= 3.5) return "A+";
+  if (r >= 2.2) return "A";
+  if (r >= 1.2) return "B+";
+  if (r >= 0.6) return "B";
+  if (r >= 0.2) return "C+";
+  return "C";
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c
+  );
+}
+
+export class DebriefScreen {
+  private readonly root: HTMLDivElement;
+  public onMainMenu: (() => void) | null = null;
+  public onPlayAgain: (() => void) | null = null;
+
+  public constructor() {
+    injectDesignTokens();
+    injectStyle();
+    this.root = document.createElement("div");
+    this.root.className = "ob-debrief-root";
+    document.body.appendChild(this.root);
+  }
+
+  public isVisible(): boolean {
+    return this.root.classList.contains("ob-debrief-visible");
+  }
+
+  public show(data: DebriefData): void {
+    this.root.innerHTML = this.buildHtml(data);
+    this.root.classList.add("ob-debrief-visible");
+
+    this.root.querySelector<HTMLButtonElement>("#debrief-main-menu")
+      ?.addEventListener("click", () => { this.hide(); this.onMainMenu?.(); });
+    this.root.querySelector<HTMLButtonElement>("#debrief-play-again")
+      ?.addEventListener("click", () => { this.hide(); this.onPlayAgain?.(); });
+  }
+
+  public hide(): void {
+    this.root.classList.remove("ob-debrief-visible");
+  }
+
+  public dispose(): void {
+    this.root.remove();
+  }
+
+  private buildHtml(data: DebriefData): string {
+    const { score, winningTeam, players, playerTeam, matchLabel } = data;
+
+    const cyan0 = winningTeam === 0 ? "ob-win" : "ob-loss";
+    const cyan1 = winningTeam === 1 ? "ob-win" : "ob-loss";
+    const verdictText = winningTeam === playerTeam ? "VICTORY"
+      : winningTeam === null ? "DRAW"
+      : "DEFEAT";
+
+    const sortedPlayers = [...players].sort((a, b) => {
+      if (a.team !== b.team) return a.team - b.team;
+      return b.breaches - a.breaches;
+    });
+
+    const tableRows = sortedPlayers.map((p, i) => {
+      const teamCls = p.team === 0 ? "ob-t-cyan" : "ob-t-magenta";
+      const selfCls = p.isSelf ? " ob-self" : "";
+      const r = rating(p.breaches, p.frozen);
+      return `<tr class="${teamCls}${selfCls}">
+        <td class="ob-pname">${escapeHtml(p.name)}${p.isBot ? " <small style='opacity:.4;font-size:9px;font-family:var(--ob-mono,monospace)'>[BOT]</small>" : ""}</td>
+        <td>${p.breaches}</td>
+        <td>${p.frozen}</td>
+        <td>${r}</td>
+      </tr>`;
+    }).join("");
+
+    const awards = this.buildAwards(players);
+
+    return `
+      <div class="ob-debrief-wrap">
+        <div class="ob-debrief-head">
+          <div class="ob-debrief-team-score ${cyan0}">
+            <div class="ob-ds-name">Team Cyan</div>
+            <div class="ob-ds-num">${score.team0}</div>
+          </div>
+          <div class="ob-debrief-verdict">
+            ${verdictText}
+            <span class="ob-dv-sub">${escapeHtml(matchLabel)}</span>
+          </div>
+          <div class="ob-debrief-team-score ${cyan1}">
+            <div class="ob-ds-name">Team Magenta</div>
+            <div class="ob-ds-num">${score.team1}</div>
+          </div>
+        </div>
+
+        <div class="ob-debrief-grid">
+          <div class="ob-debrief-panel">
+            <div class="ob-debrief-panel-head">
+              <h3>Scoreboard <span class="ob-dph-idx">// final</span></h3>
+              <span>${players.length} PILOTS</span>
+            </div>
+            <table class="ob-stats-table">
+              <thead>
+                <tr><th>Pilot</th><th>Breaches</th><th>Frozen</th><th>Rating</th></tr>
+              </thead>
+              <tbody>${tableRows}</tbody>
+            </table>
+          </div>
+
+          <div>
+            <div class="ob-awards">${awards}</div>
+            <div class="ob-debrief-actions">
+              <button class="ob-debrief-btn" id="debrief-main-menu">Main Menu →</button>
+              <button class="ob-debrief-btn ob-debrief-btn--primary" id="debrief-play-again">Play Again →</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private buildAwards(players: DebriefPlayer[]): string {
+    const humans = players.filter((p) => !p.isBot);
+    const all = players;
+
+    const mostBreaches = all.reduce<DebriefPlayer | null>(
+      (best, p) => (!best || p.breaches > best.breaches ? p : best), null,
+    );
+    const ironPilot = humans.find((p) => p.frozen === 0);
+    const topKd = all.reduce<DebriefPlayer | null>(
+      (best, p) => {
+        const scoreA = p.breaches * 3 / (p.frozen + 1);
+        const scoreB = best ? best.breaches * 3 / (best.frozen + 1) : -1;
+        return scoreA > scoreB ? p : best;
+      }, null,
+    );
+
+    const award = (key: string, val: string, note: string) =>
+      `<div class="ob-award">
+        <span class="ob-award-key">${key}</span>
+        <span class="ob-award-val">${escapeHtml(val)}</span>
+        <span class="ob-award-note">${escapeHtml(note)}</span>
+      </div>`;
+
+    const parts: string[] = [];
+    if (mostBreaches && mostBreaches.breaches > 0) {
+      parts.push(award("Most Breaches", mostBreaches.name, `${mostBreaches.breaches} portal traversals`));
+    }
+    if (ironPilot) {
+      parts.push(award("Iron Pilot", ironPilot.name, "never frozen this match"));
+    }
+    if (topKd) {
+      parts.push(award("Top Rating", topKd.name, `${rating(topKd.breaches, topKd.frozen)} · ${topKd.breaches} breaches / ${topKd.frozen} frozen`));
+    }
+    if (parts.length === 0) {
+      parts.push(award("Round Complete", "—", "match concluded"));
+    }
+
+    return parts.join("");
+  }
+}

--- a/client/src/ui/designTokens.ts
+++ b/client/src/ui/designTokens.ts
@@ -1,0 +1,29 @@
+let injected = false;
+
+export function injectDesignTokens(): void {
+  if (injected) return;
+  injected = true;
+  const style = document.createElement('style');
+  style.id = 'ob-design-tokens';
+  style.textContent = `
+    @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300&family=JetBrains+Mono:wght@300;400;500&display=swap');
+
+    :root {
+      --ob-ink-0: #070a12;
+      --ob-ink-1: #0b1120;
+      --ob-ink-2: #121a2b;
+      --ob-line:   rgba(210, 220, 240, 0.08);
+      --ob-line-2: rgba(210, 220, 240, 0.16);
+      --ob-fg:        #e8ecf4;
+      --ob-fg-dim:    #9aa5b8;
+      --ob-fg-faint:  #57637a;
+      --ob-cyan:         oklch(0.82 0.15 210);
+      --ob-magenta:      oklch(0.72 0.25 330);
+      --ob-cyan-soft:    oklch(0.82 0.15 210 / 0.18);
+      --ob-magenta-soft: oklch(0.72 0.25 330 / 0.22);
+      --ob-serif: "Cormorant Garamond", "Times New Roman", serif;
+      --ob-mono:  "JetBrains Mono", ui-monospace, monospace;
+    }
+  `;
+  document.head.appendChild(style);
+}

--- a/client/src/ui/menu.ts
+++ b/client/src/ui/menu.ts
@@ -8,6 +8,7 @@ const MATCH_SIZE_STORAGE_KEY = 'orbital_match_size';
 
 export interface PlaySelection {
   name: string;
+  noBots?: boolean;
   teamSize: MatchTeamSize;
 }
 
@@ -17,6 +18,7 @@ export class MainMenu {
 
   public onPlaySolo: ((selection: PlaySelection) => void) | null = null;
   public onPlayOnline: ((selection: PlaySelection) => void) | null = null;
+  public onPlayTutorial: ((selection: PlaySelection) => void) | null = null;
 
   public show(): void {
     this.hide();
@@ -54,6 +56,11 @@ export class MainMenu {
       if (!this.checkNameBeforePlay(elements)) return;
       const selection = this.saveSelection();
       this.fadeOut(() => this.onPlayOnline?.(selection));
+    });
+    elements.playTutorialButton.addEventListener('click', () => {
+      if (!this.checkNameBeforePlay(elements)) return;
+      const name = this.menu?.nameInput.value.trim() || 'Pilot';
+      this.fadeOut(() => this.onPlayTutorial?.({ name, teamSize: 1, noBots: true }));
     });
 
     // Enter anywhere in the menu triggers PLAY SOLO (quickest path).

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -273,8 +273,8 @@ const CSS = `
 
   /* ── MATCH GRID ── */
   .ob-match-grid {
-    display: grid; grid-template-columns: repeat(4, 1fr);
-    gap: 14px; width: 100%; max-width: 720px;
+    display: grid; grid-template-columns: repeat(5, 1fr);
+    gap: 14px; width: 100%; max-width: 880px;
   }
   .ob-match-card {
     position: relative; padding: 20px 12px 18px;
@@ -349,7 +349,7 @@ const CSS = `
 
   /* ── RESPONSIVE ── */
   @media (max-width: 640px) {
-    .ob-match-grid   { grid-template-columns: repeat(2, 1fr); }
+    .ob-match-grid   { grid-template-columns: repeat(3, 1fr); }
     .ob-launch-row   { flex-direction: column; }
     .ob-callsign-box { min-width: 0; width: 90vw; }
     .menu-root       { cursor: auto; }
@@ -367,6 +367,9 @@ const CSS = `
   @media (prefers-reduced-motion: reduce) {
     .ob-ring, .ob-stars i, .ob-pulse, .menu-root { animation: none !important; }
     .ob-title-waves { display: none; }
+  }
+  @media (hover: none) {
+    .ob-title-waves { display: none !important; }
   }
 `;
 
@@ -401,7 +404,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
   injectDesignTokens();
 
   // Map matchSize to the nearest visible card (1,5,10,20 — no 2v2 card shown)
-  const cardSizes = [1, 5, 10, 20] as const;
+  const cardSizes = [1, 2, 5, 10, 20] as const;
   const matchCardSize: number =
     (cardSizes as readonly number[]).includes(matchSize) ? matchSize : 1;
 
@@ -533,6 +536,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
 
         <div class="ob-match-grid" id="ob-match-grid">
           ${cardHtml(1,  "Skirmish",   "Bots off")}
+          ${cardHtml(2,  "Duos",       "Bots off")}
           ${cardHtml(5,  "Squad Clash","8 bots")}
           ${cardHtml(10, "Arena Rush", "18 bots")}
           ${cardHtml(20, "Zero-G War", "38 bots")}
@@ -681,7 +685,7 @@ function initMenuFx(container: HTMLElement): void {
         wavesCvs.height = H * DPR;
         ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
       };
-      resizeWave();
+      requestAnimationFrame(() => requestAnimationFrame(resizeWave));
       const ro = new ResizeObserver(resizeWave);
       ro.observe(titleEl);
 

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -1,527 +1,378 @@
 import { isTouchDevice } from "../../platform";
 import type { MatchTeamSize } from "../../../../shared/match";
+import { injectDesignTokens } from "../designTokens";
 
-/**
- * Main menu DOM view: injects the stylesheet on first use, builds the
- * menu element from HTML, and exposes the mutable handles (name input,
- * play buttons, fade-target root) the controller needs.
- */
+/* ─────────────────────────────────────────────
+   CSS
+───────────────────────────────────────────── */
 const CSS = `
-  @import url('https://fonts.googleapis.com/css2?family=Oxanium:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap');
-
-  @keyframes menuFadeIn {
+  @keyframes ob-spin       { to { transform: rotate(360deg); } }
+  @keyframes ob-twinkle {
+    0%,100% { opacity: calc(var(--o) * 0.4); transform: scale(0.8); }
+    50%     { opacity: var(--o);             transform: scale(1.1); }
+  }
+  @keyframes ob-pulseDot {
+    0%,100% { opacity: 0.4; transform: scale(0.9); }
+    50%     { opacity: 1;   transform: scale(1.15); }
+  }
+  @keyframes ob-menuFadeIn {
     from { opacity: 0; }
-    to { opacity: 1; }
+    to   { opacity: 1; }
   }
 
-  @keyframes menuRise {
-    from { opacity: 0; transform: translateY(16px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-
-  @keyframes orbDrift {
-    0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
-    50% { transform: translate3d(0, -14px, 0) scale(1.04); }
-  }
-
-  .menu-root {
-    --menu-cyan: #74f5ff;
-    --menu-magenta: #ff82ef;
-    --menu-text: #f4fdff;
-    --menu-muted: #8da7bc;
-    --menu-panel: rgba(5, 12, 18, 0.76);
-    --menu-panel-strong: rgba(4, 10, 15, 0.9);
-    --menu-border: rgba(130, 232, 255, 0.18);
-    position: fixed;
-    inset: 0;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: clamp(18px, 3vw, 36px);
+  /* ── BACKGROUND LAYERS ── */
+  .ob-planet {
+    position: fixed; left: 50%; bottom: -52vmin; transform: translateX(-50%);
+    width: 120vmin; height: 120vmin; border-radius: 50%;
     background:
-      radial-gradient(circle at 14% 18%, rgba(116, 245, 255, 0.14), rgba(116, 245, 255, 0) 28%),
-      radial-gradient(circle at 82% 18%, rgba(255, 130, 239, 0.16), rgba(255, 130, 239, 0) 30%),
-      linear-gradient(180deg, rgba(4, 10, 16, 0.98), rgba(3, 8, 13, 0.94));
-    color: var(--menu-text);
-    z-index: 300;
-    font-family: "Oxanium", sans-serif;
-    animation: menuFadeIn 0.35s ease-out both;
+      radial-gradient(circle at 35% 30%, rgba(255,190,140,.12), transparent 45%),
+      radial-gradient(circle at 50% 50%, #0c1426 0%, #070a12 70%);
+    box-shadow:
+      inset 0 2vmin 8vmin  rgba(255,180,120,.08),
+      inset 0 -6vmin 14vmin rgba(0,0,0,.9),
+      0 0 0 1px rgba(255,200,160,.06);
+    z-index: 1; pointer-events: none;
+  }
+  .ob-planet::after {
+    content: ""; position: absolute; inset: -1px; border-radius: 50%;
+    background: linear-gradient(180deg, rgba(255,210,170,.25) 0%, transparent 14%);
+    mix-blend-mode: screen; filter: blur(1px);
   }
 
-  .menu-root * {
-    box-sizing: border-box;
+  .ob-stars { position: fixed; inset: 0; z-index: 1; pointer-events: none; }
+  .ob-stars i {
+    position: absolute; width: 1px; height: 1px; background: #fff; border-radius: 50%;
+    opacity: var(--o, .6);
+    animation: ob-twinkle var(--t, 6s) ease-in-out infinite;
+    animation-delay: var(--d, 0s);
   }
 
-  .menu-orb {
-    position: absolute;
-    width: 32vw;
-    height: 32vw;
-    min-width: 240px;
-    min-height: 240px;
-    max-width: 460px;
-    max-height: 460px;
+  .ob-bg-vignette {
+    position: fixed; inset: 0; pointer-events: none; z-index: 2;
+    background:
+      radial-gradient(ellipse 120% 80% at 50% 110%, transparent 40%, rgba(0,0,0,.75) 85%),
+      radial-gradient(ellipse 80% 60% at 50% -10%, rgba(0,0,0,.4), transparent 60%);
+  }
+
+  .ob-orbit-stage {
+    position: fixed; inset: 0; z-index: 2; pointer-events: none;
+    display: grid; place-items: center;
+    transform-style: preserve-3d;
+  }
+  .ob-orbit-tilt {
+    width: 140vmin; height: 140vmin; position: relative;
+    transform-style: preserve-3d;
+    transform: rotateX(62deg) rotateZ(0deg);
+    transition: transform 1.2s cubic-bezier(.2,.7,.2,1);
+  }
+  .ob-ring {
+    position: absolute; inset: 0; border-radius: 50%;
+    border: 1px solid var(--ob-line);
+    animation: ob-spin var(--dur, 120s) linear infinite;
+  }
+  .ob-ring svg  { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; }
+  .ob-ring text { font-family: var(--ob-mono); font-size: 9px; fill: var(--ob-fg-faint); letter-spacing: 3px; }
+  .ob-tick       { stroke: rgba(210,220,240,.22); stroke-width: 1; }
+  .ob-tick-major { stroke: rgba(210,220,240,.50); stroke-width: 1; }
+  .ob-dot        { fill: var(--ob-cyan); }
+  .ob-dot-warm   { fill: var(--ob-magenta); }
+  .ob-ring-1 { inset: 0;    --dur: 240s; }
+  .ob-ring-2 { inset: 9%;  --dur: 180s; animation-direction: reverse; }
+  .ob-ring-3 { inset: 20%; --dur: 140s; }
+  .ob-ring-4 { inset: 32%; --dur:  90s; animation-direction: reverse; }
+  .ob-ring-5 { inset: 42%; --dur:  60s; }
+  .ob-ring-dashed { border-style: dashed; border-color: rgba(210,220,240,.06); }
+
+  .ob-bg-grain {
+    position: fixed; inset: -20%; pointer-events: none; z-index: 6;
+    opacity: .06; mix-blend-mode: overlay;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.1' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.6 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  }
+
+  /* ── CURSOR ── */
+  .ob-cursor {
+    position: fixed; top: 0; left: 0; pointer-events: none; z-index: 50;
+    width: 28px; height: 28px;
+    transform: translate(-50%, -50%);
+    mix-blend-mode: screen;
+    color: var(--ob-cyan);
+  }
+  .ob-cursor::before {
+    content: ""; position: absolute; inset: 0; border-radius: 50%;
+    border: 1px solid var(--ob-cyan);
+    transition: transform .2s ease, border-color .2s ease;
+  }
+  .ob-cursor::after {
+    content: ""; position: absolute;
+    width: 3px; height: 3px; left: 50%; top: 50%;
+    transform: translate(-50%,-50%);
+    background: var(--ob-cyan); box-shadow: 0 0 8px var(--ob-cyan);
     border-radius: 50%;
-    filter: blur(30px);
-    opacity: 0.6;
-    animation: orbDrift 12s ease-in-out infinite;
+  }
+  .ob-cursor.ob-hot::before { transform: scale(1.7); border-color: var(--ob-magenta); }
+  .ob-cursor.ob-hot::after  { background: var(--ob-magenta); box-shadow: 0 0 10px var(--ob-magenta); }
+  .ob-cursor svg { position: absolute; inset: -6px; width: 40px; height: 40px; opacity: .6; }
+
+  /* ── CORNER BRACKETS ── */
+  .ob-hud-corner {
+    position: fixed; width: 44px; height: 44px;
+    border: 1px solid var(--ob-line-2); pointer-events: none; z-index: 10;
+  }
+  .ob-hud-corner.ob-tl { top: 18px; left: 18px; border-right: none; border-bottom: none; }
+  .ob-hud-corner.ob-tr { top: 18px; right: 18px; border-left:  none; border-bottom: none; }
+  .ob-hud-corner.ob-bl { bottom: 18px; left: 18px;  border-right: none; border-top: none; }
+  .ob-hud-corner.ob-br { bottom: 18px; right: 18px; border-left:  none; border-top: none; }
+
+  /* ── TOP / BOTTOM BARS ── */
+  .ob-topbar {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 10;
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 22px 40px 0;
+    font-family: var(--ob-mono); font-size: 10px; letter-spacing: 3px;
+    color: var(--ob-fg-dim); text-transform: uppercase;
+    pointer-events: none;
+  }
+  .ob-topbar-brand {
+    font-family: var(--ob-serif); font-size: 14px; letter-spacing: 6px;
+    color: var(--ob-fg); font-weight: 400;
+  }
+  .ob-topbar-brand em {
+    font-style: normal; color: var(--ob-cyan); margin-left: 8px;
+    font-family: var(--ob-mono); font-size: 10px; letter-spacing: 3px;
+  }
+  .ob-topbar-right { display: flex; gap: 22px; align-items: center; }
+  .ob-topbar-dot {
+    display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+    background: var(--ob-cyan); box-shadow: 0 0 8px var(--ob-cyan);
+    margin-right: 8px; vertical-align: middle;
   }
 
-  .menu-orb--cyan {
-    left: -10vw;
-    top: -10vw;
-    background: radial-gradient(circle, rgba(116, 245, 255, 0.2), rgba(116, 245, 255, 0.02) 62%, transparent 76%);
+  .ob-bottombar {
+    position: fixed; bottom: 0; left: 0; right: 0; z-index: 10;
+    display: flex; justify-content: space-between; align-items: flex-end;
+    padding: 0 40px 18px;
+    font-family: var(--ob-mono); font-size: 9px; letter-spacing: 3px;
+    color: var(--ob-fg-faint); text-transform: uppercase;
+    pointer-events: none;
+  }
+  .ob-bottombar-tel { display: flex; gap: 28px; }
+  .ob-bottombar-tel span b { color: var(--ob-fg-dim); font-weight: 400; }
+
+  /* ── MENU ROOT ── */
+  .menu-root {
+    position: fixed; inset: 0; z-index: 10;
+    display: grid; place-items: center;
+    background: radial-gradient(ellipse at 50% 120%, #0d1426 0%, var(--ob-ink-0) 55%, #03060d 100%);
+    animation: ob-menuFadeIn .35s ease-out both;
+    cursor: none;
+  }
+  .menu-root * { box-sizing: border-box; }
+
+  /* ── MAIN CONTENT ── */
+  .ob-main-wrap {
+    position: relative; z-index: 8;
+    display: grid; grid-template-columns: 1fr;
+    justify-items: center; gap: 28px;
+    width: min(900px, 90vw);
+    text-align: center;
+    color: var(--ob-fg);
+    padding: 80px 0 60px;
   }
 
-  .menu-orb--magenta {
-    right: -10vw;
-    bottom: -12vw;
-    background: radial-gradient(circle, rgba(255, 130, 239, 0.22), rgba(255, 130, 239, 0.03) 62%, transparent 76%);
-    animation-delay: 2s;
+  .ob-tag {
+    font-family: var(--ob-mono); font-size: 10px; letter-spacing: 8px;
+    color: var(--ob-fg-faint); text-transform: uppercase;
+    display: inline-flex; align-items: center; gap: 14px;
+  }
+  .ob-tag::before, .ob-tag::after {
+    content: ""; width: 40px; height: 1px; background: var(--ob-line-2);
   }
 
-  .menu-corner {
+  .ob-title {
+    font-family: var(--ob-serif); font-weight: 300;
+    font-size: clamp(44px, 8.2vw, 110px);
+    letter-spacing: .02em; line-height: .95;
+    margin: 0; color: #fff;
+    text-shadow: 0 0 40px rgba(255,255,255,.05);
+    white-space: nowrap; text-transform: uppercase;
+    position: relative;
+  }
+  .ob-letter {
+    position: relative; z-index: 1;
+    display: inline-block;
+    transition: transform .4s cubic-bezier(.2,.7,.2,1), text-shadow .4s;
+    will-change: transform;
+  }
+  .ob-title-waves {
     position: absolute;
-    width: 20px;
-    height: 20px;
-    border-color: rgba(116, 245, 255, 0.26);
-    border-style: solid;
+    left: -6%; right: -6%; top: -40%; bottom: -40%;
+    pointer-events: none; z-index: 0;
+    opacity: 0; transition: opacity .45s ease;
+    mix-blend-mode: screen; filter: blur(.4px);
+  }
+  .ob-title:hover .ob-title-waves { opacity: 1; }
+
+  .ob-subtitle {
+    font-family: var(--ob-mono); font-size: 11px; letter-spacing: 6px;
+    color: var(--ob-fg-dim); text-transform: uppercase;
+    display: flex; align-items: center; gap: 18px; justify-content: center;
+  }
+  .ob-pulse {
+    width: 6px; height: 6px; background: var(--ob-magenta); border-radius: 50%;
+    box-shadow: 0 0 10px var(--ob-magenta);
+    animation: ob-pulseDot 1.8s ease-in-out infinite;
+    flex-shrink: 0;
   }
 
-  .menu-corner--tl { top: 18px; left: 18px; border-width: 1px 0 0 1px; }
-  .menu-corner--tr { top: 18px; right: 18px; border-width: 1px 1px 0 0; }
-  .menu-corner--bl { bottom: 18px; left: 18px; border-width: 0 0 1px 1px; }
-  .menu-corner--br { bottom: 18px; right: 18px; border-width: 0 1px 1px 0; }
+  /* ── CALLSIGN ── */
+  .ob-callsign { display: grid; gap: 8px; justify-items: center; }
+  .ob-callsign-label {
+    font-family: var(--ob-mono); font-size: 9px; letter-spacing: 6px;
+    color: var(--ob-fg-faint); text-transform: uppercase;
+  }
+  .ob-callsign-box {
+    position: relative; display: flex; align-items: center;
+    border: 1px solid var(--ob-line-2);
+    background: rgba(10,14,26,.6); backdrop-filter: blur(8px);
+    padding: 14px 22px; min-width: 340px;
+    transition: border-color .25s, box-shadow .25s;
+  }
+  .ob-callsign-box:hover { border-color: rgba(255,255,255,.2); }
+  .ob-callsign-box:focus-within {
+    border-color: var(--ob-cyan);
+    box-shadow: 0 0 0 1px var(--ob-cyan-soft), 0 0 40px rgba(120,200,255,.06);
+  }
+  .ob-callsign-box:has(input.menu-input--error) {
+    border-color: rgba(255,115,156,.56) !important;
+    box-shadow: 0 0 0 2px rgba(255,115,156,.12) !important;
+  }
+  .ob-callsign-prefix {
+    font-family: var(--ob-mono); font-size: 10px; letter-spacing: 3px;
+    color: var(--ob-fg-faint); margin-right: 12px; text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .ob-callsign-box input {
+    flex: 1; background: transparent; border: none; outline: none;
+    color: var(--ob-fg); font-family: var(--ob-serif); font-size: 20px;
+    letter-spacing: .12em; text-align: left;
+    caret-color: var(--ob-cyan); cursor: text;
+  }
+  .ob-callsign-box input::placeholder { color: var(--ob-fg-faint); }
+  .ob-bracket {
+    position: absolute; top: -5px; bottom: -5px; width: 10px;
+    border: 1px solid var(--ob-cyan); opacity: 0; transition: opacity .25s;
+  }
+  .ob-bracket.ob-l { left: -5px;  border-right: none; }
+  .ob-bracket.ob-r { right: -5px; border-left:  none; }
+  .ob-callsign-box:focus-within .ob-bracket { opacity: .8; }
+  .ob-name-error {
+    min-height: 18px; color: #ff8eb7;
+    font-family: var(--ob-mono); font-size: 11px; letter-spacing: 2px;
+    text-align: center;
+  }
 
-  .menu-grid {
+  /* ── MATCH GRID ── */
+  .ob-match-grid {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 14px; width: 100%; max-width: 720px;
+  }
+  .ob-match-card {
+    position: relative; padding: 20px 12px 18px;
+    background: rgba(10,14,26,.5); backdrop-filter: blur(6px);
+    border: 1px solid var(--ob-line); cursor: none;
+    transition: border-color .3s, background .3s, transform .3s;
+    text-align: center; overflow: hidden;
+    color: var(--ob-fg); font-family: var(--ob-serif);
+  }
+  .ob-match-card::before {
+    content: ""; position: absolute; inset: 0;
+    background: linear-gradient(180deg, transparent, var(--ob-cyan-soft));
+    opacity: 0; transition: opacity .3s;
+  }
+  .ob-match-card:hover { border-color: rgba(255,255,255,.25); transform: translateY(-2px); }
+  .ob-match-card:hover::before { opacity: .5; }
+  .ob-match-card.ob-selected { border-color: var(--ob-cyan); background: rgba(30,60,90,.35); }
+  .ob-match-card.ob-selected::before { opacity: 1; }
+  .ob-card-size {
+    font-family: var(--ob-serif); font-size: 30px; font-weight: 300;
+    color: var(--ob-fg); letter-spacing: .02em; position: relative; z-index: 1;
+  }
+  .ob-card-size em { font-style: normal; color: var(--ob-fg-faint); font-size: 17px; margin: 0 3px; }
+  .ob-card-name {
+    font-family: var(--ob-mono); font-size: 9px; letter-spacing: 3px;
+    color: var(--ob-fg-dim); text-transform: uppercase; margin-top: 5px;
+    position: relative; z-index: 1;
+  }
+  .ob-card-bots {
+    font-family: var(--ob-mono); font-size: 8px; letter-spacing: 2px;
+    color: var(--ob-fg-faint); text-transform: uppercase; margin-top: 8px;
+    position: relative; z-index: 1;
+  }
+
+  /* ── LAUNCH BUTTONS ── */
+  .ob-launch-row { display: flex; gap: 16px; }
+  .ob-btn {
     position: relative;
-    display: grid;
-    grid-template-columns: minmax(0, 1.2fr) minmax(320px, 430px);
-    gap: clamp(26px, 5vw, 60px);
-    width: min(1120px, 100%);
-    align-items: center;
-  }
-
-  .menu-brand,
-  .menu-console {
-    position: relative;
-    border: 1px solid var(--menu-border);
-    border-radius: 30px;
-    background:
-      linear-gradient(135deg, rgba(116, 245, 255, 0.07), rgba(255, 130, 239, 0.05)),
-      var(--menu-panel);
-    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(14px);
-    animation: menuRise 0.45s ease-out both;
-  }
-
-  .menu-brand {
-    padding: clamp(26px, 4vw, 44px);
+    padding: 18px 38px;
+    background: rgba(10,14,26,.55); backdrop-filter: blur(8px);
+    border: 1px solid var(--ob-line-2); color: var(--ob-fg);
+    font-family: var(--ob-mono); font-size: 11px; letter-spacing: 5px;
+    text-transform: uppercase; cursor: none;
+    transition: border-color .25s, background .25s, color .25s, transform .25s;
     overflow: hidden;
   }
-
-  .menu-console {
-    padding: 22px;
-    background:
-      linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
-      var(--menu-panel-strong);
-    animation-delay: 0.08s;
+  .ob-btn-label { position: relative; z-index: 2; display: flex; align-items: center; gap: 12px; }
+  .ob-btn-arrow { font-family: var(--ob-serif); font-size: 16px; letter-spacing: 0; transition: transform .3s; }
+  .ob-btn::before {
+    content: ""; position: absolute; inset: 0;
+    opacity: 0; transition: opacity .3s; z-index: 1;
   }
-
-  .menu-kicker,
-  .menu-console-kicker,
-  .menu-label,
-  .menu-controls-title,
-  .menu-btn__eyebrow,
-  .menu-version {
-    font-family: "Space Mono", monospace;
-    text-transform: uppercase;
+  .ob-btn-primary::before  { background: radial-gradient(circle at var(--mx,50%) var(--my,50%), var(--ob-magenta-soft), transparent 60%); }
+  .ob-btn-secondary::before{ background: radial-gradient(circle at var(--mx,50%) var(--my,50%), var(--ob-cyan-soft),    transparent 60%); }
+  .ob-btn:hover { border-color: rgba(255,255,255,.4); transform: translateY(-1px); }
+  .ob-btn:hover::before { opacity: 1; }
+  .ob-btn:hover .ob-btn-arrow { transform: translateX(6px); }
+  .ob-btn-primary:hover  { color: oklch(0.88 0.12 60);  border-color: var(--ob-magenta); }
+  .ob-btn-secondary:hover{ color: var(--ob-cyan); border-color: var(--ob-cyan); }
+  .ob-btn:focus-visible { outline: 2px solid var(--ob-cyan); outline-offset: 3px; }
+  .ob-btn-corner {
+    position: absolute; width: 8px; height: 8px; z-index: 3;
+    border: 1px solid currentColor; opacity: .5;
   }
+  .ob-btn-corner.ob-tl { top: 4px; left: 4px;   border-right: none; border-bottom: none; }
+  .ob-btn-corner.ob-tr { top: 4px; right: 4px;   border-left:  none; border-bottom: none; }
+  .ob-btn-corner.ob-bl { bottom: 4px; left: 4px;  border-right: none; border-top:    none; }
+  .ob-btn-corner.ob-br { bottom: 4px; right: 4px; border-left:  none; border-top:    none; }
 
-  .menu-kicker {
-    color: var(--menu-muted);
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.22em;
-  }
+  /* hidden select keeps controller wiring intact */
+  .ob-match-select-hidden { display: none; }
 
-  .menu-title {
-    margin-top: 14px;
-    font-size: clamp(52px, 9vw, 102px);
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    line-height: 0.9;
-    text-transform: uppercase;
-    text-shadow: 0 0 30px rgba(116, 245, 255, 0.16);
-  }
-
-  .menu-title span {
-    display: block;
-  }
-
-  .menu-title span:last-child {
-    color: transparent;
-    background: linear-gradient(90deg, var(--menu-cyan), #f2f7ff 55%, var(--menu-magenta));
-    -webkit-background-clip: text;
-    background-clip: text;
-  }
-
-  .menu-subtitle {
-    margin-top: 12px;
-    color: #d9f2fb;
-    font-size: 20px;
-    font-weight: 500;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .menu-description {
-    max-width: 560px;
-    margin: 18px 0 0;
-    color: #d5e9f4;
-    font-size: 16px;
-    line-height: 1.7;
-  }
-
-  .menu-highlights {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    margin-top: 22px;
-  }
-
-  .menu-chip {
-    display: inline-flex;
-    align-items: center;
-    min-height: 34px;
-    padding: 0 12px;
-    border-radius: 999px;
-    color: #d8f8ff;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    font-family: "Space Mono", monospace;
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .menu-controls {
-    margin-top: 26px;
-    padding-top: 20px;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
-  }
-
-  .menu-controls-title {
-    color: var(--menu-muted);
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.18em;
-  }
-
-  .menu-controls-copy {
-    margin-top: 12px;
-    color: #d8edf5;
-    font-size: 13px;
-    line-height: 1.9;
-  }
-
-  .menu-key {
-    display: inline-flex;
-    align-items: center;
-    min-height: 22px;
-    padding: 0 7px;
-    border-radius: 999px;
-    color: #dffcff;
-    background: rgba(116, 245, 255, 0.12);
-    border: 1px solid rgba(116, 245, 255, 0.2);
-    font-family: "Space Mono", monospace;
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    vertical-align: middle;
-  }
-
-  .menu-console-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 16px;
-  }
-
-  .menu-console-kicker {
-    color: var(--menu-muted);
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.2em;
-  }
-
-  .menu-console-note {
-    color: #d6edf5;
-    font-size: 12px;
-    line-height: 1.5;
-    text-align: right;
-  }
-
-  .menu-section + .menu-section {
-    margin-top: 16px;
-  }
-
-  .menu-label {
-    display: block;
-    margin-bottom: 8px;
-    color: var(--menu-muted);
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.18em;
-  }
-
-  .menu-input {
-    width: 100%;
-    min-height: 54px;
-    padding: 0 16px;
-    border-radius: 18px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    background: rgba(255, 255, 255, 0.03);
-    color: var(--menu-text);
-    font-family: "Oxanium", sans-serif;
-    font-size: 18px;
-    letter-spacing: 0.06em;
-    outline: none;
-    transition: border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
-    appearance: none;
-  }
-
-  .menu-input::placeholder {
-    color: #5f7689;
-  }
-
-  .menu-input:hover:not(:focus) {
-    border-color: rgba(255, 255, 255, 0.18);
-  }
-
-  .menu-input:focus {
-    border-color: rgba(116, 245, 255, 0.42);
-    box-shadow: 0 0 0 3px rgba(116, 245, 255, 0.12);
-    background: rgba(255, 255, 255, 0.05);
-  }
-
-  .menu-input option {
-    color: var(--menu-text);
-    background: #071019;
-  }
-
-  .menu-input--error {
-    border-color: rgba(255, 115, 156, 0.56) !important;
-    box-shadow: 0 0 0 3px rgba(255, 115, 156, 0.12) !important;
-  }
-
-  .menu-name-error {
-    min-height: 18px;
-    margin-top: 7px;
-    color: #ff8eb7;
-    font-size: 12px;
-    line-height: 1.4;
-  }
-
-  .menu-divider {
-    height: 1px;
-    margin: 18px 0;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.12), transparent);
-  }
-
-  .menu-actions {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 12px;
-  }
-
-  .menu-btn {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    gap: 4px;
-    min-height: 88px;
-    padding: 14px 16px;
-    border-radius: 22px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    background: rgba(255, 255, 255, 0.04);
-    color: var(--menu-text);
-    cursor: pointer;
-    text-align: left;
-    transition: transform 0.14s ease, border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
-  }
-
-  .menu-btn:hover {
-    transform: translateY(-2px);
-    border-color: rgba(255, 255, 255, 0.24);
-    background: rgba(255, 255, 255, 0.06);
-    box-shadow: 0 16px 28px rgba(0, 0, 0, 0.2);
-  }
-
-  .menu-btn:active {
-    transform: translateY(0);
-  }
-
-  .menu-btn:focus-visible {
-    outline: 2px solid rgba(116, 245, 255, 0.48);
-    outline-offset: 3px;
-  }
-
-  .menu-btn--primary {
-    background: linear-gradient(135deg, rgba(116, 245, 255, 0.16), rgba(116, 245, 255, 0.05));
-    border-color: rgba(116, 245, 255, 0.26);
-  }
-
-  .menu-btn--secondary {
-    background: linear-gradient(135deg, rgba(255, 130, 239, 0.16), rgba(255, 130, 239, 0.05));
-    border-color: rgba(255, 130, 239, 0.26);
-  }
-
-  .menu-btn__eyebrow {
-    color: var(--menu-muted);
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.16em;
-  }
-
-  .menu-btn__title {
-    font-size: 19px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-  }
-
-  .menu-actions-note {
-    margin-top: 14px;
-    color: #cfe4ee;
-    font-size: 12px;
-    line-height: 1.55;
-  }
-
-  .menu-version {
-    position: absolute;
-    left: 18px;
-    bottom: 14px;
-    color: rgba(141, 167, 188, 0.7);
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.16em;
-  }
-
-  @media (max-width: 920px) {
-    .menu-grid {
-      grid-template-columns: 1fr;
-    }
-
-    .menu-console {
-      max-width: none;
-    }
-  }
-
+  /* ── RESPONSIVE ── */
   @media (max-width: 640px) {
-    .menu-root {
-      padding: 12px;
-    }
-
-    .menu-brand,
-    .menu-console {
-      border-radius: 24px;
-    }
-
-    .menu-brand {
-      padding: 20px;
-    }
-
-    .menu-console {
-      padding: 18px;
-    }
-
-    .menu-title {
-      font-size: 42px;
-    }
-
-    .menu-subtitle {
-      font-size: 16px;
-    }
-
-    .menu-description {
-      font-size: 14px;
-      line-height: 1.6;
-    }
-
-    .menu-input {
-      min-height: 48px;
-      font-size: 16px;
-    }
-
-    .menu-actions {
-      grid-template-columns: 1fr;
-    }
-
-    .menu-btn {
-      min-height: 74px;
-    }
-
-    .menu-controls-copy {
-      font-size: 12px;
-      line-height: 1.8;
-    }
+    .ob-match-grid   { grid-template-columns: repeat(2, 1fr); }
+    .ob-launch-row   { flex-direction: column; }
+    .ob-callsign-box { min-width: 0; width: 90vw; }
+    .menu-root       { cursor: auto; }
+    .ob-cursor       { display: none; }
+    .ob-topbar, .ob-bottombar { padding-left: 20px; padding-right: 20px; }
+    .ob-main-wrap    { gap: 22px; }
   }
-
-  @media (max-height: 720px) {
-    .menu-brand {
-      padding-top: 20px;
-      padding-bottom: 22px;
-    }
-
-    .menu-title {
-      font-size: clamp(38px, 7vw, 72px);
-    }
-
-    .menu-subtitle {
-      margin-top: 10px;
-      font-size: 17px;
-    }
-
-    .menu-description {
-      margin-top: 14px;
-      font-size: 14px;
-    }
-
-    .menu-highlights {
-      margin-top: 16px;
-    }
-
-    .menu-controls {
-      margin-top: 18px;
-      padding-top: 16px;
-    }
-
-    .menu-input {
-      min-height: 48px;
-    }
-
-    .menu-btn {
-      min-height: 74px;
-      padding-top: 12px;
-      padding-bottom: 12px;
-    }
+  @media (max-width: 920px) {
+    .ob-topbar-right .ob-clock { display: none; }
   }
-
+  @media (max-height: 700px) {
+    .ob-main-wrap { gap: 18px; padding: 60px 0 40px; }
+    .ob-title { font-size: clamp(34px, 7vw, 80px); }
+  }
   @media (prefers-reduced-motion: reduce) {
-    .menu-root,
-    .menu-brand,
-    .menu-console,
-    .menu-orb {
-      animation: none !important;
-    }
+    .ob-ring, .ob-stars i, .ob-pulse, .menu-root { animation: none !important; }
+    .ob-title-waves { display: none; }
   }
 `;
 
+/* ─────────────────────────────────────────────
+   EXPORTED INTERFACE (unchanged from original)
+───────────────────────────────────────────── */
 export interface MenuElements {
   container: HTMLDivElement;
   root: HTMLElement;
@@ -532,148 +383,446 @@ export interface MenuElements {
   playOnlineButton: HTMLButtonElement;
 }
 
+/* ─────────────────────────────────────────────
+   STYLE INJECTION (called by menu.ts controller)
+───────────────────────────────────────────── */
 export function injectMenuStyle(): HTMLStyleElement {
+  injectDesignTokens();
   const style = document.createElement("style");
   style.textContent = CSS;
   document.head.appendChild(style);
   return style;
 }
 
+/* ─────────────────────────────────────────────
+   VIEW FACTORY
+───────────────────────────────────────────── */
 export function createMenuView(savedName: string, matchSize: MatchTeamSize): MenuElements {
-  const mobile = isTouchDevice();
-  const controlsHtml = mobile
-    ? `Drag screen to look &nbsp;&middot;&nbsp; Left stick moves in the breach room<br>
-       <span class="menu-key">GRAB</span> Catch a rail &nbsp;&middot;&nbsp;
-       <span class="menu-key">LAUNCH</span> Hold and drag down to charge<br>
-       <span class="menu-key">FIRE</span> Freeze shot &nbsp;&middot;&nbsp;
-       <span class="menu-key">3RD / 1ST</span> Swap view`
-    : `<span class="menu-key">WASD</span> Move in breach room &nbsp;&middot;&nbsp;
-       <span class="menu-key">E</span> Grab / release rail &nbsp;&middot;&nbsp;
-       <span class="menu-key">SPACE</span> Jump or charge launch<br>
-       <span class="menu-key">LMB</span> Freeze shot &nbsp;&middot;&nbsp;
-       <span class="menu-key">V</span> Third person &nbsp;&middot;&nbsp;
-       <span class="menu-key">B</span> Selfie view &nbsp;&middot;&nbsp;
-       <span class="menu-key">ESC</span> Release cursor`;
+  injectDesignTokens();
 
-  const container = document.createElement("div");
+  // Map matchSize to the nearest visible card (1,5,10,20 — no 2v2 card shown)
+  const cardSizes = [1, 5, 10, 20] as const;
+  const matchCardSize: number =
+    (cardSizes as readonly number[]).includes(matchSize) ? matchSize : 1;
+
+  const touch = isTouchDevice();
+
+  function cardHtml(size: number, label: string, bots: string): string {
+    return `
+      <button class="ob-match-card${matchCardSize === size ? " ob-selected" : ""}" data-card-size="${size}">
+        <div class="ob-card-size">${size}<em>v</em>${size}</div>
+        <div class="ob-card-name">${label}</div>
+        <div class="ob-card-bots">${bots}</div>
+      </button>`;
+  }
+
+  function btn(id: string, mod: string, label: string): string {
+    return `
+      <button class="ob-btn ob-btn-${mod}" id="${id}">
+        <span class="ob-btn-corner ob-tl"></span><span class="ob-btn-corner ob-tr"></span>
+        <span class="ob-btn-corner ob-bl"></span><span class="ob-btn-corner ob-br"></span>
+        <span class="ob-btn-label">${label} <span class="ob-btn-arrow">→</span></span>
+      </button>`;
+  }
+
+  const container = document.createElement("div") as HTMLDivElement;
   container.innerHTML = `
     <div class="menu-root" id="menu-root">
-      <div class="menu-orb menu-orb--cyan"></div>
-      <div class="menu-orb menu-orb--magenta"></div>
 
-      <span class="menu-corner menu-corner--tl"></span>
-      <span class="menu-corner menu-corner--tr"></span>
-      <span class="menu-corner menu-corner--bl"></span>
-      <span class="menu-corner menu-corner--br"></span>
-
-      <div class="menu-grid">
-        <section class="menu-brand">
-          <div class="menu-kicker">Zero-G squad skirmish</div>
-          <div class="menu-title">
-            <span>Orbital</span>
-            <span>Breach</span>
+      <!-- BACKGROUND (fixed children; removed with container) -->
+      <div class="ob-planet"></div>
+      <div class="ob-stars" id="ob-stars"></div>
+      <div class="ob-bg-vignette"></div>
+      <div class="ob-orbit-stage">
+        <div class="ob-orbit-tilt" id="ob-orbit-tilt">
+          <div class="ob-ring ob-ring-1">
+            <svg viewBox="-200 -200 400 400">
+              <g class="ob-ring-ticks"></g>
+              <text x="0"    y="-205" text-anchor="middle">R = 4.21 AU · TRAJ 000</text>
+              <text x="205"  y="3"    text-anchor="start">090</text>
+              <text x="0"    y="213"  text-anchor="middle">180</text>
+              <text x="-205" y="3"    text-anchor="end">270</text>
+              <circle cx="140"  cy="-140" r="3" class="ob-dot"/>
+              <circle cx="-170" cy="85"   r="2" class="ob-dot-warm"/>
+            </svg>
           </div>
-          <div class="menu-subtitle">Freeze. Slingshot. Breach.</div>
-
-          <p class="menu-description">
-            Freeze their movement, sling off arena rails, and punch through the enemy portal
-            before your squad gets stranded in open zero-G.
-          </p>
-
-          <div class="menu-highlights">
-            <span class="menu-chip">Vibe Jam 2026 build</span>
-            <span class="menu-chip">Solo bots 1v1 to 20v20</span>
-            <span class="menu-chip">5-round match point</span>
+          <div class="ob-ring ob-ring-2 ob-ring-dashed">
+            <svg viewBox="-200 -200 400 400">
+              <text x="0" y="-203" text-anchor="middle">ORBITAL TIER II · STANDING BY</text>
+            </svg>
           </div>
-
-          <div class="menu-controls">
-            <div class="menu-controls-title">Flight controls</div>
-            <div class="menu-controls-copy">${controlsHtml}</div>
+          <div class="ob-ring ob-ring-3">
+            <svg viewBox="-200 -200 400 400">
+              <circle cx="0"   cy="-194" r="4"  class="ob-dot"/>
+              <circle cx="0"   cy="-194" r="9"  fill="none" stroke="var(--ob-cyan)" stroke-opacity=".4"/>
+              <text x="14" y="-188">BREACH α</text>
+              <circle cx="165" cy="102"  r="3"  class="ob-dot-warm"/>
+              <text x="178" y="108">BREACH β</text>
+            </svg>
           </div>
-        </section>
-
-        <section class="menu-console">
-          <div class="menu-console-header">
-            <div class="menu-console-kicker">Pre-flight console</div>
-            <div class="menu-console-note">Press Enter any time to launch straight into solo.</div>
+          <div class="ob-ring ob-ring-4 ob-ring-dashed"></div>
+          <div class="ob-ring ob-ring-5">
+            <svg viewBox="-200 -200 400 400">
+              <g id="ob-inner-ticks"></g>
+              <text x="0" y="-186" text-anchor="middle">CORE · SYNC 97.4%</text>
+            </svg>
           </div>
+        </div>
+      </div>
+      <div class="ob-bg-grain"></div>
 
-          <div class="menu-section">
-            <label class="menu-label" for="menu-name">Call Sign</label>
+      <!-- CURSOR -->
+      ${!touch ? `
+      <div class="ob-cursor" id="ob-cursor">
+        <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" stroke-width=".8">
+          <line x1="20" y1="0"  x2="20" y2="10"/>
+          <line x1="20" y1="30" x2="20" y2="40"/>
+          <line x1="0"  y1="20" x2="10" y2="20"/>
+          <line x1="30" y1="20" x2="40" y2="20"/>
+        </svg>
+      </div>` : ""}
+
+      <!-- CORNER CHROME -->
+      <span class="ob-hud-corner ob-tl"></span>
+      <span class="ob-hud-corner ob-tr"></span>
+      <span class="ob-hud-corner ob-bl"></span>
+      <span class="ob-hud-corner ob-br"></span>
+
+      <!-- TOPBAR -->
+      <div class="ob-topbar">
+        <div class="ob-topbar-brand">ORBITAL BREACH <em>v0.4 · ZERO-G ARENA</em></div>
+        <div class="ob-topbar-right">
+          <span><span class="ob-topbar-dot"></span>LINK SYNC</span>
+          <span class="ob-clock" id="ob-clock">00:00:00 UTC</span>
+        </div>
+      </div>
+
+      <!-- MAIN CONTENT -->
+      <div class="ob-main-wrap">
+        <div class="ob-tag">ZERO-G ARENA · STANDING BY</div>
+
+        <h1 class="ob-title" id="ob-title">
+          <canvas class="ob-title-waves" id="ob-title-waves"></canvas>
+          ORBITAL BREACH
+        </h1>
+
+        <div class="ob-subtitle">
+          <span class="ob-pulse"></span>
+          <span>Freeze &middot; Slingshot &middot; Breach</span>
+          <span class="ob-pulse"></span>
+        </div>
+
+        <div class="ob-callsign">
+          <div class="ob-callsign-label">Call Sign</div>
+          <label class="ob-callsign-box">
+            <span class="ob-bracket ob-l"></span>
+            <span class="ob-callsign-prefix">[ CS-07 ]</span>
             <input
-              class="menu-input"
-              id="menu-name"
               type="text"
-              placeholder="ENTER NAME"
+              id="menu-name"
               maxlength="16"
+              placeholder="ENTER CALL SIGN"
               value="${escapeHtml(savedName)}"
               autocomplete="off"
               spellcheck="false"
             />
-            <div class="menu-name-error" id="menu-name-error" aria-live="polite"></div>
-          </div>
+            <span class="ob-bracket ob-r"></span>
+          </label>
+          <div class="ob-name-error" id="menu-name-error" aria-live="polite"></div>
+        </div>
 
-          <div class="menu-section">
-            <label class="menu-label" for="menu-match-size">Solo Match Size</label>
-            <select class="menu-input" id="menu-match-size" aria-label="Solo match size">
-              <option value="1" ${matchSize === 1 ? "selected" : ""}>1v1 Skirmish</option>
-              <option value="2" ${matchSize === 2 ? "selected" : ""}>2v2 Duos</option>
-              <option value="5" ${matchSize === 5 ? "selected" : ""}>5v5 Squad Clash</option>
-              <option value="10" ${matchSize === 10 ? "selected" : ""}>10v10 Arena Rush</option>
-              <option value="20" ${matchSize === 20 ? "selected" : ""}>20v20 Zero-G War</option>
-            </select>
-          </div>
+        <div class="ob-match-grid" id="ob-match-grid">
+          ${cardHtml(1,  "Skirmish",   "Bots off")}
+          ${cardHtml(5,  "Squad Clash","8 bots")}
+          ${cardHtml(10, "Arena Rush", "18 bots")}
+          ${cardHtml(20, "Zero-G War", "38 bots")}
+        </div>
 
-          <div class="menu-divider"></div>
+        <!-- Hidden select keeps the controller's .value + change listener working -->
+        <select class="ob-match-select-hidden" id="menu-match-size" aria-label="Solo match size">
+          <option value="1"  ${matchSize === 1  ? "selected" : ""}>1v1 Skirmish</option>
+          <option value="2"  ${matchSize === 2  ? "selected" : ""}>2v2 Duos</option>
+          <option value="5"  ${matchSize === 5  ? "selected" : ""}>5v5 Squad Clash</option>
+          <option value="10" ${matchSize === 10 ? "selected" : ""}>10v10 Arena Rush</option>
+          <option value="20" ${matchSize === 20 ? "selected" : ""}>20v20 Zero-G War</option>
+        </select>
 
-          <div class="menu-actions">
-            <button class="menu-btn menu-btn--primary" id="btn-play-solo">
-              <span class="menu-btn__eyebrow">Fastest route</span>
-              <span class="menu-btn__title">Play Solo</span>
-            </button>
-            <button class="menu-btn menu-btn--secondary" id="btn-play-online">
-              <span class="menu-btn__eyebrow">Live room</span>
-              <span class="menu-btn__title">Play Online</span>
-            </button>
-          </div>
-
-          <div class="menu-actions-note">
-            Solo drops you in immediately. Online opens the shared lobby and match setup flow.
-          </div>
-        </section>
+        <div class="ob-launch-row">
+          ${btn("btn-play-solo",   "primary",   "Engage Solo")}
+          ${btn("btn-play-online", "secondary", "Join Online")}
+        </div>
       </div>
 
-      <div class="menu-version">v0.1.0 &middot; Orbital Breach</div>
+      <!-- BOTTOMBAR -->
+      <div class="ob-bottombar">
+        <div class="ob-bottombar-tel">
+          <span>CLIENT <b>CY-07</b></span>
+          <span>TICK <b>20 Hz</b></span>
+        </div>
+        <div>© 2026 ORBITAL BREACH</div>
+      </div>
+
     </div>
   `;
+
   document.body.appendChild(container);
+
+  // Wire visual cards → hidden select
+  const matchSelect = container.querySelector<HTMLSelectElement>("#menu-match-size")!;
+  container.querySelectorAll<HTMLElement>(".ob-match-card").forEach((card) => {
+    card.addEventListener("click", () => {
+      container.querySelectorAll(".ob-match-card").forEach((c) => c.classList.remove("ob-selected"));
+      card.classList.add("ob-selected");
+      const size = card.dataset["cardSize"];
+      if (size) {
+        matchSelect.value = size;
+        matchSelect.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    });
+  });
+
+  // Launch background animations
+  initMenuFx(container);
 
   return {
     container,
-    root: container.querySelector<HTMLElement>("#menu-root")!,
-    nameInput: container.querySelector<HTMLInputElement>("#menu-name")!,
-    nameError: container.querySelector<HTMLElement>("#menu-name-error")!,
-    matchSizeSelect: container.querySelector<HTMLSelectElement>("#menu-match-size")!,
-    playSoloButton: container.querySelector<HTMLButtonElement>("#btn-play-solo")!,
-    playOnlineButton: container.querySelector<HTMLButtonElement>("#btn-play-online")!,
+    root:           container.querySelector<HTMLElement>("#menu-root")!,
+    nameInput:      container.querySelector<HTMLInputElement>("#menu-name")!,
+    nameError:      container.querySelector<HTMLElement>("#menu-name-error")!,
+    matchSizeSelect: matchSelect,
+    playSoloButton:  container.querySelector<HTMLButtonElement>("#btn-play-solo")!,
+    playOnlineButton:container.querySelector<HTMLButtonElement>("#btn-play-online")!,
   };
 }
 
+/* ─────────────────────────────────────────────
+   INTERACTIVE FX
+───────────────────────────────────────────── */
+function initMenuFx(container: HTMLElement): void {
+  const root = container.querySelector<HTMLElement>("#menu-root");
+  if (!root) return;
+
+  // ── 1. Starfield ──
+  const starsEl = root.querySelector<HTMLElement>("#ob-stars");
+  if (starsEl) {
+    const frag = document.createDocumentFragment();
+    for (let i = 0; i < 180; i++) {
+      const s = document.createElement("i");
+      s.style.left = Math.random() * 100 + "vw";
+      s.style.top  = Math.random() * 100 + "vh";
+      const sz = Math.random() < 0.15 ? 2 : 1;
+      s.style.width = sz + "px"; s.style.height = sz + "px";
+      s.style.setProperty("--o", (0.2 + Math.random() * 0.8).toFixed(2));
+      s.style.setProperty("--t", (3 + Math.random() * 7).toFixed(1) + "s");
+      s.style.setProperty("--d", (Math.random() * 6).toFixed(1) + "s");
+      frag.appendChild(s);
+    }
+    starsEl.appendChild(frag);
+  }
+
+  // ── 2. Ring ticks ──
+  const outerTickG = root.querySelector<SVGGElement>(".ob-ring-1 .ob-ring-ticks");
+  if (outerTickG) {
+    for (let i = 0; i < 72; i++) {
+      const a = (i / 72) * Math.PI * 2;
+      const inner = i % 6 === 0 ? 190 : 194;
+      const ln = document.createElementNS("http://www.w3.org/2000/svg", "line");
+      ln.setAttribute("x1", String(Math.cos(a) * inner));
+      ln.setAttribute("y1", String(Math.sin(a) * inner));
+      ln.setAttribute("x2", String(Math.cos(a) * 200));
+      ln.setAttribute("y2", String(Math.sin(a) * 200));
+      ln.setAttribute("class", i % 6 === 0 ? "ob-tick-major" : "ob-tick");
+      outerTickG.appendChild(ln);
+    }
+  }
+  const innerTickG = root.querySelector<SVGGElement>("#ob-inner-ticks");
+  if (innerTickG) {
+    for (let i = 0; i < 48; i++) {
+      const a = (i / 48) * Math.PI * 2;
+      const ln = document.createElementNS("http://www.w3.org/2000/svg", "line");
+      ln.setAttribute("x1", String(Math.cos(a) * 172));
+      ln.setAttribute("y1", String(Math.sin(a) * 172));
+      ln.setAttribute("x2", String(Math.cos(a) * 180));
+      ln.setAttribute("y2", String(Math.sin(a) * 180));
+      ln.setAttribute("stroke", "rgba(210,220,240,0.28)");
+      ln.setAttribute("stroke-width", "1");
+      innerTickG.appendChild(ln);
+    }
+  }
+
+  // ── 3. Per-letter title wrap ──
+  const titleEl  = root.querySelector<HTMLElement>("#ob-title");
+  const wavesCvs = root.querySelector<HTMLCanvasElement>("#ob-title-waves");
+  if (titleEl && wavesCvs) {
+    wavesCvs.remove();
+    titleEl.innerHTML = "";
+    titleEl.appendChild(wavesCvs);
+    for (const ch of "ORBITAL BREACH") {
+      if (ch === " ") { titleEl.appendChild(document.createTextNode(" ")); continue; }
+      const s = document.createElement("span");
+      s.className = "ob-letter";
+      s.textContent = ch;
+      titleEl.appendChild(s);
+    }
+  }
+
+  // ── 4. Sine wave canvas on title hover ──
+  if (titleEl && wavesCvs) {
+    const ctx = wavesCvs.getContext("2d");
+    if (ctx) {
+      let W = 0, H = 0, rafWave = 0, waveRunning = false;
+      const DPR = Math.min(window.devicePixelRatio || 1, 2);
+
+      const resizeWave = () => {
+        const r = wavesCvs.getBoundingClientRect();
+        W = Math.max(1, Math.floor(r.width));
+        H = Math.max(1, Math.floor(r.height));
+        wavesCvs.width  = W * DPR;
+        wavesCvs.height = H * DPR;
+        ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+      };
+      resizeWave();
+      const ro = new ResizeObserver(resizeWave);
+      ro.observe(titleEl);
+
+      const drawWave = (t: number, color: string, phase: number, amp: number, freq: number, speed: number, offset: number) => {
+        const mid = H / 2;
+        const passes = [
+          { dOff: -6, a: 0.06, w: 14 }, { dOff: -3, a: 0.10, w: 8 },
+          { dOff:  0, a: 0.28, w:  3 }, { dOff:  3, a: 0.10, w: 8 },
+          { dOff:  6, a: 0.06, w: 14 },
+        ];
+        for (const p of passes) {
+          ctx.beginPath(); ctx.strokeStyle = color;
+          ctx.globalAlpha = p.a; ctx.lineWidth = p.w; ctx.lineCap = "round";
+          for (let x = 0; x <= W; x += 4) {
+            const nx = x / W;
+            const y = mid
+              + Math.sin(nx * freq + t * speed + phase) * amp
+              + Math.sin(nx * (freq * 0.47) - t * speed * 0.6 + phase * 1.3) * (amp * 0.45)
+              + offset + p.dOff;
+            x === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+          }
+          ctx.stroke();
+        }
+        ctx.globalAlpha = 1;
+      };
+
+      let waveStart = performance.now();
+      const frameWave = (now: number) => {
+        if (!waveRunning) return;
+        const t = (now - waveStart) / 1000;
+        ctx.clearRect(0, 0, W, H);
+        const cs = getComputedStyle(document.documentElement);
+        const c  = cs.getPropertyValue("--ob-cyan").trim()    || "#5ccfff";
+        const m  = cs.getPropertyValue("--ob-magenta").trim() || "#ff5cd0";
+        const amp = Math.min(H * 0.18, 42);
+        drawWave(t, c, 0,          amp,       7,  1.6, -amp * 0.4);
+        drawWave(t, m, Math.PI,    amp,       7, -1.6,  amp * 0.4);
+        drawWave(t, c, Math.PI * 0.5, amp * 0.55, 11, -1.1, 0);
+        drawWave(t, m, Math.PI * 1.5, amp * 0.55, 11,  1.1, 0);
+        rafWave = requestAnimationFrame(frameWave);
+      };
+      titleEl.addEventListener("mouseenter", () => {
+        waveRunning = true; waveStart = performance.now();
+        rafWave = requestAnimationFrame(frameWave);
+      });
+      titleEl.addEventListener("mouseleave", () => {
+        waveRunning = false;
+        setTimeout(() => { if (!waveRunning) ctx.clearRect(0, 0, W, H); }, 500);
+      });
+    }
+  }
+
+  // ── 5. Cursor + orbit tilt + letter parallax loop ──
+  const cursorEl = root.querySelector<HTMLElement>("#ob-cursor");
+  const orbitEl  = root.querySelector<HTMLElement>("#ob-orbit-tilt");
+  let mx = window.innerWidth / 2, my = window.innerHeight / 2;
+  let cx = mx, cy = my;
+  let rafMain = 0;
+
+  const onMove = (e: MouseEvent) => { mx = e.clientX; my = e.clientY; };
+  const onDown = () => cursorEl?.classList.add("ob-hot");
+  const onUp   = () => cursorEl?.classList.remove("ob-hot");
+  window.addEventListener("mousemove", onMove);
+  window.addEventListener("mousedown", onDown);
+  window.addEventListener("mouseup",   onUp);
+
+  const mainLoop = () => {
+    if (!root.isConnected) return;
+    cx += (mx - cx) * 0.25;
+    cy += (my - cy) * 0.25;
+    if (cursorEl) cursorEl.style.transform = `translate(${cx}px,${cy}px) translate(-50%,-50%)`;
+    if (orbitEl) {
+      const nx = (mx / window.innerWidth  - 0.5) * 2;
+      const ny = (my / window.innerHeight - 0.5) * 2;
+      orbitEl.style.transform = `rotateX(${62 + ny * 5}deg) rotateZ(${-nx * 13}deg)`;
+    }
+    if (titleEl) {
+      titleEl.querySelectorAll<HTMLElement>(".ob-letter").forEach((l) => {
+        const r = l.getBoundingClientRect();
+        const dx = mx - (r.left + r.width  / 2);
+        const dy = my - (r.top  + r.height / 2);
+        const d  = Math.sqrt(dx * dx + dy * dy);
+        const pull = Math.max(0, 1 - d / 340);
+        l.style.transform = `translate(${-(dx / 340) * 12 * pull}px, ${-(dy / 340) * 6 * pull}px)`;
+      });
+    }
+    rafMain = requestAnimationFrame(mainLoop);
+  };
+  rafMain = requestAnimationFrame(mainLoop);
+
+  // Cleanup once container leaves the DOM
+  const mo = new MutationObserver(() => {
+    if (!root.isConnected) {
+      cancelAnimationFrame(rafMain);
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("mouseup",   onUp);
+      mo.disconnect();
+    }
+  });
+  mo.observe(document.body, { childList: true });
+
+  // ── 6. Button radial hover ──
+  root.querySelectorAll<HTMLElement>(".ob-btn, .ob-match-card").forEach((el) => {
+    el.addEventListener("mousemove", (e: MouseEvent) => {
+      const r = el.getBoundingClientRect();
+      el.style.setProperty("--mx", ((e.clientX - r.left) / r.width  * 100) + "%");
+      el.style.setProperty("--my", ((e.clientY - r.top)  / r.height * 100) + "%");
+    });
+  });
+  root.querySelectorAll<HTMLElement>(".ob-btn-primary, .ob-match-card").forEach((el) => {
+    el.addEventListener("mouseenter", () => cursorEl?.classList.add("ob-hot"));
+    el.addEventListener("mouseleave", () => cursorEl?.classList.remove("ob-hot"));
+  });
+
+  // ── 7. UTC clock ──
+  const clockEl = root.querySelector<HTMLElement>("#ob-clock");
+  if (clockEl) {
+    const tick = () => {
+      if (!root.isConnected) return;
+      const d = new Date();
+      clockEl.textContent = [d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds()]
+        .map((n) => String(n).padStart(2, "0")).join(":") + " UTC";
+      setTimeout(tick, 1000);
+    };
+    tick();
+  }
+}
+
+/* ─────────────────────────────────────────────
+   UTIL
+───────────────────────────────────────────── */
 function escapeHtml(raw: string): string {
   return raw.replace(/[&<>"']/g, (ch) => {
     switch (ch) {
-      case "&":
-        return "&amp;";
-      case "<":
-        return "&lt;";
-      case ">":
-        return "&gt;";
-      case '"':
-        return "&quot;";
-      case "'":
-        return "&#39;";
-      default:
-        return ch;
+      case "&":  return "&amp;";
+      case "<":  return "&lt;";
+      case ">":  return "&gt;";
+      case '"':  return "&quot;";
+      case "'":  return "&#39;";
+      default:   return ch;
     }
   });
 }

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -344,6 +344,70 @@ const CSS = `
   .ob-btn-corner.ob-bl { bottom: 4px; left: 4px;  border-right: none; border-top:    none; }
   .ob-btn-corner.ob-br { bottom: 4px; right: 4px; border-left:  none; border-top:    none; }
 
+  /* ── TUTORIAL BUTTON ── */
+  .ob-tutorial-btn {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    width: 100%;
+    max-width: 880px;
+    padding: 16px 38px;
+    background: rgba(255, 125, 248, 0.06);
+    border: 1px solid rgba(255, 125, 248, 0.28);
+    color: var(--ob-fg);
+    font-family: var(--ob-mono);
+    text-transform: uppercase;
+    cursor: none;
+    overflow: hidden;
+    transition: border-color .25s, background .25s, transform .25s;
+  }
+  .ob-tutorial-btn::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at var(--mx,50%) var(--my,50%), var(--ob-magenta-soft), transparent 60%);
+    opacity: 0;
+    transition: opacity .3s;
+    z-index: 1;
+  }
+  .ob-tutorial-btn:hover {
+    border-color: var(--ob-magenta);
+    background: rgba(255, 125, 248, 0.1);
+    transform: translateY(-1px);
+  }
+  .ob-tutorial-btn:hover::before { opacity: 1; }
+  .ob-tutorial-btn-main {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    position: relative;
+    z-index: 2;
+  }
+  .ob-tutorial-btn-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 5px;
+    color: var(--ob-magenta);
+  }
+  .ob-tutorial-btn-sub {
+    font-size: 9px;
+    letter-spacing: 3px;
+    color: var(--ob-fg-faint);
+  }
+  .ob-tutorial-btn-arrow {
+    font-family: var(--ob-serif);
+    font-size: 20px;
+    color: var(--ob-magenta);
+    letter-spacing: 0;
+    position: relative;
+    z-index: 2;
+    transition: transform .3s;
+  }
+  .ob-tutorial-btn:hover .ob-tutorial-btn-arrow { transform: translateX(6px); }
+
   /* hidden select keeps controller wiring intact */
   .ob-match-select-hidden { display: none; }
 
@@ -384,6 +448,7 @@ export interface MenuElements {
   matchSizeSelect: HTMLSelectElement;
   playSoloButton: HTMLButtonElement;
   playOnlineButton: HTMLButtonElement;
+  playTutorialButton: HTMLButtonElement;
 }
 
 /* ─────────────────────────────────────────────
@@ -534,12 +599,24 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
           <div class="ob-name-error" id="menu-name-error" aria-live="polite"></div>
         </div>
 
+        <button id="btn-play-tutorial" class="ob-tutorial-btn">
+          <span class="ob-btn-corner ob-tl" style="border-color:var(--ob-magenta);opacity:.4;"></span>
+          <span class="ob-btn-corner ob-tr" style="border-color:var(--ob-magenta);opacity:.4;"></span>
+          <span class="ob-btn-corner ob-bl" style="border-color:var(--ob-magenta);opacity:.4;"></span>
+          <span class="ob-btn-corner ob-br" style="border-color:var(--ob-magenta);opacity:.4;"></span>
+          <span class="ob-tutorial-btn-main">
+            <span class="ob-tutorial-btn-label">Tutorial</span>
+            <span class="ob-tutorial-btn-sub">Empty Arena · Bots Off · First Flight Guide</span>
+          </span>
+          <span class="ob-tutorial-btn-arrow">→</span>
+        </button>
+
         <div class="ob-match-grid" id="ob-match-grid">
-          ${cardHtml(1,  "Skirmish",   "Bots off")}
-          ${cardHtml(2,  "Duos",       "Bots off")}
-          ${cardHtml(5,  "Squad Clash","8 bots")}
-          ${cardHtml(10, "Arena Rush", "18 bots")}
-          ${cardHtml(20, "Zero-G War", "38 bots")}
+          ${cardHtml(1,  "Skirmish",   "1 bot")}
+          ${cardHtml(2,  "Duos",       "3 bots")}
+          ${cardHtml(5,  "Squad Clash","9 bots")}
+          ${cardHtml(10, "Arena Rush", "19 bots")}
+          ${cardHtml(20, "Zero-G War", "39 bots")}
         </div>
 
         <!-- Hidden select keeps the controller's .value + change listener working -->
@@ -590,12 +667,13 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
 
   return {
     container,
-    root:           container.querySelector<HTMLElement>("#menu-root")!,
-    nameInput:      container.querySelector<HTMLInputElement>("#menu-name")!,
-    nameError:      container.querySelector<HTMLElement>("#menu-name-error")!,
-    matchSizeSelect: matchSelect,
-    playSoloButton:  container.querySelector<HTMLButtonElement>("#btn-play-solo")!,
-    playOnlineButton:container.querySelector<HTMLButtonElement>("#btn-play-online")!,
+    root:              container.querySelector<HTMLElement>("#menu-root")!,
+    nameInput:         container.querySelector<HTMLInputElement>("#menu-name")!,
+    nameError:         container.querySelector<HTMLElement>("#menu-name-error")!,
+    matchSizeSelect:   matchSelect,
+    playSoloButton:    container.querySelector<HTMLButtonElement>("#btn-play-solo")!,
+    playOnlineButton:  container.querySelector<HTMLButtonElement>("#btn-play-online")!,
+    playTutorialButton:container.querySelector<HTMLButtonElement>("#btn-play-tutorial")!,
   };
 }
 
@@ -789,7 +867,7 @@ function initMenuFx(container: HTMLElement): void {
   mo.observe(document.body, { childList: true });
 
   // ── 6. Button radial hover ──
-  root.querySelectorAll<HTMLElement>(".ob-btn, .ob-match-card").forEach((el) => {
+  root.querySelectorAll<HTMLElement>(".ob-btn, .ob-match-card, .ob-tutorial-btn").forEach((el) => {
     el.addEventListener("mousemove", (e: MouseEvent) => {
       const r = el.getBoundingClientRect();
       el.style.setProperty("--mx", ((e.clientX - r.left) / r.width  * 100) + "%");
@@ -800,6 +878,9 @@ function initMenuFx(container: HTMLElement): void {
     el.addEventListener("mouseenter", () => cursorEl?.classList.add("ob-hot"));
     el.addEventListener("mouseleave", () => cursorEl?.classList.remove("ob-hot"));
   });
+  const tutorialBtn = root.querySelector<HTMLElement>(".ob-tutorial-btn");
+  tutorialBtn?.addEventListener("mouseenter", () => cursorEl?.classList.add("ob-hot"));
+  tutorialBtn?.addEventListener("mouseleave", () => cursorEl?.classList.remove("ob-hot"));
 
   // ── 7. UTC clock ──
   const clockEl = root.querySelector<HTMLElement>("#ob-clock");

--- a/client/src/ui/multiplayerLobby.ts
+++ b/client/src/ui/multiplayerLobby.ts
@@ -41,7 +41,7 @@ const CSS = `
     max-height: calc(100vh - 32px);
     overflow: auto;
     border: 1px solid var(--mp-border);
-    border-radius: 28px;
+    border-radius: 0;
     background:
       radial-gradient(circle at top left, rgba(127, 252, 255, 0.11), rgba(127, 252, 255, 0) 24%),
       radial-gradient(circle at bottom right, rgba(255, 125, 248, 0.12), rgba(255, 125, 248, 0) 28%),
@@ -64,7 +64,7 @@ const CSS = `
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 18px;
     padding: 22px 24px 18px;
-    border-radius: 28px 28px 0 0;
+    border-radius: 0;
     background:
       linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
       var(--mp-panel-strong);
@@ -120,7 +120,7 @@ const CSS = `
     align-items: center;
     min-height: 32px;
     padding: 0 12px;
-    border-radius: 999px;
+    border-radius: 2px;
     color: #defdff;
     background: rgba(127, 252, 255, 0.12);
     border: 1px solid rgba(127, 252, 255, 0.2);
@@ -149,7 +149,7 @@ const CSS = `
 
   .ob-mp-status {
     padding: 13px 15px;
-    border-radius: 18px;
+    border-radius: 0;
     font-size: 14px;
     line-height: 1.5;
   }
@@ -160,7 +160,7 @@ const CSS = `
     gap: 10px;
     margin-top: 16px;
     padding: 14px;
-    border-radius: 20px;
+    border-radius: 0;
   }
 
   .ob-mp-select-wrap {
@@ -181,7 +181,7 @@ const CSS = `
   .ob-mp-select,
   .ob-mp-button {
     min-height: 44px;
-    border-radius: 14px;
+    border-radius: 0;
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: rgba(255, 255, 255, 0.04);
     color: #effcff;
@@ -257,7 +257,7 @@ const CSS = `
 
   .ob-mp-summary-card {
     padding: 14px 16px;
-    border-radius: 18px;
+    border-radius: 0;
   }
 
   .ob-mp-card-label {
@@ -291,7 +291,7 @@ const CSS = `
 
   .ob-mp-team {
     padding: 16px;
-    border-radius: 22px;
+    border-radius: 0;
   }
 
   .ob-mp-team--cyan {
@@ -312,9 +312,10 @@ const CSS = `
   }
 
   .ob-mp-team-title {
-    font-size: 22px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
+    font-family: "Cormorant Garamond", serif;
+    font-size: 26px;
+    font-weight: 300;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
   }
 
@@ -348,7 +349,7 @@ const CSS = `
     gap: 12px;
     align-items: center;
     padding: 12px 13px;
-    border-radius: 18px;
+    border-radius: 0;
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid rgba(255, 255, 255, 0.08);
   }
@@ -382,7 +383,7 @@ const CSS = `
     align-items: center;
     min-height: 22px;
     padding: 0 8px;
-    border-radius: 999px;
+    border-radius: 2px;
     font-size: 9px;
     font-weight: 700;
     letter-spacing: 0.1em;
@@ -420,7 +421,7 @@ const CSS = `
 
   .ob-mp-empty {
     padding: 18px 14px;
-    border-radius: 16px;
+    border-radius: 0;
     color: var(--mp-muted);
     background: rgba(255, 255, 255, 0.03);
     border: 1px dashed rgba(255, 255, 255, 0.1);

--- a/client/src/ui/multiplayerLobby.ts
+++ b/client/src/ui/multiplayerLobby.ts
@@ -476,6 +476,129 @@ const CSS = `
       justify-content: flex-start;
     }
   }
+
+  /* ===== BRIEFING 3-COLUMN LAYOUT ===== */
+  .ob-mp-briefing-layout {
+    display: grid;
+    grid-template-columns: 280px 1fr 280px;
+    gap: 14px;
+    margin-top: 14px;
+  }
+
+  .ob-mp-brief-panel {
+    border: 1px solid var(--mp-border);
+    background: rgba(7, 10, 18, 0.55);
+    backdrop-filter: blur(10px);
+    padding: 16px;
+  }
+  .ob-mp-brief-panel--cyan  { box-shadow: inset 0 0 0 1px rgba(127, 252, 255, 0.06); }
+  .ob-mp-brief-panel--magenta { box-shadow: inset 0 0 0 1px rgba(255, 125, 248, 0.06); }
+
+  .ob-mp-panel-head {
+    display: flex; justify-content: space-between; align-items: center;
+    font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 4px;
+    color: var(--mp-muted); text-transform: uppercase;
+    padding-bottom: 10px; margin-bottom: 12px;
+    border-bottom: 1px solid rgba(210, 220, 240, 0.06);
+  }
+  .ob-mp-panel-title {
+    margin: 0; font-family: "JetBrains Mono", monospace; font-weight: 400;
+    color: var(--mp-muted); font-size: 9px; letter-spacing: 4px;
+  }
+  .ob-mp-panel-idx { color: var(--mp-cyan); }
+
+  .ob-mp-brief-team-head {
+    display: flex; justify-content: space-between; align-items: baseline;
+    margin-bottom: 8px;
+  }
+  .ob-mp-brief-team-name {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 20px; font-weight: 300; letter-spacing: 0.1em;
+  }
+  .ob-mp-brief-team-count {
+    font-family: "JetBrains Mono", monospace; font-size: 10px;
+    color: var(--mp-muted); letter-spacing: 3px;
+  }
+
+  .ob-mp-brief-roster {
+    display: flex; flex-direction: column; gap: 1px;
+  }
+  .ob-mp-brief-row {
+    display: grid;
+    grid-template-columns: 18px 1fr auto auto;
+    gap: 10px; align-items: center;
+    padding: 8px 8px; border: 1px solid transparent;
+    font-family: "JetBrains Mono", monospace; font-size: 10px; letter-spacing: 2px;
+    color: var(--mp-muted);
+    transition: background 0.2s, border-color 0.2s, color 0.2s;
+  }
+  .ob-mp-brief-row:hover {
+    background: rgba(255, 255, 255, 0.03);
+    border-color: var(--mp-border);
+    color: #e8ecf4;
+  }
+  .ob-mp-brief-row--self-cyan    { background: rgba(100, 190, 255, 0.06); border-color: var(--mp-cyan); color: #e8ecf4; }
+  .ob-mp-brief-row--self-magenta { background: oklch(0.72 0.25 330 / 0.08); border-color: var(--mp-magenta); color: #e8ecf4; }
+  .ob-mp-brief-row--pending      { opacity: 0.5; }
+  .ob-mp-brief-slot { font-size: 9px; color: var(--mp-muted); opacity: 0.7; }
+  .ob-mp-brief-kd   { font-size: 9px; color: var(--mp-muted); opacity: 0.7; }
+  .ob-mp-brief-ready-dot {
+    width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+    background: var(--mp-cyan); box-shadow: 0 0 6px var(--mp-cyan);
+  }
+  .ob-mp-brief-ready-dot--magenta { background: var(--mp-magenta); box-shadow: 0 0 6px var(--mp-magenta); }
+  .ob-mp-brief-ready-dot--pending { background: var(--mp-muted); box-shadow: none; opacity: 0.3; }
+
+  /* Stage preview (center) */
+  .ob-mp-stage-preview {
+    border: 1px solid var(--mp-border);
+    background: rgba(7, 10, 18, 0.55);
+    backdrop-filter: blur(10px);
+    padding: 18px;
+    display: grid; grid-template-rows: auto 1fr auto;
+    gap: 10px; overflow: hidden;
+  }
+  .ob-mp-stage-head { display: flex; justify-content: space-between; align-items: baseline; }
+  .ob-mp-stage-title {
+    margin: 0;
+    font-family: "Cormorant Garamond", serif;
+    font-weight: 300; font-size: 26px; letter-spacing: 0.06em;
+    color: #e8ecf4;
+  }
+  .ob-mp-stage-meta {
+    font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 3px;
+    color: var(--mp-muted); text-transform: uppercase;
+  }
+  .ob-mp-map { display: grid; place-items: center; padding: 8px 0; }
+  .ob-mp-map-inner { width: 100%; max-width: 280px; aspect-ratio: 1; }
+  .ob-mp-arena-svg { width: 100%; height: 100%; overflow: visible; }
+
+  .ob-mp-loadout-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  .ob-mp-loadout-item {
+    border: 1px solid rgba(210, 220, 240, 0.06); padding: 10px 10px;
+    font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 2px;
+    text-transform: uppercase; display: grid; gap: 3px;
+    transition: border-color 0.2s;
+  }
+  .ob-mp-loadout-item:hover { border-color: rgba(210, 220, 240, 0.12); }
+  .ob-mp-loadout-key { color: var(--mp-muted); font-size: 8px; letter-spacing: 2px; }
+  .ob-mp-loadout-val {
+    color: #e8ecf4; font-family: "Cormorant Garamond", serif;
+    font-size: 13px; letter-spacing: 0.05em; text-transform: none;
+  }
+
+  /* Mission briefing (right panel bottom) */
+  .ob-mp-rule { height: 1px; background: rgba(210, 220, 240, 0.06); margin: 12px 0; }
+  .ob-mp-mission-brief {
+    font-family: "Cormorant Garamond", serif; font-size: 13px; line-height: 1.7;
+    color: var(--mp-muted);
+  }
+  .ob-mp-mission-brief p { margin: 0; }
+  .ob-mp-mission-brief strong { color: #e8ecf4; font-weight: 400; }
+
+  @media (max-width: 1100px) {
+    .ob-mp-briefing-layout { grid-template-columns: 1fr; }
+  }
 `;
 
 let styleInjected = false;
@@ -693,7 +816,7 @@ function buildMarkup(): string {
       <div class="ob-mp-header">
         <div>
           <div class="ob-mp-kicker">Online queue</div>
-          <div class="ob-mp-title">Orbital Breach Matchmaking</div>
+          <div class="ob-mp-title">Orbital Breach</div>
           <div class="ob-mp-subtitle">
             Balance the squads, ready the room, and deploy straight into the live round cycle.
           </div>
@@ -723,34 +846,97 @@ function buildMarkup(): string {
           <button id="mp-leave" class="ob-mp-button ob-mp-button--leave">Main Menu</button>
         </div>
 
-        <div class="ob-mp-summary">
-          <div id="mp-playlist-card" class="ob-mp-summary-card"></div>
-          <div id="mp-queue-card" class="ob-mp-summary-card"></div>
-          <div id="mp-team-card" class="ob-mp-summary-card"></div>
+        <div style="display:none">
+          <div id="mp-playlist-card"></div>
+          <div id="mp-queue-card"></div>
+          <div id="mp-team-card"></div>
         </div>
 
-        <div class="ob-mp-rosters">
-          <section class="ob-mp-team ob-mp-team--cyan">
-            <div class="ob-mp-team-header">
-              <div>
-                <div id="mp-team0-title" class="ob-mp-team-title" style="color:${CYAN};">Cyan squad</div>
-                <div class="ob-mp-team-meta">Freeze-first entry team</div>
-              </div>
-              <div id="mp-team0-count" class="ob-mp-team-count"></div>
-            </div>
-            <div id="mp-team0-roster" class="ob-mp-roster"></div>
-          </section>
+        <div class="ob-mp-briefing-layout">
 
-          <section class="ob-mp-team ob-mp-team--magenta">
-            <div class="ob-mp-team-header">
-              <div>
-                <div id="mp-team1-title" class="ob-mp-team-title" style="color:${MAGENTA};">Magenta squad</div>
-                <div class="ob-mp-team-meta">Counter-breach response team</div>
-              </div>
-              <div id="mp-team1-count" class="ob-mp-team-count"></div>
+          <div class="ob-mp-brief-panel ob-mp-brief-panel--cyan">
+            <div class="ob-mp-panel-head">
+              <h3 class="ob-mp-panel-title">Team Cyan <span class="ob-mp-panel-idx">// 01</span></h3>
+              <span>Friendly</span>
             </div>
-            <div id="mp-team1-roster" class="ob-mp-roster"></div>
-          </section>
+            <div class="ob-mp-brief-team-head">
+              <span id="mp-team0-title" class="ob-mp-brief-team-name" style="color:${CYAN}">Cyan</span>
+              <span id="mp-team0-count" class="ob-mp-brief-team-count"></span>
+            </div>
+            <div id="mp-team0-roster" class="ob-mp-brief-roster"></div>
+          </div>
+
+          <div class="ob-mp-stage-preview">
+            <div class="ob-mp-stage-head">
+              <h2 class="ob-mp-stage-title">Zero-G Arena</h2>
+              <div class="ob-mp-stage-meta">Orbital Station</div>
+            </div>
+            <div class="ob-mp-map">
+              <div class="ob-mp-map-inner">
+                <svg class="ob-mp-arena-svg" viewBox="-200 -200 400 400">
+                  <rect x="-190" y="-190" width="380" height="380" fill="none" stroke="rgba(210,220,240,0.1)"/>
+                  <line x1="0" y1="-190" x2="0" y2="190" stroke="rgba(210,220,240,0.05)" stroke-dasharray="2 4"/>
+                  <line x1="-190" y1="0" x2="190" y2="0" stroke="rgba(210,220,240,0.05)" stroke-dasharray="2 4"/>
+                  <g stroke="rgba(210,220,240,0.25)" fill="none">
+                    <path d="M -170 -130 L -80 -130 L -80 -60 L -170 -60 Z"/>
+                    <path d="M 170 130 L 80 130 L 80 60 L 170 60 Z"/>
+                  </g>
+                  <text x="-125" y="-142" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="oklch(0.82 0.15 210)" letter-spacing="2">CYAN BREACH</text>
+                  <text x="125" y="150" text-anchor="middle" font-family="JetBrains Mono" font-size="8" fill="oklch(0.72 0.25 330)" letter-spacing="2">MAGENTA BREACH</text>
+                  <circle cx="-80" cy="-95" r="10" fill="none" stroke="oklch(0.82 0.15 210)" stroke-opacity="0.7"/>
+                  <circle cx="-80" cy="-95" r="3" fill="oklch(0.82 0.15 210)"/>
+                  <circle cx="80" cy="95" r="10" fill="none" stroke="oklch(0.72 0.25 330)" stroke-opacity="0.7"/>
+                  <circle cx="80" cy="95" r="3" fill="oklch(0.72 0.25 330)"/>
+                  <g stroke="rgba(210,220,240,0.18)">
+                    <line x1="-40" y1="-40" x2="40" y2="40"/>
+                    <line x1="40" y1="-40" x2="-40" y2="40"/>
+                    <line x1="-60" y1="0" x2="60" y2="0"/>
+                    <line x1="0" y1="-60" x2="0" y2="60"/>
+                  </g>
+                  <circle cx="0" cy="0" r="4" fill="rgba(210,220,240,0.3)"/>
+                  <circle cx="0" cy="0" r="18" fill="none" stroke="rgba(210,220,240,0.1)"/>
+                  <circle cx="0" cy="0" r="45" fill="none" stroke="rgba(210,220,240,0.05)"/>
+                  <path d="M -80 -95 Q -20 0 80 95" fill="none" stroke="oklch(0.82 0.15 210)" stroke-opacity="0.35" stroke-dasharray="3 4"/>
+                  <text x="-185" y="185" font-family="JetBrains Mono" font-size="7" fill="rgba(87,99,122,1)">400m</text>
+                  <text x="148" y="-178" font-family="JetBrains Mono" font-size="7" fill="rgba(87,99,122,1)">&#8593; ZENITH</text>
+                </svg>
+              </div>
+            </div>
+            <div class="ob-mp-loadout-row">
+              <div class="ob-mp-loadout-item">
+                <span class="ob-mp-loadout-key">Weapon</span>
+                <span class="ob-mp-loadout-val">Freeze Pistol</span>
+              </div>
+              <div class="ob-mp-loadout-item">
+                <span class="ob-mp-loadout-key">Module</span>
+                <span class="ob-mp-loadout-val">Grip Glove</span>
+              </div>
+              <div class="ob-mp-loadout-item">
+                <span class="ob-mp-loadout-key">Mode</span>
+                <span class="ob-mp-loadout-val">Freeze &amp; Breach</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="ob-mp-brief-panel ob-mp-brief-panel--magenta">
+            <div class="ob-mp-panel-head">
+              <h3 class="ob-mp-panel-title">Team Magenta <span class="ob-mp-panel-idx" style="color:oklch(0.72 0.25 330)">// 02</span></h3>
+              <span>Hostile</span>
+            </div>
+            <div class="ob-mp-brief-team-head">
+              <span id="mp-team1-title" class="ob-mp-brief-team-name" style="color:${MAGENTA}">Magenta</span>
+              <span id="mp-team1-count" class="ob-mp-brief-team-count"></span>
+            </div>
+            <div id="mp-team1-roster" class="ob-mp-brief-roster"></div>
+
+            <div class="ob-mp-rule"></div>
+
+            <div class="ob-mp-mission-brief">
+              <p><strong>Objective.</strong> Slip a pilot through the opposing portal. Freeze shots disable movement for the remainder of the round.</p>
+              <p><strong>Scoring.</strong> Each successful breach scores one point. First team to fill their round quota wins the match.</p>
+            </div>
+          </div>
+
         </div>
       </div>
     </div>
@@ -774,25 +960,25 @@ function renderRoster(
     return `<div class="ob-mp-empty">Open lane</div>`;
   }
 
-  return members.map((member) => {
+  const isMagentaTeam = accent === MAGENTA;
+  return members.map((member, i) => {
     const isSelf = member.id === sessionId;
+    const selfCls = isSelf
+      ? (isMagentaTeam ? "ob-mp-brief-row--self-magenta" : "ob-mp-brief-row--self-cyan")
+      : "";
+    const pendingCls = !member.ready ? "ob-mp-brief-row--pending" : "";
+    const dotCls = !member.ready
+      ? "ob-mp-brief-ready-dot--pending"
+      : isMagentaTeam ? "ob-mp-brief-ready-dot--magenta" : "";
+    const slot = String(i + 1).padStart(2, "0");
+    const nameLabel = escapeHtml(member.name)
+      + (member.isBot ? `<small style="opacity:.4;font-size:8px;letter-spacing:1px"> [bot]</small>` : "");
     return `
-      <div class="ob-mp-roster-card ${isSelf ? "ob-mp-roster-card--self" : ""}">
-        <div>
-          <div class="ob-mp-roster-name" style="color:${accent};text-shadow:0 0 10px ${accent}33;">
-            ${escapeHtml(member.name)}
-          </div>
-          <div class="ob-mp-roster-meta">${member.connected ? "Connected" : "Disconnected"}</div>
-        </div>
-        <div class="ob-mp-roster-badges">
-          ${isSelf ? `<span class="ob-mp-badge ob-mp-badge--self">You</span>` : ""}
-          <span class="ob-mp-badge ${member.isBot ? "ob-mp-badge--bot" : "ob-mp-badge--human"}">
-            ${member.isBot ? "Bot" : "Human"}
-          </span>
-          <span class="ob-mp-badge ${member.ready ? "ob-mp-badge--ready" : "ob-mp-badge--waiting"}">
-            ${member.ready ? "Ready" : "Waiting"}
-          </span>
-        </div>
+      <div class="ob-mp-brief-row ${selfCls} ${pendingCls}">
+        <span class="ob-mp-brief-slot">${slot}</span>
+        <span>${nameLabel}</span>
+        <span class="ob-mp-brief-kd">${member.connected ? "—" : "dc"}</span>
+        <span class="ob-mp-brief-ready-dot ${dotCls}"></span>
       </div>
     `;
   }).join("");

--- a/client/src/ui/multiplayerLobby.ts
+++ b/client/src/ui/multiplayerLobby.ts
@@ -9,15 +9,15 @@ const CYAN = "#7ffcff";
 const MAGENTA = "#ff7df8";
 
 const CSS = `
-  @import url('https://fonts.googleapis.com/css2?family=Oxanium:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300&family=JetBrains+Mono:wght@300;400;500&display=swap');
 
   .ob-mp-root {
-    --mp-cyan: #7ffcff;
-    --mp-magenta: #ff7df8;
-    --mp-panel: rgba(6, 11, 18, 0.82);
-    --mp-panel-strong: rgba(4, 9, 14, 0.92);
-    --mp-border: rgba(127, 252, 255, 0.16);
-    --mp-muted: #8ea8ba;
+    --mp-cyan: oklch(0.82 0.15 210);
+    --mp-magenta: oklch(0.72 0.25 330);
+    --mp-panel: rgba(7, 10, 18, 0.82);
+    --mp-panel-strong: rgba(7, 10, 18, 0.94);
+    --mp-border: rgba(210, 220, 240, 0.16);
+    --mp-muted: #9aa5b8;
     position: fixed;
     inset: 0;
     display: none;
@@ -28,8 +28,8 @@ const CSS = `
       radial-gradient(circle at top, rgba(18, 41, 64, 0.82), rgba(4, 8, 18, 0.94) 55%, rgba(0, 0, 0, 0.98)),
       linear-gradient(180deg, rgba(0, 0, 0, 0.28), rgba(0, 0, 0, 0.44));
     z-index: 350;
-    color: #ebfbff;
-    font-family: "Oxanium", sans-serif;
+    color: #e8ecf4;
+    font-family: "Cormorant Garamond", serif;
   }
 
   .ob-mp-root * {
@@ -80,7 +80,7 @@ const CSS = `
   .ob-mp-button,
   .ob-mp-select,
   .ob-mp-empty {
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     text-transform: uppercase;
   }
 
@@ -327,7 +327,7 @@ const CSS = `
   }
 
   .ob-mp-team-count {
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 11px;
     color: var(--mp-muted);
     letter-spacing: 0.12em;

--- a/client/src/ui/sessionMenu.ts
+++ b/client/src/ui/sessionMenu.ts
@@ -34,29 +34,25 @@ const CSS = `
     display: none;
     align-items: center;
     justify-content: center;
-    min-height: 42px;
-    padding: 0 14px;
-    border-radius: 999px;
+    min-height: 38px;
+    padding: 0 16px;
+    border-radius: 0;
     border: 1px solid rgba(127, 252, 255, 0.22);
-    background:
-      linear-gradient(135deg, rgba(127, 252, 255, 0.12), rgba(255, 125, 248, 0.08)),
-      rgba(4, 9, 14, 0.78);
-    box-shadow: 0 18px 34px rgba(0, 0, 0, 0.28);
+    background: rgba(4, 9, 14, 0.82);
     color: #effcff;
     cursor: pointer;
     font-family: "JetBrains Mono", monospace;
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 700;
-    letter-spacing: 0.16em;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
     backdrop-filter: blur(12px);
+    transition: border-color 0.2s, background 0.2s;
   }
 
   .ob-session-launcher:hover {
-    border-color: rgba(127, 252, 255, 0.34);
-    background:
-      linear-gradient(135deg, rgba(127, 252, 255, 0.18), rgba(255, 125, 248, 0.1)),
-      rgba(4, 9, 14, 0.9);
+    border-color: rgba(127, 252, 255, 0.5);
+    background: rgba(7, 15, 28, 0.92);
   }
 
   .ob-session-root {
@@ -82,13 +78,13 @@ const CSS = `
     width: min(620px, calc(100vw - 36px));
     max-height: calc(100vh - 36px);
     overflow: auto;
-    border-radius: 28px;
+    border-radius: 0;
     border: 1px solid rgba(210, 220, 240, 0.16);
     background:
-      radial-gradient(circle at top left, rgba(127, 252, 255, 0.1), rgba(127, 252, 255, 0) 26%),
-      radial-gradient(circle at bottom right, rgba(255, 125, 248, 0.1), rgba(255, 125, 248, 0) 28%),
-      rgba(5, 11, 17, 0.92);
-    box-shadow: 0 28px 80px rgba(0, 0, 0, 0.42);
+      radial-gradient(circle at top left, rgba(127, 252, 255, 0.07), rgba(127, 252, 255, 0) 30%),
+      radial-gradient(circle at bottom right, rgba(255, 125, 248, 0.07), rgba(255, 125, 248, 0) 32%),
+      rgba(5, 11, 17, 0.96);
+    box-shadow: 0 28px 80px rgba(0, 0, 0, 0.55);
     backdrop-filter: blur(16px);
   }
 
@@ -145,30 +141,41 @@ const CSS = `
   }
 
   .ob-session-button {
-    min-height: 52px;
-    border-radius: 16px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    background: rgba(255, 255, 255, 0.04);
+    position: relative;
+    min-height: 50px;
+    border-radius: 0;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    background: rgba(255, 255, 255, 0.03);
     color: #effcff;
     cursor: pointer;
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 700;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.16em;
+    transition: border-color 0.2s, background 0.2s, transform 0.2s;
   }
 
   .ob-session-button:hover {
-    border-color: rgba(255, 255, 255, 0.22);
-    background: rgba(255, 255, 255, 0.07);
+    border-color: rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.06);
+    transform: translateY(-1px);
   }
 
   .ob-session-button--resume {
-    border-color: rgba(127, 252, 255, 0.26);
-    box-shadow: 0 0 0 1px rgba(127, 252, 255, 0.08) inset;
+    border-color: rgba(127, 252, 255, 0.28);
+  }
+
+  .ob-session-button--resume:hover {
+    border-color: rgba(127, 252, 255, 0.55);
+    color: oklch(0.88 0.12 210);
   }
 
   .ob-session-button--exit {
-    border-color: rgba(255, 140, 160, 0.26);
-    box-shadow: 0 0 0 1px rgba(255, 140, 160, 0.06) inset;
+    border-color: rgba(255, 140, 160, 0.28);
+  }
+
+  .ob-session-button--exit:hover {
+    border-color: rgba(255, 140, 160, 0.55);
+    color: #ffb1c0;
   }
 
   .ob-session-settings {
@@ -178,16 +185,17 @@ const CSS = `
   }
 
   .ob-session-settings-card {
-    border-radius: 22px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    background: rgba(255, 255, 255, 0.03);
+    border-radius: 0;
+    border: 1px solid rgba(210, 220, 240, 0.08);
+    background: rgba(255, 255, 255, 0.02);
     padding: 16px;
   }
 
   .ob-session-settings-title {
-    font-size: 18px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    font-family: "Cormorant Garamond", serif;
+    font-size: 22px;
+    font-weight: 300;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
   }
 
@@ -236,9 +244,9 @@ const CSS = `
     align-items: center;
     margin-top: 10px;
     padding: 12px 14px;
-    border-radius: 16px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    background: rgba(255, 255, 255, 0.03);
+    border-radius: 0;
+    border: 1px solid rgba(210, 220, 240, 0.08);
+    background: rgba(255, 255, 255, 0.02);
   }
 
   .ob-session-toggle-copy {
@@ -260,8 +268,11 @@ const CSS = `
     }
 
     .ob-session-launcher {
-      top: 12px;
-      right: 12px;
+      top: 10px;
+      right: 10px;
+      font-size: 9px;
+      min-height: 32px;
+      padding: 0 12px;
     }
   }
 `;

--- a/client/src/ui/sessionMenu.ts
+++ b/client/src/ui/sessionMenu.ts
@@ -24,7 +24,7 @@ const DEFAULT_SETTINGS: SessionSettings = {
 };
 
 const CSS = `
-  @import url('https://fonts.googleapis.com/css2?family=Oxanium:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300&family=JetBrains+Mono:wght@300;400;500&display=swap');
 
   .ob-session-launcher {
     position: fixed;
@@ -44,7 +44,7 @@ const CSS = `
     box-shadow: 0 18px 34px rgba(0, 0, 0, 0.28);
     color: #effcff;
     cursor: pointer;
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.16em;
@@ -71,7 +71,7 @@ const CSS = `
       radial-gradient(circle at top, rgba(16, 36, 54, 0.74), rgba(3, 8, 14, 0.92) 56%, rgba(2, 4, 7, 0.98)),
       linear-gradient(180deg, rgba(0, 0, 0, 0.34), rgba(0, 0, 0, 0.6));
     color: #effcff;
-    font-family: "Oxanium", sans-serif;
+    font-family: "Cormorant Garamond", serif;
   }
 
   .ob-session-root * {
@@ -83,7 +83,7 @@ const CSS = `
     max-height: calc(100vh - 36px);
     overflow: auto;
     border-radius: 28px;
-    border: 1px solid rgba(127, 252, 255, 0.18);
+    border: 1px solid rgba(210, 220, 240, 0.16);
     background:
       radial-gradient(circle at top left, rgba(127, 252, 255, 0.1), rgba(127, 252, 255, 0) 26%),
       radial-gradient(circle at bottom right, rgba(255, 125, 248, 0.1), rgba(255, 125, 248, 0) 28%),
@@ -109,7 +109,7 @@ const CSS = `
   .ob-session-value,
   .ob-session-note,
   .ob-session-toggle-copy {
-    font-family: "Space Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
     text-transform: uppercase;
   }
 

--- a/shared/match.ts
+++ b/shared/match.ts
@@ -5,6 +5,7 @@ export type MatchTeamSize = (typeof MATCH_TEAM_SIZES)[number];
 export interface SoloMatchConfig {
   humanName: string;
   humanTeam: 0 | 1;
+  noBots?: boolean;
   teamSize: MatchTeamSize;
 }
 


### PR DESCRIPTION
## Summary

- Command-console design system (Cormorant Garamond + JetBrains Mono, oklch tokens, 0-radius sharp rects)
- Main menu: wave canvas fix, 2v2 card, tutorial button (BOTS OFF, magenta), corrected bot counts
- Multiplayer lobby: 3-column briefing layout (Team Cyan · arena SVG map · Team Magenta + mission brief)
- Debrief screen: post-match scoreboard with score head, stats table, awards, play again / main menu
- Session menu polish, help overlay (H key), design tokens

## Needs fixing after merge

- **Breach on entry**: currently gravity starts but breach isn't registered until deeper inside the enemy room — fix to trigger breach the moment gravity activates for the player (entry threshold = gravity threshold)
- **Bots in Online game**: bots not working / not spawning facing the door forward the way they do in solo mode
- **Sync playlist choice**: match the player's current playlist selection from the main menu and pre-fill the playlist dropdown when clicking Join Online
- **Remove sine-wave background on main menu**: remove completely from all screen sizes (desktop and mobile)
- **Music + SFX system**: add audio soundtrack and SFX system; sounds made by Noam Ouzana are saved at `C:\Users\dotan\Downloads\ORBITAL_BREACH_SOUNDS`
- **Mobile horizontal mode**: fix main menu layout in mobile landscape orientation
- **Mobile vertical tutorial overlap**: tutorial text in vertical mobile mode should have the same gap as the timer/score row — currently it touches the timer and slightly overlaps
- **Debrief mouse focus**: after match ends the player stays in pointer-lock mode with no visible cursor; need to release pointer lock and restore the cursor so the debrief screen buttons are clickable

## Test plan

- [ ] Solo 1v1: play to match end → debrief screen appears with correct scores and awards
- [x] Debrief "Play Again" restarts with the same playlist size
- [x] Debrief "Main Menu" returns to main menu cleanly
- [x] Online lobby shows 3-column briefing layout with team rosters and arena SVG
- [x] Tutorial button launches empty arena with tutorial steps, H key shows help overlay
- [x] TypeScript compiles clean: `cd client && node_modules/.bin/tsc --noEmit`
- [x] All 145 tests pass: `npm test` from repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added help overlay accessible during gameplay (press H)
  * Added tutorial mode with dedicated entrypoint from main menu
  * Added debrief screen after solo matches displaying match results, player stats, and awards
  * Added solo mode option to play without AI opponents

* **Style**
  * Updated global typography (new font families)
  * Redesigned main menu with new visual layout and animations
  * Redesigned multiplayer lobby briefing layout
  * Updated UI styling with refined colors, borders, and spacing across all screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->