### PR TITLE
Fix online keyboard camera controls

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -493,7 +493,10 @@ export class App {
       this.sendOnlinePlayerUpdate();
     }
 
-    const isSelfie = false;
+    if (FEATURE_FLAGS.thirdPersonLookBehind && this.input.consumeThirdPersonToggle()) {
+      this.thirdPerson = !this.thirdPerson;
+    }
+    const isSelfie = FEATURE_FLAGS.thirdPersonLookBehind && this.input.isSelfieHeld();
     this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie);
     this.updateGunVisibility(isSelfie);
     this.updateOnlineHud(dt);
@@ -508,7 +511,9 @@ export class App {
     if (!this.input.canControlGame() || !inZeroG) return;
     if (!this.player.canFire() || !this.input.consumeFire()) return;
 
-    const shot = buildShotFromCamera(this.player, this.cam, this.gun, false);
+    const useThirdPersonMuzzle = this.thirdPerson
+      || (FEATURE_FLAGS.thirdPersonLookBehind && this.input.isSelfieHeld());
+    const shot = buildShotFromCamera(this.player, this.cam, this.gun, useThirdPersonMuzzle);
     if (!shot) return;
 
     const localActorId = this.getOnlineLocalActorId();
@@ -756,6 +761,7 @@ export class App {
       const max = this.player.maxLaunchPower();
       const pct = max > 0 ? this.player.launchPower / max : 0;
       this.mobileControls.setPowerLevel(pct, showPower);
+      this.mobileControls.setViewMode(this.thirdPerson);
     }
 
     const rosters = this.onlineMatch.getHudRosters(


### PR DESCRIPTION
## Summary
- restore online keyboard camera controls so desktop multiplayer matches solo camera behavior
- handle `V` toggle and held `B` rear view in the online game loop
- keep online mobile view switching working and sync the mobile view button state
- align online firing with the active first-person / third-person / rear-view muzzle path

## Root Cause
Online mode had drifted from solo camera handling in `client/src/game/gameApp.ts`: the online tick never consumed the `V` toggle, hardcoded rear view off, and always fired from the first-person muzzle.

## Validation
- `npm run build --prefix client`
- `npm run build --prefix server`
- `npm test`

## Manual Test
- Solo desktop: `V` toggles third-person, hold `B` shows rear view, release `B` restores prior view
- Online desktop: `V` toggles third-person, hold `B` shows rear view, release `B` restores prior view
- Online mobile: mobile view button still switches view modes
- Regression: aiming, shooting, pointer lock, and match end/debrief still behave normally

Closes #30
