### PR TITLE
Preserve breach-entry momentum and trigger breach score on BREACH snap

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -483,11 +483,13 @@ export class App {
 
     const enemyTeam = (1 - this.player.team) as 0 | 1;
     if (!this.arena.isGoalDoorOpen(enemyTeam)) return;
-    if (!this.arena.isDeepInBreachRoom(this.player.getPosition(), enemyTeam, 1.0)) return;
+    const reachedEnemyBreach = this.player.phase === "BREACH"
+      ? this.arena.isInBreachRoom(this.player.getPosition(), enemyTeam)
+      : this.arena.isDeepInBreachRoom(this.player.getPosition(), enemyTeam, 1.0);
+    if (!reachedEnemyBreach) return;
 
     this.player.currentBreachTeam = enemyTeam;
     this.player.phase = "BREACH";
-    this.player.phys.vel.y = 0;
     this.onlineBreachReported = true;
 
     this.net.sendBreachReport({

--- a/client/src/match/localMatch.ts
+++ b/client/src/match/localMatch.ts
@@ -33,6 +33,9 @@ import { buildHudRosters } from "./rosterView";
 import { SimulatedPlayerAvatar } from "./simulatedPlayerAvatar";
 
 const LOCAL_PLAYER_ID = "local-player";
+const BREACH_ENTRY_CARRY_TIME = 0.55;
+const BREACH_ENTRY_CARRY_DAMPING_PER_60HZ = 0.9;
+const ZERO_CARRY = new THREE.Vector3();
 
 export interface ProjectileActorTarget {
   active: boolean;
@@ -101,6 +104,8 @@ interface BotState {
   name: string;
   phase: PlayerPhase;
   phys: PhysicsState;
+  breachEntryCarry: THREE.Vector3;
+  breachEntryCarryTimer: number;
   rot: { yaw: number; pitch: number };
   team: 0 | 1;
 }
@@ -377,18 +382,19 @@ export class LocalMatch {
 
       const enemyTeam = (1 - actor.team) as 0 | 1;
       if (!arena.isGoalDoorOpen(enemyTeam)) continue;
-      if (!arena.isDeepInBreachRoom(actor.pos, enemyTeam, 1.0)) continue;
+      const reachedEnemyBreach = actor.phase === "BREACH"
+        ? arena.isInBreachRoom(actor.pos, enemyTeam)
+        : arena.isDeepInBreachRoom(actor.pos, enemyTeam, 1.0);
+      if (!reachedEnemyBreach) continue;
 
       if (actor.id === LOCAL_PLAYER_ID) {
         player.currentBreachTeam = enemyTeam;
         player.phase = "BREACH";
-        player.phys.vel.y = 0;
       } else {
         const bot = this.getBot(actor.id);
         if (!bot) continue;
         bot.currentBreachTeam = enemyTeam;
         bot.phase = "BREACH";
-        bot.phys.vel.y = 0;
       }
 
       this.awardRoundPoint(actor.team, actor.name, "breach");
@@ -678,8 +684,10 @@ export class LocalMatch {
       yawRightVec,
       false,
       isOnBreachGround(bot, center.y),
+      bot.breachEntryCarryTimer > 0 ? bot.breachEntryCarry : ZERO_CARRY,
       dt,
     );
+    decayBreachEntryCarry(bot, isOnBreachGround(bot, center.y), dt);
     clampBreachRoom(bot.phys, center, openAxis, openSign, arena.isGoalDoorOpen(bot.currentBreachTeam));
 
     if (command.grab && !bot.damage.leftArm && arena.isGoalDoorOpen(bot.currentBreachTeam)) {
@@ -733,8 +741,10 @@ export class LocalMatch {
       yawRightVec,
       false,
       isOnBreachGround(bot, center.y),
+      bot.breachEntryCarryTimer > 0 ? bot.breachEntryCarry : ZERO_CARRY,
       dt,
     );
+    decayBreachEntryCarry(bot, isOnBreachGround(bot, center.y), dt);
     clampBreachRoom(bot.phys, center, openAxis, openSign, arena.isGoalDoorOpen(bot.currentBreachTeam));
   }
 }
@@ -765,6 +775,8 @@ function createBotState(scene: THREE.Scene, id: string, name: string, team: 0 | 
     name,
     phase: "BREACH",
     phys: { pos: new THREE.Vector3(), vel: new THREE.Vector3() },
+    breachEntryCarry: new THREE.Vector3(),
+    breachEntryCarryTimer: 0,
     rot: { yaw: 0, pitch: 0 },
     team,
   };
@@ -864,6 +876,8 @@ function launchBot(bot: BotState): void {
   const forward = directionFromRotation(bot.rot.yaw, bot.rot.pitch);
   bot.phys.pos.addScaledVector(forward, PLAYER_RADIUS + 0.8);
   bot.phys.vel.copy(forward).multiplyScalar(bot.launchPower);
+  bot.breachEntryCarry.set(0, 0, 0);
+  bot.breachEntryCarryTimer = 0;
   bot.grabbedBarPos = null;
   bot.launchPower = 0;
   bot.phase = "FLOATING";
@@ -893,6 +907,8 @@ function resetBotsForRound(
     bot.phase = "BREACH";
     bot.phys.pos.set(spawn.x, spawn.y, spawn.z);
     bot.phys.vel.set(0, 0, 0);
+    bot.breachEntryCarry.set(0, 0, 0);
+    bot.breachEntryCarryTimer = 0;
     bot.rot = exitRotation(query, bot.team);
     bot.brain.resetForRound(roundSeed * 37 + i * 13 + bot.team);
     bot.avatar.update(bot.phys.pos, bot.damage, bot.phase, bot.rot.yaw, 0, 0);
@@ -914,7 +930,9 @@ function enterBotBreachRoom(bot: BotState, team: 0 | 1): void {
   bot.damage.leftLeg = false;
   bot.damage.rightLeg = false;
   bot.phase = "BREACH";
-  bot.phys.vel.y = 0;
+  bot.breachEntryCarry.copy(bot.phys.vel);
+  bot.breachEntryCarry.y = 0;
+  bot.breachEntryCarryTimer = BREACH_ENTRY_CARRY_TIME;
 }
 
 function settleSpawnOnFloor(
@@ -951,6 +969,19 @@ function toVec3(vec: THREE.Vector3): Vec3 {
 
 function toThree(vec: Vec3): THREE.Vector3 {
   return new THREE.Vector3(vec.x, vec.y, vec.z);
+}
+
+function decayBreachEntryCarry(bot: BotState, onGround: boolean, dt: number): void {
+  if (onGround) {
+    bot.breachEntryCarry.set(0, 0, 0);
+    bot.breachEntryCarryTimer = 0;
+    return;
+  }
+  if (bot.breachEntryCarryTimer <= 0) return;
+  bot.breachEntryCarryTimer = Math.max(0, bot.breachEntryCarryTimer - dt);
+  const damp = Math.pow(BREACH_ENTRY_CARRY_DAMPING_PER_60HZ, dt * 60);
+  bot.breachEntryCarry.multiplyScalar(damp);
+  bot.breachEntryCarry.y = 0;
 }
 
 function yawForward(yaw: number): Vec3 {

--- a/client/src/physics.ts
+++ b/client/src/physics.ts
@@ -82,6 +82,7 @@ export function integrateBreachRoom(
   yawRight: THREE.Vector3,
   jumping: boolean,
   onGround: boolean,
+  carryVelocity: THREE.Vector3,
   dt: number,
 ): void {
   // Horizontal: WASD always responsive
@@ -90,8 +91,8 @@ export function integrateBreachRoom(
     .multiplyScalar(walkAxes.x)
     .add(yawFwd.clone().multiplyScalar(walkAxes.z));
   if (h.length() > 0) h.normalize();
-  state.vel.x = h.x * BREACH_WALK_SPEED;
-  state.vel.z = h.z * BREACH_WALK_SPEED;
+  state.vel.x = h.x * BREACH_WALK_SPEED + carryVelocity.x;
+  state.vel.z = h.z * BREACH_WALK_SPEED + carryVelocity.z;
 
   // Vertical: pure upward jump — no forward force
   if (jumping && onGround) {

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -58,6 +58,9 @@ import { ThirdPersonGun, type ThirdPersonGunTuningState } from './playerThirdPer
 const GRAB_ROTATION_SMOOTHING = 0.0008;
 const FLOAT_ARM_TUNING_STEP = Math.PI / 180;
 const FLOAT_ARM_FINE_TUNING_STEP = Math.PI / 900;
+const BREACH_ENTRY_CARRY_TIME = 0.55;
+const BREACH_ENTRY_CARRY_DAMPING_PER_60HZ = 0.9;
+const ZERO_CARRY = new THREE.Vector3();
 
 export class LocalPlayer {
   public phys: PhysicsState = {
@@ -85,6 +88,8 @@ export class LocalPlayer {
   private respawnTimer = 0;
   private onGround = false;
   private breachJumpAnimationActive = false;
+  private breachEntryCarry = new THREE.Vector3();
+  private breachEntryCarryTimer = 0;
 
   private mesh: THREE.Group;
   private leftHandGripLocal = DEFAULT_LEFT_HAND_GRIP_LOCAL.clone();
@@ -216,11 +221,21 @@ export class LocalPlayer {
       cam.getYawRight(),
       input.isJumping(),
       this.onGround,
+      this.breachEntryCarryTimer > 0 ? this.breachEntryCarry : ZERO_CARRY,
       dt,
     );
 
     clampBreachRoom(this.phys, center, openAxis, openSign, arena.isGoalDoorOpen(this.currentBreachTeam));
     this.onGround = this.phys.pos.y <= floorY + 0.02;
+    if (this.onGround) {
+      this.breachEntryCarry.set(0, 0, 0);
+      this.breachEntryCarryTimer = 0;
+    } else if (this.breachEntryCarryTimer > 0) {
+      this.breachEntryCarryTimer = Math.max(0, this.breachEntryCarryTimer - dt);
+      const damp = Math.pow(BREACH_ENTRY_CARRY_DAMPING_PER_60HZ, dt * 60);
+      this.breachEntryCarry.multiplyScalar(damp);
+      this.breachEntryCarry.y = 0;
+    }
 
     if (jumpStarted) {
       this.breachJumpAnimationActive = true;
@@ -373,7 +388,9 @@ export class LocalPlayer {
     this.damage.rightArm = false;
     this.damage.leftLeg = false;
     this.damage.rightLeg = false;
-    this.phys.vel.y = 0;
+    this.breachEntryCarry.copy(this.phys.vel);
+    this.breachEntryCarry.y = 0;
+    this.breachEntryCarryTimer = BREACH_ENTRY_CARRY_TIME;
   }
 
   private updateAnimation(input: InputManager, cam: CameraController, dt: number): void {
@@ -577,6 +594,8 @@ export class LocalPlayer {
     this.grabHandGripLocal = null;
     this.grabPoseLocked = false;
     this.breachJumpAnimationActive = false;
+    this.breachEntryCarry.set(0, 0, 0);
+    this.breachEntryCarryTimer = 0;
     this.currentBreachTeam = this.team;
     this.phys.vel.set(0, 0, 0);
 

--- a/tests/localMatch.test.ts
+++ b/tests/localMatch.test.ts
@@ -169,6 +169,7 @@ describe("LocalMatch", () => {
     const arena = {
       isGoalDoorOpen: () => true,
       isDeepInBreachRoom: () => true,
+      isInBreachRoom: () => true,
     };
 
     (match as unknown as { checkForBreachScore: (arenaArg: unknown, playerArg: unknown) => void })
@@ -198,6 +199,7 @@ describe("LocalMatch", () => {
     const arena = {
       isGoalDoorOpen: () => true,
       isDeepInBreachRoom: () => true,
+      isInBreachRoom: () => true,
     };
 
     (match as unknown as { checkForBreachScore: (arenaArg: unknown, playerArg: unknown) => void })


### PR DESCRIPTION
### Motivation
- Players who floated through the portal were having their momentum zeroed and stopped at the threshold instead of landing inside the enemy breach room, and scoring only matched deep-in-room checks for FLOATING actors which missed the case where the actor snaps into BREACH on entry. 

### Description
- Add a transient carry vector to BREACH physics by extending `integrateBreachRoom` with a `carryVelocity` parameter that is added to horizontal BREACH movement. 
- Preserve incoming FLOATING momentum on transition by capturing the actor's horizontal velocity in `enterBreachRoom` for `LocalPlayer` and bots, and decay it over time while in BREACH until grounding. 
- Update local match and online score checks to trigger a breach win when the actor is already in `BREACH` and inside the enemy room (`isInBreachRoom`), while keeping the previous `isDeepInBreachRoom` requirement for still-FLOATING actors. 
- Apply the same carry/reset behavior to bots (`LocalMatch`), add helper `decayBreachEntryCarry`, and update tests to mock `isInBreachRoom` where needed. 

### Testing
- Ran TypeScript checks: `cd client && node_modules/.bin/tsc --noEmit` succeeded. 
- Ran server TypeScript checks: `cd server && node_modules/.bin/tsc --noEmit` succeeded. 
- Updated `tests/localMatch.test.ts` to include `isInBreachRoom` stubs for BREACH-phase checks, but running the root `vitest` in this environment failed due to a missing root `package.json` so full test runner execution was not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5312ccac8832db6a4aec881436644)