### PR TITLE
Fix online match end flow and prevent premature score reset

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -30,6 +30,7 @@ import { NetClient } from "../net/client";
 import { MultiplayerLobby } from "../ui/multiplayerLobby";
 import type { PlaySelection } from "../ui/menu";
 import { DebriefScreen, type DebriefData, type DebriefPlayer } from "../ui/debrief";
+import { showConfirmDialog } from "../ui/confirmDialog";
 import {
   PORTAL_ARRIVAL_SPAWN,
   checkPortalCollisions,
@@ -48,6 +49,8 @@ const PLAYER_UPDATE_RATE = 0.05; // 20hz
 export class App {
   private appMode: "menu" | "solo" | "online" = "menu";
   private onlineGameActive = false;
+  private onlineSessionToken = 0;
+  private isUserExitingOnline = false;
   private matchOver = false;
   private helpVisible = false;
   private lastSoloSelection: PlaySelection | null = null;
@@ -151,7 +154,7 @@ export class App {
 
     this.debrief.onMainMenu = () => {
       if (this.appMode === "online") {
-        void this.returnToMenuFromOnline();
+        void this.forceLeaveOnline();
         return;
       }
       this.returnToMenuFromSolo();
@@ -169,6 +172,7 @@ export class App {
     };
 
     this.net.onStateChange = (snapshot) => {
+      if (this.isUserExitingOnline || this.appMode !== "online") return;
       this.latestOnlineSnapshot = snapshot;
 
       const prev = this.previousOnlinePhase;
@@ -205,10 +209,12 @@ export class App {
     };
 
     this.net.onLobbyEvent = (event) => {
+      if (this.isUserExitingOnline || this.appMode !== "online") return;
       this.multiplayer.setStatus(event.text, event.type);
     };
 
     this.net.onFreezeEvent = (event) => {
+      if (this.isUserExitingOnline || this.appMode !== "online") return;
       const sessionId = this.net.getSessionId();
       this.killFeed.addKill(event.killerName, event.killerTeam, event.victimName, event.victimTeam);
 
@@ -220,6 +226,7 @@ export class App {
     };
 
     this.net.onRoundResultEvent = (event) => {
+      if (this.isUserExitingOnline || this.appMode !== "online") return;
       if (!this.onlineGameActive) return;
 
       this.projectiles.clear();
@@ -247,6 +254,7 @@ export class App {
     };
 
     this.net.onShotEvent = (event) => {
+      if (this.isUserExitingOnline || this.appMode !== "online") return;
       if (!this.onlineGameActive) return;
       if (event.ownerId === this.getOnlineLocalActorId()) return;
 
@@ -261,13 +269,13 @@ export class App {
     };
 
     this.net.onLeave = () => {
-      if (this.appMode === "online") {
-        void this.returnToMenuFromOnline();
-      }
+      if (this.isUserExitingOnline) return;
+      if (this.appMode !== "online") return;
+      void this.requestLeaveOnline("server_disconnect");
     };
 
     this.multiplayer.onLeaveLobby = () => {
-      void this.returnToMenuFromOnline();
+      void this.requestLeaveOnline("user_exit");
     };
     this.multiplayer.onReadyChange = (ready) => {
       this.net.setReady(ready);
@@ -975,7 +983,42 @@ export class App {
       return;
     }
     if (this.appMode === "online") {
+      await this.requestLeaveOnline("user_exit");
+    }
+  }
+
+  private countOtherHumans(): number {
+    const snap = this.latestOnlineSnapshot;
+    if (!snap) return 0;
+    return snap.members.filter((m) => !m.isBot && m.id !== snap.sessionId).length;
+  }
+
+  private async requestLeaveOnline(
+    reason: "user_exit" | "server_disconnect" | "join_failed",
+  ): Promise<void> {
+    if (this.isUserExitingOnline) return;
+
+    if (reason === "user_exit" && this.countOtherHumans() > 0) {
+      const confirmed = await showConfirmDialog({
+        title: "Leave online room?",
+        body: "Other players are still in this room. Are you sure you want to leave?",
+        confirmLabel: "LEAVE",
+        cancelLabel: "CANCEL",
+      });
+      if (!confirmed) return;
+    }
+
+    await this.forceLeaveOnline();
+  }
+
+  private async forceLeaveOnline(): Promise<void> {
+    if (this.isUserExitingOnline) return;
+    this.isUserExitingOnline = true;
+    this.onlineSessionToken += 1;
+    try {
       await this.returnToMenuFromOnline();
+    } finally {
+      this.isUserExitingOnline = false;
     }
   }
 
@@ -1056,6 +1099,7 @@ export class App {
     this.pendingOnlineDebrief = null;
     if (this.matchEndHandle) { clearTimeout(this.matchEndHandle); this.matchEndHandle = null; }
     this.previousOnlinePhase = null;
+    this.latestOnlineSnapshot = null;
     this.projectiles.clear();
     this.hud.setVisible(false);
     this.killFeed.setVisible(false);
@@ -1066,8 +1110,15 @@ export class App {
     this.sessionMenu.setLauncherVisible(true);
     this.multiplayer.showConnecting(selection.name);
 
+    this.isUserExitingOnline = false;
+    const myToken = ++this.onlineSessionToken;
+
     try {
       const snapshot = await this.net.connect({ name: selection.name });
+      if (myToken !== this.onlineSessionToken || this.isUserExitingOnline || this.appMode !== "online") {
+        try { await this.net.disconnect(); } catch { /* ignore */ }
+        return;
+      }
       this.latestOnlineSnapshot = snapshot;
       this.previousOnlinePhase = snapshot.phase;
       if (snapshot.phase === "COUNTDOWN" || snapshot.phase === "PLAYING") {
@@ -1077,7 +1128,14 @@ export class App {
       }
     } catch (error) {
       console.error("Failed to connect to the multiplayer room.", error);
-      this.multiplayer.setStatus("Could not reach the Colyseus server. Check that the server is running.", "error");
+      if (myToken !== this.onlineSessionToken || this.isUserExitingOnline || this.appMode !== "online") {
+        return;
+      }
+      this.multiplayer.setStatus(
+        "Could not reach the Colyseus server. Check that the server is running.",
+        "error",
+      );
+      await this.requestLeaveOnline("join_failed");
     }
   }
 
@@ -1088,6 +1146,9 @@ export class App {
     this.onlineGameActive = false;
     this.onlineBreachReported = false;
     this.pendingOnlineDebrief = null;
+    this.latestOnlineSnapshot = null;
+    this.previousOnlinePhase = null;
+    this.helpVisible = false;
     if (this.matchEndHandle) { clearTimeout(this.matchEndHandle); this.matchEndHandle = null; }
     this.onlineMatch.dispose();
     this.multiplayer.hide();
@@ -1100,6 +1161,10 @@ export class App {
     this.input.setUiBlocked(false);
     this.input.exitPointerLock();
     this.sessionMenu.setLauncherVisible(false);
+    this.gun.setVisible(false);
+    this.gun.setFrozenTint(null);
+    this.player.setThirdPersonGunVisible(false);
+    this.player.setThirdPersonGunFrozenTint(null);
 
     try {
       await this.net.disconnect();

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -56,6 +56,7 @@ export class App {
   private lastSoloSelection: PlaySelection | null = null;
   private matchEndHandle: ReturnType<typeof setTimeout> | null = null;
   private pendingOnlineDebrief: DebriefData | null = null;
+  private onlineMatchConcluding = false;
   private playerUpdateTimer = 0;
   private latestOnlineSnapshot: MultiplayerRoomSnapshot | null = null;
   private previousOnlinePhase: MultiplayerRoomSnapshot["phase"] | null = null;
@@ -178,6 +179,13 @@ export class App {
       const prev = this.previousOnlinePhase;
       this.previousOnlinePhase = snapshot.phase;
 
+      if (this.onlineMatchConcluding) {
+        if (!this.debrief.isVisible() && (snapshot.matchComplete || snapshot.phase === "LOBBY")) {
+          this.endOnlineGame();
+        }
+        return;
+      }
+
       if (!this.onlineGameActive || snapshot.phase === "LOBBY") {
         this.multiplayer.render(snapshot);
       }
@@ -239,11 +247,9 @@ export class App {
       }
 
       if (event.matchWinner !== null && event.finalScore) {
-        const label = event.matchWinner === 0 ? "CYAN" : "MAGENTA";
-        this.hud.showRoundEnd(
-          `${label} WINS THE MATCH  ${event.finalScore.team0} - ${event.finalScore.team1}`,
-        );
+        this.onlineMatchConcluding = true;
         this.pendingOnlineDebrief = this.buildOnlineDebrief(event.matchWinner, event.finalScore);
+        this.endOnlineGame();
         return;
       }
 
@@ -589,6 +595,10 @@ export class App {
   // ── Online game lifecycle ───────────────────────────────────────────────────
 
   private beginOnlineRound(snapshot: MultiplayerRoomSnapshot): void {
+    if (this.onlineMatchConcluding || this.debrief.isVisible()) {
+      return;
+    }
+
     this.onlineGameActive = true;
     this.onlineBreachReported = false;
     this.playerUpdateTimer = 0;
@@ -1090,6 +1100,7 @@ export class App {
     this.onlinePlayerName = selection.name;
     this.onlineGameActive = false;
     this.onlineBreachReported = false;
+    this.onlineMatchConcluding = false;
     this.pendingOnlineDebrief = null;
     if (this.matchEndHandle) { clearTimeout(this.matchEndHandle); this.matchEndHandle = null; }
     this.previousOnlinePhase = null;
@@ -1142,6 +1153,7 @@ export class App {
     this.appMode = "menu";
     this.onlineGameActive = false;
     this.onlineBreachReported = false;
+    this.onlineMatchConcluding = false;
     this.pendingOnlineDebrief = null;
     this.latestOnlineSnapshot = null;
     this.previousOnlinePhase = null;
@@ -1240,6 +1252,7 @@ export class App {
   }
 
   private returnToOnlineLobbyFromDebrief(): void {
+    this.onlineMatchConcluding = false;
     this.input.setUiBlocked(false);
     this.sessionMenu.setLauncherVisible(true);
 

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -186,17 +186,14 @@ export class App {
         snapshot.phase === "COUNTDOWN"
         && prev !== "COUNTDOWN"
         && prev !== "PLAYING";
-      const joinedLiveRound = !this.onlineGameActive && snapshot.phase === "PLAYING";
 
-      if (shouldBeginOnlineRound || joinedLiveRound) {
+      if (shouldBeginOnlineRound) {
         this.beginOnlineRound(snapshot);
-        if (shouldBeginOnlineRound) {
-          this.sound.playCountdown();
-        }
+        this.sound.playCountdown();
       }
 
       if (snapshot.phase === "LOBBY") {
-        if (this.onlineGameActive) {
+        if (this.onlineGameActive || this.pendingOnlineDebrief) {
           this.endOnlineGame();
         }
         return;
@@ -651,16 +648,15 @@ export class App {
     this.mobileControls?.hide();
     this.input.setMobileControlsActive(false);
 
-    const snap = this.latestOnlineSnapshot;
-    if (snap) {
-      this.multiplayer.render(snap);
-    }
-
     if (this.pendingOnlineDebrief) {
       const debrief = this.pendingOnlineDebrief;
       this.pendingOnlineDebrief = null;
       this.showMatchDebrief(debrief);
     } else {
+      const snap = this.latestOnlineSnapshot;
+      if (snap) {
+        this.multiplayer.render(snap);
+      }
       this.hud.setVisible(false);
       this.hud.hideRoundEnd();
     }
@@ -1119,7 +1115,7 @@ export class App {
       }
       this.latestOnlineSnapshot = snapshot;
       this.previousOnlinePhase = snapshot.phase;
-      if (snapshot.phase === "COUNTDOWN" || snapshot.phase === "PLAYING") {
+      if (snapshot.phase === "COUNTDOWN") {
         this.beginOnlineRound(snapshot);
       } else {
         this.multiplayer.render(snapshot);
@@ -1129,8 +1125,11 @@ export class App {
       if (myToken !== this.onlineSessionToken || this.isUserExitingOnline || this.appMode !== "online") {
         return;
       }
+      const message = error instanceof Error && error.message.trim().length > 0
+        ? error.message
+        : "Could not reach the Colyseus server. Check that the server is running.";
       this.multiplayer.setStatus(
-        "Could not reach the Colyseus server. Check that the server is running.",
+        message,
         "error",
       );
       await this.requestLeaveOnline("join_failed");

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -1166,13 +1166,17 @@ export class App {
     this.player.setThirdPersonGunVisible(false);
     this.player.setThirdPersonGunFrozenTint(null);
 
-    try {
-      await this.net.disconnect();
-    } catch (error) {
-      console.warn("Multiplayer disconnect raised an error.", error);
-    }
-
+    // Show the main menu BEFORE awaiting disconnect. Colyseus's
+    // room.leave(true) waits for server ack and can hang for several
+    // seconds after a fully-joined session, leaving a black canvas
+    // if menu.show() ran after the await.
     this.menu.show();
+
+    const disconnectPromise = this.net.disconnect().catch((error) => {
+      console.warn("Multiplayer disconnect raised an error.", error);
+    });
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, 1500));
+    await Promise.race([disconnectPromise, timeout]);
   }
 
   // ── Weapon fire (solo) ──────────────────────────────────────────────────────

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -45,6 +45,7 @@ import {
 import type { PortalParams } from "./portal/parsePortalParams";
 
 const PLAYER_UPDATE_RATE = 0.05; // 20hz
+const ONLINE_MATCH_DEBRIEF_DELAY_MS = 4000;
 
 export class App {
   private appMode: "menu" | "solo" | "online" = "menu";
@@ -180,8 +181,9 @@ export class App {
       this.previousOnlinePhase = snapshot.phase;
 
       if (this.onlineMatchConcluding) {
-        if (!this.debrief.isVisible() && (snapshot.matchComplete || snapshot.phase === "LOBBY")) {
-          this.endOnlineGame();
+        if (this.onlineGameActive) {
+          this.arena.setPortalDoorsOpen(snapshot.phase === "PLAYING");
+          this.onlineMatch.applySnapshot(snapshot.actors, snapshot.sessionId);
         }
         return;
       }
@@ -249,7 +251,27 @@ export class App {
       if (event.matchWinner !== null && event.finalScore) {
         this.onlineMatchConcluding = true;
         this.pendingOnlineDebrief = this.buildOnlineDebrief(event.matchWinner, event.finalScore);
-        this.endOnlineGame();
+        const label = event.matchWinner === 0 ? "CYAN" : "MAGENTA";
+        this.hud.showRoundEnd(
+          `${label} WINS THE MATCH  ${event.finalScore.team0} - ${event.finalScore.team1}`,
+        );
+        this.input.exitPointerLock();
+        this.input.setUiBlocked(true);
+        this.mobileControls?.hide();
+        this.input.setMobileControlsActive(false);
+        this.sessionMenu.setLauncherVisible(false);
+        if (this.matchEndHandle) {
+          clearTimeout(this.matchEndHandle);
+        }
+        this.matchEndHandle = setTimeout(() => {
+          this.matchEndHandle = null;
+          const debrief = this.pendingOnlineDebrief;
+          this.pendingOnlineDebrief = null;
+          if (!debrief || this.appMode !== "online") {
+            return;
+          }
+          this.showMatchDebrief(debrief);
+        }, ONLINE_MATCH_DEBRIEF_DELAY_MS);
         return;
       }
 
@@ -658,18 +680,12 @@ export class App {
     this.mobileControls?.hide();
     this.input.setMobileControlsActive(false);
 
-    if (this.pendingOnlineDebrief) {
-      const debrief = this.pendingOnlineDebrief;
-      this.pendingOnlineDebrief = null;
-      this.showMatchDebrief(debrief);
-    } else {
-      const snap = this.latestOnlineSnapshot;
-      if (snap) {
-        this.multiplayer.render(snap);
-      }
-      this.hud.setVisible(false);
-      this.hud.hideRoundEnd();
+    const snap = this.latestOnlineSnapshot;
+    if (snap) {
+      this.multiplayer.render(snap);
     }
+    this.hud.setVisible(false);
+    this.hud.hideRoundEnd();
   }
 
   // ── HUD updates ─────────────────────────────────────────────────────────────
@@ -1253,8 +1269,10 @@ export class App {
 
   private returnToOnlineLobbyFromDebrief(): void {
     this.onlineMatchConcluding = false;
+    this.onlineGameActive = false;
     this.input.setUiBlocked(false);
     this.sessionMenu.setLauncherVisible(true);
+    this.hud.hideRoundEnd();
 
     if (this.latestOnlineSnapshot) {
       this.multiplayer.render(this.latestOnlineSnapshot);

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -251,10 +251,8 @@ export class App {
       if (event.matchWinner !== null && event.finalScore) {
         this.onlineMatchConcluding = true;
         this.pendingOnlineDebrief = this.buildOnlineDebrief(event.matchWinner, event.finalScore);
-        const label = event.matchWinner === 0 ? "CYAN" : "MAGENTA";
-        this.hud.showRoundEnd(
-          `${label} WINS THE MATCH  ${event.finalScore.team0} - ${event.finalScore.team1}`,
-        );
+        this.sessionMenu.close();
+        this.hud.showRoundEnd(this.buildOnlineMatchEndMessage(event.matchWinner, event.finalScore));
         this.input.exitPointerLock();
         this.input.setUiBlocked(true);
         this.mobileControls?.hide();
@@ -936,7 +934,7 @@ export class App {
   }
 
   private openSessionMenu(): void {
-    if (this.sessionMenu.isOpen() || this.debrief.isVisible()) return;
+    if (this.sessionMenu.isOpen() || this.debrief.isVisible() || this.onlineMatchConcluding) return;
 
     const inMenu = this.appMode === "menu";
     const inLiveMatch = this.appMode === "solo" || this.onlineGameActive;
@@ -985,6 +983,12 @@ export class App {
     this.input.setUiBlocked(false);
 
     if (!this.mobile) return;
+
+    if (this.onlineMatchConcluding || this.debrief.isVisible()) {
+      this.input.setMobileControlsActive(false);
+      this.mobileControls?.hide();
+      return;
+    }
 
     if (this.appMode === "solo" || this.onlineGameActive) {
       this.input.setMobileControlsActive(true);
@@ -1265,6 +1269,17 @@ export class App {
       playerTeam,
       matchLabel: `${sizeLabelMap[teamSize] ?? `${teamSize}v${teamSize}`} Online · ${finalScore.team0} – ${finalScore.team1}`,
     };
+  }
+
+  private buildOnlineMatchEndMessage(
+    winningTeam: 0 | 1,
+    finalScore: { team0: number; team1: number },
+  ): string {
+    const label = winningTeam === 0 ? "CYAN" : "MAGENTA";
+    const compactScore = `[${finalScore.team0}-${finalScore.team1}]`;
+    return this.mobile
+      ? `${label} WINS\n${compactScore}`
+      : `${label} WINS THE MATCH\n${compactScore}`;
   }
 
   private returnToOnlineLobbyFromDebrief(): void {

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -252,7 +252,10 @@ export class App {
         this.onlineMatchConcluding = true;
         this.pendingOnlineDebrief = this.buildOnlineDebrief(event.matchWinner, event.finalScore);
         this.sessionMenu.close();
-        this.hud.showRoundEnd(this.buildOnlineMatchEndMessage(event.matchWinner, event.finalScore));
+        const label = event.matchWinner === 0 ? "CYAN" : "MAGENTA";
+        this.hud.showRoundEnd(
+          `${label} WINS THE MATCH  ${event.finalScore.team0} - ${event.finalScore.team1}`,
+        );
         this.input.exitPointerLock();
         this.input.setUiBlocked(true);
         this.mobileControls?.hide();
@@ -1269,17 +1272,6 @@ export class App {
       playerTeam,
       matchLabel: `${sizeLabelMap[teamSize] ?? `${teamSize}v${teamSize}`} Online · ${finalScore.team0} – ${finalScore.team1}`,
     };
-  }
-
-  private buildOnlineMatchEndMessage(
-    winningTeam: 0 | 1,
-    finalScore: { team0: number; team1: number },
-  ): string {
-    const label = winningTeam === 0 ? "CYAN" : "MAGENTA";
-    const compactScore = `[${finalScore.team0}-${finalScore.team1}]`;
-    return this.mobile
-      ? `${label} WINS\n${compactScore}`
-      : `${label} WINS THE MATCH\n${compactScore}`;
   }
 
   private returnToOnlineLobbyFromDebrief(): void {

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -659,11 +659,7 @@ export class App {
     if (this.pendingOnlineDebrief) {
       const debrief = this.pendingOnlineDebrief;
       this.pendingOnlineDebrief = null;
-      if (this.matchEndHandle) clearTimeout(this.matchEndHandle);
-      this.matchEndHandle = setTimeout(() => {
-        this.matchEndHandle = null;
-        this.showMatchDebrief(debrief);
-      }, 4000);
+      this.showMatchDebrief(debrief);
     } else {
       this.hud.setVisible(false);
       this.hud.hideRoundEnd();
@@ -889,6 +885,8 @@ export class App {
       score: finalScore,
       players: [...ownPlayers, ...enemyPlayers],
       playerTeam,
+      primaryActionLabel: "Return To Room",
+      secondaryActionLabel: "Main Menu",
       matchLabel: `${sizeLabelMap[teamSize] ?? "Solo"} · ${finalScore.team0} – ${finalScore.team1}`,
     };
 

--- a/client/src/net/client.ts
+++ b/client/src/net/client.ts
@@ -29,6 +29,7 @@ const SERVER_URL = getColyseusEndpoint();
 
 type ColyseusRoomState = {
   phase: string;
+  matchComplete: boolean;
   countdownRemaining: number;
   roundTimeRemaining: number;
   scoreTeam0: number;
@@ -152,6 +153,7 @@ function buildSnapshot(
     sessionId: room.sessionId,
     selfTeam: self?.team ?? 0,
     phase: toRoomPhase(state.phase),
+    matchComplete: Boolean(state.matchComplete),
     countdownRemaining: Number(state.countdownRemaining ?? 0),
     roundTimeRemaining: Number(state.roundTimeRemaining ?? 0),
     score: {

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -359,6 +359,9 @@ const HUD_CSS = `
     letter-spacing: 0.08em;
     text-align: center;
     text-transform: uppercase;
+    white-space: pre-line;
+    line-height: 1.12;
+    max-width: min(900px, 92vw);
     text-shadow: 0 0 34px rgba(255, 255, 255, 0.28);
   }
 
@@ -640,6 +643,12 @@ const HUD_CSS = `
       bottom: 12px;
       width: auto;
       padding: 10px;
+    }
+
+    .ob-round-end {
+      padding: 18px;
+      font-size: clamp(26px, 8vw, 40px);
+      letter-spacing: 0.06em;
     }
 
     .ob-scoreboard-overlay {

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -359,9 +359,6 @@ const HUD_CSS = `
     letter-spacing: 0.08em;
     text-align: center;
     text-transform: uppercase;
-    white-space: pre-line;
-    line-height: 1.12;
-    max-width: min(900px, 92vw);
     text-shadow: 0 0 34px rgba(255, 255, 255, 0.28);
   }
 
@@ -643,12 +640,6 @@ const HUD_CSS = `
       bottom: 12px;
       width: auto;
       padding: 10px;
-    }
-
-    .ob-round-end {
-      padding: 18px;
-      font-size: clamp(26px, 8vw, 40px);
-      letter-spacing: 0.06em;
     }
 
     .ob-scoreboard-overlay {

--- a/client/src/ui/confirmDialog.ts
+++ b/client/src/ui/confirmDialog.ts
@@ -1,0 +1,163 @@
+export interface ConfirmOptions {
+  title: string;
+  body: string;
+  confirmLabel: string;
+  cancelLabel: string;
+}
+
+const STYLE_ID = "ob-confirm-dialog-style";
+const CSS = `
+  .ob-confirm-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 18px;
+    background:
+      radial-gradient(circle at top, rgba(16, 36, 54, 0.74), rgba(3, 8, 14, 0.92) 56%, rgba(2, 4, 7, 0.98)),
+      linear-gradient(180deg, rgba(0, 0, 0, 0.34), rgba(0, 0, 0, 0.6));
+    color: #effcff;
+    font-family: "Cormorant Garamond", serif;
+  }
+  .ob-confirm-card {
+    width: min(420px, 92vw);
+    padding: 28px 30px 24px;
+    border: 1px solid rgba(127, 252, 255, 0.32);
+    background: rgba(4, 9, 14, 0.94);
+    box-shadow: 0 0 0 1px rgba(127, 252, 255, 0.06) inset, 0 24px 48px rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(16px);
+  }
+  .ob-confirm-title {
+    margin: 0 0 12px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: #7ffcff;
+  }
+  .ob-confirm-body {
+    margin: 0 0 22px;
+    font-size: 18px;
+    line-height: 1.4;
+    color: #dffcff;
+  }
+  .ob-confirm-buttons {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+  }
+  .ob-confirm-btn {
+    min-height: 38px;
+    padding: 0 18px;
+    border: 1px solid rgba(127, 252, 255, 0.32);
+    background: rgba(7, 15, 28, 0.86);
+    color: #effcff;
+    cursor: pointer;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    transition: border-color 0.15s, background 0.15s, color 0.15s;
+  }
+  .ob-confirm-btn:hover {
+    border-color: rgba(127, 252, 255, 0.6);
+    background: rgba(12, 26, 42, 0.95);
+  }
+  .ob-confirm-btn--danger {
+    border-color: rgba(255, 120, 150, 0.5);
+    color: #ffd1dc;
+  }
+  .ob-confirm-btn--danger:hover {
+    border-color: rgba(255, 120, 150, 0.85);
+    background: rgba(40, 10, 18, 0.92);
+    color: #ffe6ec;
+  }
+`;
+
+function injectStyle(): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = CSS;
+  document.head.appendChild(style);
+}
+
+let activeOverlay: HTMLDivElement | null = null;
+
+export function showConfirmDialog(opts: ConfirmOptions): Promise<boolean> {
+  injectStyle();
+
+  if (activeOverlay) {
+    activeOverlay.remove();
+    activeOverlay = null;
+  }
+
+  return new Promise<boolean>((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.className = "ob-confirm-overlay";
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+
+    const card = document.createElement("div");
+    card.className = "ob-confirm-card";
+
+    const title = document.createElement("h2");
+    title.className = "ob-confirm-title";
+    title.textContent = opts.title;
+
+    const body = document.createElement("p");
+    body.className = "ob-confirm-body";
+    body.textContent = opts.body;
+
+    const buttons = document.createElement("div");
+    buttons.className = "ob-confirm-buttons";
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.type = "button";
+    cancelBtn.className = "ob-confirm-btn";
+    cancelBtn.textContent = opts.cancelLabel;
+
+    const confirmBtn = document.createElement("button");
+    confirmBtn.type = "button";
+    confirmBtn.className = "ob-confirm-btn ob-confirm-btn--danger";
+    confirmBtn.textContent = opts.confirmLabel;
+
+    buttons.appendChild(cancelBtn);
+    buttons.appendChild(confirmBtn);
+    card.appendChild(title);
+    card.appendChild(body);
+    card.appendChild(buttons);
+    overlay.appendChild(card);
+    document.body.appendChild(overlay);
+    activeOverlay = overlay;
+
+    const close = (result: boolean): void => {
+      document.removeEventListener("keydown", onKey, true);
+      if (activeOverlay === overlay) activeOverlay = null;
+      overlay.remove();
+      resolve(result);
+    };
+
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        close(false);
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopPropagation();
+        close(true);
+      }
+    };
+    document.addEventListener("keydown", onKey, true);
+
+    cancelBtn.addEventListener("click", () => close(false));
+    confirmBtn.addEventListener("click", () => close(true));
+
+    confirmBtn.focus();
+  });
+}

--- a/client/src/ui/debrief.ts
+++ b/client/src/ui/debrief.ts
@@ -16,6 +16,8 @@ export interface DebriefData {
   players: DebriefPlayer[];
   playerTeam: 0 | 1;
   matchLabel: string;
+  primaryActionLabel?: string;
+  secondaryActionLabel?: string;
 }
 
 const CSS = `
@@ -289,13 +291,19 @@ export class DebriefScreen {
     this.root.innerHTML = this.buildHtml(data);
     this.root.classList.add("ob-debrief-visible");
 
-    this.root.querySelector<HTMLButtonElement>("#debrief-main-menu")
-      ?.addEventListener("click", () => { this.hide(); this.onMainMenu?.(); });
-    this.root.querySelector<HTMLButtonElement>("#debrief-play-again")
-      ?.addEventListener("click", () => { this.hide(); this.onPlayAgain?.(); });
+    const mainMenuButton = this.root.querySelector<HTMLButtonElement>("#debrief-main-menu");
+    if (mainMenuButton && data.secondaryActionLabel) {
+      mainMenuButton.textContent = `${data.secondaryActionLabel} ->`;
+    }
+    const primaryActionButton = this.root.querySelector<HTMLButtonElement>("#debrief-play-again");
+    if (primaryActionButton && data.primaryActionLabel) {
+      primaryActionButton.textContent = `${data.primaryActionLabel} ->`;
+    }
 
-    const focusTarget = this.root.querySelector<HTMLButtonElement>("#debrief-play-again")
-      ?? this.root.querySelector<HTMLButtonElement>("#debrief-main-menu");
+    mainMenuButton?.addEventListener("click", () => { this.hide(); this.onMainMenu?.(); });
+    primaryActionButton?.addEventListener("click", () => { this.hide(); this.onPlayAgain?.(); });
+
+    const focusTarget = primaryActionButton ?? mainMenuButton;
     requestAnimationFrame(() => {
       focusTarget?.focus({ preventScroll: true });
     });
@@ -311,6 +319,8 @@ export class DebriefScreen {
 
   private buildHtml(data: DebriefData): string {
     const { score, winningTeam, players, playerTeam, matchLabel } = data;
+    const mainMenuLabel = data.secondaryActionLabel ?? "Main Menu";
+    const primaryActionLabel = data.primaryActionLabel ?? "Play Again";
 
     const cyan0 = winningTeam === 0 ? "ob-win" : "ob-loss";
     const cyan1 = winningTeam === 1 ? "ob-win" : "ob-loss";

--- a/client/src/ui/debrief.ts
+++ b/client/src/ui/debrief.ts
@@ -23,14 +23,22 @@ export interface DebriefData {
 const CSS = `
   .ob-debrief-root {
     position: fixed; inset: 0; z-index: 450;
-    display: none; align-items: center; justify-content: center; padding: 18px;
+    display: flex; align-items: center; justify-content: center; padding: 18px;
     background:
-      radial-gradient(circle at top, rgba(18, 41, 64, 0.82), rgba(4, 8, 18, 0.96) 55%, rgba(0, 0, 0, 0.99));
+      radial-gradient(circle at top, rgba(18, 41, 64, 0.48), rgba(4, 8, 18, 0.72) 55%, rgba(0, 0, 0, 0.82));
     color: #e8ecf4;
     font-family: "Cormorant Garamond", serif;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 320ms ease, visibility 320ms ease;
   }
   .ob-debrief-root * { box-sizing: border-box; }
-  .ob-debrief-root.ob-debrief-visible { display: flex; }
+  .ob-debrief-root.ob-debrief-visible {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
 
   .ob-debrief-wrap {
     width: min(1100px, 94vw);

--- a/client/src/ui/multiplayerLobby.ts
+++ b/client/src/ui/multiplayerLobby.ts
@@ -820,6 +820,8 @@ export class MultiplayerLobby {
       this.setStatus(`Round live. ${formatTime(state.roundTimeRemaining)} remaining.`, "info");
     } else if (state.phase === "ROUND_END") {
       this.setStatus("Round complete. Rebuilding the arena for the next point...", "info");
+    } else if (state.matchComplete) {
+      this.setStatus("Match complete. Review the debrief, then ready up to launch the next match.", "info");
     } else {
       this.setStatus("Form up, balance the squads, and lock ready when both sides are full.", "info");
     }
@@ -1040,6 +1042,9 @@ function describeQueueState(state: MultiplayerRoomSnapshot, humans: number): str
   }
   if (state.phase === "ROUND_END") {
     return "Point resolved. The next round will auto-cycle while the room stays checked in.";
+  }
+  if (state.matchComplete) {
+    return "Match complete. Teams stay together in-room until everyone explicitly readies again.";
   }
   if (humans === 0) {
     return "Waiting for pilots to join the room.";

--- a/server/src/colyseus/OrbitalLobbyRoom.ts
+++ b/server/src/colyseus/OrbitalLobbyRoom.ts
@@ -127,6 +127,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     if (!this.hasHumanMembers()) {
       this.removeAllBots();
       this.resetScore();
+      this.state.matchComplete = false;
       this.cancelRoundFlow();
       this.resetLobbyReadiness();
       this.state.phase = "LOBBY";
@@ -348,6 +349,10 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
 
   private startCountdown(): void {
     this.clearTimers();
+    if (this.state.matchComplete) {
+      this.resetScore();
+      this.state.matchComplete = false;
+    }
     this.prepareCountdownRound();
     this.state.phase = "COUNTDOWN";
     this.state.countdownRemaining = MULTIPLAYER_COUNTDOWN_SECONDS;
@@ -442,7 +447,12 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
       this.state.countdownRemaining = 0;
       this.state.roundTimeRemaining = 0;
       if (matchWinner !== null) {
-        this.resetScore();
+        this.state.matchComplete = true;
+        this.resetLobbyReadiness();
+        this.broadcast("lobby_event", {
+          type: "info",
+          text: "Match complete. Review the debrief, then ready up to start the next one.",
+        });
       }
       void this.unlock();
       this.syncLobbyFlow();

--- a/server/src/colyseus/OrbitalLobbyRoom.ts
+++ b/server/src/colyseus/OrbitalLobbyRoom.ts
@@ -1,6 +1,7 @@
 import { Room, type Client } from "@colyseus/core";
 import {
   buildBotName,
+  canJoinMultiplayerRoom,
   canStartLobbyRound,
   getPreferredJoinTeam,
   isMatchTeamSizeValue,
@@ -13,6 +14,7 @@ import {
   type FreezeEventMessage,
   type HitReportMessage,
   type LobbyTeam,
+  type MultiplayerRoomPhase,
   type PlayerUpdateMessage,
   type RoundResultEventMessage,
   type SetReadyMessage,
@@ -90,6 +92,14 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     });
 
     void this.unlock();
+  }
+
+  public onAuth(): true {
+    if (!canJoinMultiplayerRoom(this.state.phase as MultiplayerRoomPhase)) {
+      throw new Error("A match is already in progress. Wait for the lobby before joining.");
+    }
+
+    return true;
   }
 
   public onJoin(client: RoomClient, options?: { name?: string }): void {

--- a/server/src/colyseus/state.ts
+++ b/server/src/colyseus/state.ts
@@ -35,6 +35,7 @@ export class ActorState extends Schema {
 
 export class OrbitalLobbyState extends Schema {
   public phase = "LOBBY";
+  public matchComplete = false;
   public countdownRemaining = 0;
   public roundTimeRemaining = 0;
   public scoreTeam0 = 0;
@@ -80,6 +81,7 @@ defineTypes(ActorState, {
 
 defineTypes(OrbitalLobbyState, {
   phase: "string",
+  matchComplete: "boolean",
   countdownRemaining: "number",
   roundTimeRemaining: "number",
   scoreTeam0: "number",

--- a/shared/multiplayer.ts
+++ b/shared/multiplayer.ts
@@ -212,3 +212,7 @@ export function buildBotName(botIndex: number, team: LobbyTeam): string {
   const prefix = team === 0 ? "CY" : "MG";
   return `${prefix}-BOT-${String(botIndex + 1).padStart(2, "0")}`;
 }
+
+export function canJoinMultiplayerRoom(phase: MultiplayerRoomPhase): boolean {
+  return phase === "LOBBY";
+}

--- a/shared/multiplayer.ts
+++ b/shared/multiplayer.ts
@@ -49,6 +49,7 @@ export interface MultiplayerRoomSnapshot {
   sessionId: string;
   selfTeam: LobbyTeam;
   phase: MultiplayerRoomPhase;
+  matchComplete: boolean;
   countdownRemaining: number;
   roundTimeRemaining: number;
   score: {

--- a/tests/multiplayer.test.ts
+++ b/tests/multiplayer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildBotName,
+  canJoinMultiplayerRoom,
   canStartLobbyRound,
   getPreferredJoinTeam,
 } from "../shared/multiplayer";
@@ -36,6 +37,15 @@ describe("buildBotName", () => {
   it("uses readable team-prefixed bot names", () => {
     expect(buildBotName(0, 0)).toBe("CY-BOT-01");
     expect(buildBotName(2, 1)).toBe("MG-BOT-03");
+  });
+});
+
+describe("canJoinMultiplayerRoom", () => {
+  it("only allows fresh joins from the lobby", () => {
+    expect(canJoinMultiplayerRoom("LOBBY")).toBe(true);
+    expect(canJoinMultiplayerRoom("COUNTDOWN")).toBe(false);
+    expect(canJoinMultiplayerRoom("PLAYING")).toBe(false);
+    expect(canJoinMultiplayerRoom("ROUND_END")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- remove automatic online rejoin/session-restore behavior
- stop online matches from resetting to 0-0 before debrief
- show the final match result briefly before fading into debrief, including the mobile flow

Closes #23.

## Testing
- npm run build --prefix client
- npm run build --prefix server
- npm test