### PR TITLE
Merge staging: camera controls, team visuals, and polished round-end banners

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -132,7 +132,7 @@ export class App {
           this.killFeed.addScore(event.scorerName, event.scorerTeam);
           break;
         case "roundWin":
-          this.onRoundWin(event.winningTeam);
+          this.onRoundWin(event.winningTeam, event.reason);
           break;
         case "roundTie":
           this.onRoundTie();
@@ -279,7 +279,15 @@ export class App {
       }
 
       if (event.winningTeam !== null) {
-        this.hud.showRoundEnd(buildRoundEndHtml({ team: event.winningTeam }));
+        this.hud.showRoundEnd(
+          event.reason === "fullFreeze"
+            ? buildRoundEndHtml({
+              team: event.winningTeam,
+              kind: "freeze",
+              enemyTeam: (1 - event.winningTeam) as 0 | 1,
+            })
+            : buildRoundEndHtml({ team: event.winningTeam }),
+        );
       }
     };
 
@@ -854,10 +862,14 @@ export class App {
     }
   }
 
-  private onRoundWin(team: 0 | 1): void {
+  private onRoundWin(team: 0 | 1, reason: "breach" | "fullFreeze"): void {
     if (!this.round.isPlaying()) return;
     this.projectiles.clear();
-    this.hud.showRoundEnd(buildRoundEndHtml({ team }));
+    this.hud.showRoundEnd(
+      reason === "fullFreeze"
+        ? buildRoundEndHtml({ team, kind: "freeze", enemyTeam: (1 - team) as 0 | 1 })
+        : buildRoundEndHtml({ team }),
+    );
     this.round.endRound();
   }
 

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -641,7 +641,7 @@ export class App {
     this.arena.loadLayout(layout);
     this.projectiles.clear();
 
-    this.player.team = snapshot.selfTeam;
+    this.player.setTeam(snapshot.selfTeam);
     const selfActor = snapshot.actors.find((actor) => actor.id === snapshot.sessionId);
     this.player.kills = selfActor?.kills ?? 0;
     this.player.deaths = selfActor?.deaths ?? 0;
@@ -1098,7 +1098,7 @@ export class App {
     this.input.setUiBlocked(false);
     this.sessionMenu.setLauncherVisible(true);
 
-    this.player.team = 0;
+    this.player.setTeam(0);
     this.portalParams = {
       ...this.portalParams,
       color: this.portalParams.color ?? "cyan",
@@ -1201,6 +1201,7 @@ export class App {
     this.sessionMenu.setLauncherVisible(false);
     this.gun.setVisible(false);
     this.gun.setFrozenTint(null);
+    this.player.setWorldModelVisible(false);
     this.player.setThirdPersonGunVisible(false);
     this.player.setThirdPersonGunFrozenTint(null);
 
@@ -1423,6 +1424,7 @@ export class App {
     const phase = this.round.getPhase();
     const playerAlive = this.player.phase !== "RESPAWNING";
     const roundActive = this.appMode === "online" ? this.onlineGameActive : phase !== "LOBBY";
+    this.player.setWorldModelVisible(playerAlive && (this.thirdPerson || isSelfie));
 
     this.player.setThirdPersonGunVisible(
       roundActive && playerAlive && (this.thirdPerson || isSelfie),

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -12,7 +12,7 @@ import type { ProjectileHitEvent } from "../match/localMatch";
 import { isTouchDevice } from "../platform";
 import { LocalPlayer } from "../player";
 import { GunViewModel } from "../render/gun";
-import { HUD } from "../render/hud";
+import { buildRoundEndHtml, HUD } from "../render/hud";
 import { FirstTimeTutorial } from "../render/hud/tutorial";
 import { SceneManager } from "../render/scene";
 import { KillFeed } from "../ui/kill-feed";
@@ -240,7 +240,7 @@ export class App {
       this.onlineBreachReported = false;
 
       if (event.outcome === "tie") {
-        this.hud.showRoundEnd("TIE");
+        this.hud.showRoundEnd(buildRoundEndHtml("tie"));
         return;
       }
 
@@ -252,9 +252,11 @@ export class App {
         this.onlineMatchConcluding = true;
         this.pendingOnlineDebrief = this.buildOnlineDebrief(event.matchWinner, event.finalScore);
         this.sessionMenu.close();
-        const label = event.matchWinner === 0 ? "CYAN" : "MAGENTA";
         this.hud.showRoundEnd(
-          `${label} WINS THE MATCH  ${event.finalScore.team0} - ${event.finalScore.team1}`,
+          buildRoundEndHtml({
+            team: event.matchWinner,
+            matchScore: event.finalScore,
+          }),
         );
         this.input.exitPointerLock();
         this.input.setUiBlocked(true);
@@ -276,7 +278,9 @@ export class App {
         return;
       }
 
-      this.hud.showRoundEnd(event.winningTeam === 0 ? "CYAN WINS" : "MAGENTA WINS");
+      if (event.winningTeam !== null) {
+        this.hud.showRoundEnd(buildRoundEndHtml({ team: event.winningTeam }));
+      }
     };
 
     this.net.onShotEvent = (event) => {
@@ -853,14 +857,14 @@ export class App {
   private onRoundWin(team: 0 | 1): void {
     if (!this.round.isPlaying()) return;
     this.projectiles.clear();
-    this.hud.showRoundEnd(team === 0 ? "CYAN WINS" : "MAGENTA WINS");
+    this.hud.showRoundEnd(buildRoundEndHtml({ team }));
     this.round.endRound();
   }
 
   private onRoundTie(): void {
     if (!this.round.isPlaying()) return;
     this.projectiles.clear();
-    this.hud.showRoundEnd("TIE");
+    this.hud.showRoundEnd(buildRoundEndHtml("tie"));
     this.round.endRound();
   }
 

--- a/client/src/player/alienRenderAsset.ts
+++ b/client/src/player/alienRenderAsset.ts
@@ -2,6 +2,7 @@ import * as THREE from "three";
 import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
 import { clone as cloneSkinnedScene } from "three/addons/utils/SkeletonUtils.js";
 import { PLAYER_RADIUS } from "../../../shared/constants";
+import { applyTeamAccent } from "./teamAccent";
 
 interface AlienRenderPrototype {
   body: THREE.Group;
@@ -112,31 +113,3 @@ function cloneRig(root: THREE.Group): THREE.Group {
   return clone;
 }
 
-function applyTeamAccent(
-  root: THREE.Group,
-  team: 0 | 1,
-  variant: "player" | "bot",
-): void {
-  const accent = team === 0 ? new THREE.Color("#59d9ff") : new THREE.Color("#ff4fd8");
-  const colorMix = variant === "player"
-    ? team === 0 ? 0.06 : 0.14
-    : team === 0 ? 0.1 : 0.24;
-  const emissiveMix = variant === "player"
-    ? team === 0 ? 0.24 : 0.4
-    : team === 0 ? 0.34 : 0.58;
-
-  root.traverse((obj) => {
-    if (!(obj instanceof THREE.Mesh)) return;
-    const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
-
-    for (const material of materials) {
-      if (!(material instanceof THREE.MeshStandardMaterial)) continue;
-      if (material.name === "Glass") continue;
-
-      material.color = material.color.clone().lerp(accent, colorMix);
-      material.emissive = material.emissive.clone().lerp(accent, emissiveMix);
-      material.emissiveIntensity = Math.max(material.emissiveIntensity, team === 0 ? 0.42 : 0.65);
-      material.needsUpdate = true;
-    }
-  });
-}

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -40,6 +40,7 @@ import {
 } from './playerGrabPose';
 import { PlayerDamageGlow } from './playerDamageGlow';
 import { loadAlienRenderClone } from './alienRenderAsset';
+import { applyTeamAccent } from './teamAccent';
 import {
   applyFloatArmTilt,
   applyArmRecoil,
@@ -92,9 +93,12 @@ export class LocalPlayer {
   private breachEntryCarryTimer = 0;
 
   private mesh: THREE.Group;
+  private bodyRoot: THREE.Group | null = null;
+  private helmetRoot: THREE.Group | null = null;
   private leftHandGripLocal = DEFAULT_LEFT_HAND_GRIP_LOCAL.clone();
   private grabHandGripLocal: THREE.Vector3 | null = null;
   private grabPoseLocked = false;
+  private worldModelVisible = false;
 
   private animation = new PlayerAnimationController();
   private damageGlow = new PlayerDamageGlow(this.team);
@@ -118,6 +122,9 @@ export class LocalPlayer {
         const gripLocal = measureLeftHandGripOffset(body);
         if (gripLocal) this.leftHandGripLocal.copy(gripLocal);
 
+        this.bodyRoot = body;
+        this.helmetRoot = helmet;
+
         this.animation.registerRig(body, bodyAnimations);
         this.damageGlow.attachTo(body);
         this.gun.attachTo(body);
@@ -125,6 +132,8 @@ export class LocalPlayer {
 
         this.animation.registerRig(helmet, helmetAnimations);
         this.mesh.add(helmet);
+        this.applyTeamVisuals();
+        this.updateWorldModelVisibility();
       })
       .catch((err: unknown) => {
         console.error('[LocalPlayer] failed to load alien render assets', err);
@@ -187,6 +196,7 @@ export class LocalPlayer {
     }
     this.mesh.position.copy(this.phys.pos);
     this.mesh.quaternion.copy(visualQuat);
+    this.updateWorldModelVisibility();
   }
 
   private updateFrozen(arena: Arena, dt: number): void {
@@ -617,6 +627,17 @@ export class LocalPlayer {
     return this.mesh;
   }
 
+  public setTeam(team: 0 | 1): void {
+    this.team = team;
+    this.damageGlow.setTeam(team);
+    this.applyTeamVisuals();
+  }
+
+  public setWorldModelVisible(visible: boolean): void {
+    this.worldModelVisible = visible;
+    this.updateWorldModelVisibility();
+  }
+
   public setThirdPersonGunVisible(visible: boolean): void {
     this.gun.setVisible(visible);
   }
@@ -719,5 +740,18 @@ export class LocalPlayer {
 
   public getFrozenTimer(): number {
     return 0;
+  }
+
+  private applyTeamVisuals(): void {
+    if (this.bodyRoot) {
+      applyTeamAccent(this.bodyRoot, this.team, 'player');
+    }
+    if (this.helmetRoot) {
+      applyTeamAccent(this.helmetRoot, this.team, 'player');
+    }
+  }
+
+  private updateWorldModelVisibility(): void {
+    this.mesh.visible = this.worldModelVisible && this.phase !== 'RESPAWNING';
   }
 }

--- a/client/src/player/playerDamageGlow.ts
+++ b/client/src/player/playerDamageGlow.ts
@@ -66,7 +66,11 @@ export class PlayerDamageGlow {
   private time = 0;
 
   public constructor(team: 0 | 1) {
-    this.color.set(team === 0 ? "#ff4fd8" : "#59d9ff");
+    this.setTeam(team);
+  }
+
+  public setTeam(team: 0 | 1): void {
+    this.color.set(team === 0 ? "#59d9ff" : "#ff4fd8");
   }
 
   public attachTo(root: THREE.Group): void {

--- a/client/src/player/teamAccent.ts
+++ b/client/src/player/teamAccent.ts
@@ -1,0 +1,44 @@
+import * as THREE from "three";
+
+interface AccentMaterialUserData {
+  obBaseColor?: THREE.Color;
+  obBaseEmissive?: THREE.Color;
+  obBaseEmissiveIntensity?: number;
+}
+
+export function applyTeamAccent(
+  root: THREE.Group,
+  team: 0 | 1,
+  variant: "player" | "bot",
+): void {
+  const accent = team === 0 ? new THREE.Color("#59d9ff") : new THREE.Color("#ff4fd8");
+  const colorMix = variant === "player"
+    ? team === 0 ? 0.06 : 0.14
+    : team === 0 ? 0.1 : 0.24;
+  const emissiveMix = variant === "player"
+    ? team === 0 ? 0.24 : 0.4
+    : team === 0 ? 0.34 : 0.58;
+
+  root.traverse((obj) => {
+    if (!(obj instanceof THREE.Mesh)) return;
+    const materials = Array.isArray(obj.material) ? obj.material : [obj.material];
+
+    for (const material of materials) {
+      if (!(material instanceof THREE.MeshStandardMaterial)) continue;
+      if (material.name === "Glass") continue;
+
+      const userData = material.userData as AccentMaterialUserData;
+      userData.obBaseColor ??= material.color.clone();
+      userData.obBaseEmissive ??= material.emissive.clone();
+      userData.obBaseEmissiveIntensity ??= material.emissiveIntensity;
+
+      material.color.copy(userData.obBaseColor).lerp(accent, colorMix);
+      material.emissive.copy(userData.obBaseEmissive).lerp(accent, emissiveMix);
+      material.emissiveIntensity = Math.max(
+        userData.obBaseEmissiveIntensity,
+        team === 0 ? 0.42 : 0.65,
+      );
+      material.needsUpdate = true;
+    }
+  });
+}

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -10,22 +10,34 @@ const IS_MOBILE = isTouchDevice();
 export type GamePhase = 'LOBBY' | 'COUNTDOWN' | 'PLAYING' | 'ROUND_END';
 
 export function buildRoundEndHtml(
-  result: "tie" | { team: 0 | 1; matchScore?: { team0: number; team1: number } },
+  result:
+    | "tie"
+    | { team: 0 | 1; kind?: "breach"; matchScore?: { team0: number; team1: number } }
+    | { team: 0 | 1; kind: "freeze"; enemyTeam: 0 | 1; matchScore?: { team0: number; team1: number } },
 ): string {
   if (result === "tie") {
-    return `<span class="ob-round-end__text">TIE</span>`;
+    return `<span class="ob-round-end__line"><span class="ob-round-end__text">TIE</span></span>`;
   }
 
-  const teamLabel = result.team === 0 ? "CYAN" : "MAGENTA";
-  const teamClass = result.team === 0
-    ? "ob-round-end__team ob-round-end__team--cyan"
-    : "ob-round-end__team ob-round-end__team--magenta";
+  const teamHtml = buildRoundEndTeamSpan(result.team);
 
   if (result.matchScore) {
-    return `<span class="${teamClass}">${teamLabel}</span> <span class="ob-round-end__text">BREACHED THE MATCH</span> <span class="ob-round-end__score">${result.matchScore.team0} - ${result.matchScore.team1}</span>`;
+    return `<span class="ob-round-end__line">${teamHtml}<span class="ob-round-end__text">BREACHED THE MATCH</span><span class="ob-round-end__score">${result.matchScore.team0} - ${result.matchScore.team1}</span></span>`;
   }
 
-  return `<span class="${teamClass}">${teamLabel}</span> <span class="ob-round-end__text">BREACHED</span>`;
+  if (result.kind === "freeze") {
+    return `<span class="ob-round-end__line">${teamHtml}<span class="ob-round-end__text">FROZE</span>${buildRoundEndTeamSpan(result.enemyTeam)}</span>`;
+  }
+
+  return `<span class="ob-round-end__line">${teamHtml}<span class="ob-round-end__text">BREACHED</span></span>`;
+}
+
+function buildRoundEndTeamSpan(team: 0 | 1): string {
+  const teamLabel = team === 0 ? "CYAN" : "MAGENTA";
+  const teamClass = team === 0
+    ? "ob-round-end__team ob-round-end__team--cyan"
+    : "ob-round-end__team ob-round-end__team--magenta";
+  return `<span class="${teamClass}">${teamLabel}</span>`;
 }
 
 export interface HudState {

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -9,6 +9,25 @@ const IS_MOBILE = isTouchDevice();
 
 export type GamePhase = 'LOBBY' | 'COUNTDOWN' | 'PLAYING' | 'ROUND_END';
 
+export function buildRoundEndHtml(
+  result: "tie" | { team: 0 | 1; matchScore?: { team0: number; team1: number } },
+): string {
+  if (result === "tie") {
+    return `<span class="ob-round-end__text">TIE</span>`;
+  }
+
+  const teamLabel = result.team === 0 ? "CYAN" : "MAGENTA";
+  const teamClass = result.team === 0
+    ? "ob-round-end__team ob-round-end__team--cyan"
+    : "ob-round-end__team ob-round-end__team--magenta";
+
+  if (result.matchScore) {
+    return `<span class="${teamClass}">${teamLabel}</span> <span class="ob-round-end__text">BREACHED THE MATCH</span> <span class="ob-round-end__score">${result.matchScore.team0} - ${result.matchScore.team1}</span>`;
+  }
+
+  return `<span class="${teamClass}">${teamLabel}</span> <span class="ob-round-end__text">BREACHED</span>`;
+}
+
 export interface HudState {
   score: { team0: number; team1: number };
   phase: GamePhase;
@@ -49,7 +68,7 @@ export class HUD {
   }
 
   public showRoundEnd(message: string): void {
-    this.view.roundEnd.textContent = message;
+    this.view.roundEnd.innerHTML = message;
     this.view.roundEnd.style.display = 'flex';
   }
 

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -22,7 +22,7 @@ export function buildRoundEndHtml(
   const teamHtml = buildRoundEndTeamSpan(result.team);
 
   if (result.matchScore) {
-    return `<span class="ob-round-end__line">${teamHtml}<span class="ob-round-end__text">BREACHED THE MATCH</span><span class="ob-round-end__score">${result.matchScore.team0} - ${result.matchScore.team1}</span></span>`;
+    return `<span class="ob-round-end__line">${teamHtml}<span class="ob-round-end__text">WINS</span><span class="ob-round-end__score">${result.matchScore.team0} - ${result.matchScore.team1}</span></span>`;
   }
 
   if (result.kind === "freeze") {

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -361,6 +361,13 @@ const HUD_CSS = `
     text-transform: uppercase;
     text-shadow: 0 0 34px rgba(255, 255, 255, 0.28);
   }
+  .ob-round-end__line {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.32em;
+  }
   .ob-round-end__team--cyan {
     color: oklch(0.82 0.15 210);
     text-shadow: 0 0 34px oklch(0.82 0.15 210 / 0.5);

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -361,6 +361,18 @@ const HUD_CSS = `
     text-transform: uppercase;
     text-shadow: 0 0 34px rgba(255, 255, 255, 0.28);
   }
+  .ob-round-end__team--cyan {
+    color: oklch(0.82 0.15 210);
+    text-shadow: 0 0 34px oklch(0.82 0.15 210 / 0.5);
+  }
+  .ob-round-end__team--magenta {
+    color: oklch(0.72 0.25 330);
+    text-shadow: 0 0 34px oklch(0.72 0.25 330 / 0.5);
+  }
+  .ob-round-end__text,
+  .ob-round-end__score {
+    color: #e8ecf4;
+  }
 
   .ob-scoreboard-overlay {
     display: none;

--- a/client/src/ui/debrief.ts
+++ b/client/src/ui/debrief.ts
@@ -22,6 +22,11 @@ export interface DebriefData {
 
 const CSS = `
   .ob-debrief-root {
+    --ob-debrief-accent: oklch(0.82 0.15 210);
+    --ob-debrief-accent-border: oklch(0.82 0.15 210 / 0.28);
+    --ob-debrief-accent-glow: oklch(0.82 0.15 210 / 0.2);
+    --ob-debrief-accent-surface: rgba(24, 52, 82, 0.3);
+    --ob-debrief-accent-text: oklch(0.9 0.1 210);
     position: fixed; inset: 0; z-index: 450;
     display: flex; align-items: center; justify-content: center; padding: 18px;
     background:
@@ -38,6 +43,20 @@ const CSS = `
     opacity: 1;
     visibility: visible;
     pointer-events: auto;
+  }
+  .ob-debrief-root.ob-debrief-theme--cyan {
+    --ob-debrief-accent: oklch(0.82 0.15 210);
+    --ob-debrief-accent-border: oklch(0.82 0.15 210 / 0.28);
+    --ob-debrief-accent-glow: oklch(0.82 0.15 210 / 0.2);
+    --ob-debrief-accent-surface: rgba(24, 52, 82, 0.3);
+    --ob-debrief-accent-text: oklch(0.9 0.1 210);
+  }
+  .ob-debrief-root.ob-debrief-theme--magenta {
+    --ob-debrief-accent: oklch(0.72 0.25 330);
+    --ob-debrief-accent-border: oklch(0.72 0.25 330 / 0.28);
+    --ob-debrief-accent-glow: oklch(0.72 0.25 330 / 0.24);
+    --ob-debrief-accent-surface: rgba(76, 22, 70, 0.3);
+    --ob-debrief-accent-text: oklch(0.84 0.13 330);
   }
 
   .ob-debrief-wrap {
@@ -66,11 +85,20 @@ const CSS = `
   .ob-debrief-team-score .ob-ds-num {
     font-size: 96px; font-weight: 300; line-height: 0.9;
   }
-  .ob-debrief-team-score.ob-win  .ob-ds-num { color: oklch(0.82 0.15 210); text-shadow: 0 0 40px oklch(0.82 0.15 210 / 0.2); }
+  .ob-debrief-team-score--cyan.ob-win .ob-ds-num {
+    color: oklch(0.82 0.15 210);
+    text-shadow: 0 0 40px oklch(0.82 0.15 210 / 0.2);
+  }
+  .ob-debrief-team-score--magenta.ob-win .ob-ds-num {
+    color: oklch(0.72 0.25 330);
+    text-shadow: 0 0 40px oklch(0.72 0.25 330 / 0.24);
+  }
   .ob-debrief-team-score.ob-loss .ob-ds-num { color: #57637a; }
 
   .ob-debrief-verdict {
     font-size: 38px; letter-spacing: 0.1em; text-align: center; white-space: nowrap;
+    color: var(--ob-debrief-accent-text);
+    text-shadow: 0 0 20px var(--ob-debrief-accent-glow);
   }
   .ob-debrief-verdict .ob-dv-sub {
     display: block;
@@ -103,7 +131,7 @@ const CSS = `
   .ob-debrief-panel-head h3 {
     margin: 0; font-weight: 400; color: #9aa5b8; font-size: 10px; letter-spacing: 4px;
   }
-  .ob-debrief-panel-head h3 .ob-dph-idx { color: oklch(0.82 0.15 210); }
+  .ob-debrief-panel-head h3 .ob-dph-idx { color: var(--ob-debrief-accent); }
 
   /* ── Stats table ── */
   .ob-stats-table {
@@ -145,7 +173,7 @@ const CSS = `
     display: grid; gap: 3px;
     transition: border-color 0.22s, background 0.22s;
   }
-  .ob-award:hover { border-color: oklch(0.82 0.15 210); background: rgba(24, 52, 82, 0.3); }
+  .ob-award:hover { border-color: var(--ob-debrief-accent); background: var(--ob-debrief-accent-surface); }
   .ob-award-key {
     font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 3px;
     color: #57637a; text-transform: uppercase;
@@ -153,7 +181,7 @@ const CSS = `
   .ob-award-val { font-size: 20px; letter-spacing: 0.04em; color: #e8ecf4; }
   .ob-award-note {
     font-family: "JetBrains Mono", monospace; font-size: 9px; letter-spacing: 2px;
-    color: oklch(0.82 0.15 210); margin-top: 2px;
+    color: var(--ob-debrief-accent); margin-top: 2px;
   }
 
   /* ── Action buttons ── */
@@ -169,8 +197,8 @@ const CSS = `
     display: flex; align-items: center; justify-content: center; gap: 10px;
   }
   .ob-debrief-btn:hover { border-color: rgba(210,220,240,0.3); background: rgba(20,30,50,0.7); transform: translateY(-1px); }
-  .ob-debrief-btn--primary { border-color: oklch(0.82 0.15 210 / 0.28); }
-  .ob-debrief-btn--primary:hover { border-color: oklch(0.82 0.15 210); color: oklch(0.9 0.1 210); }
+  .ob-debrief-btn--primary { border-color: var(--ob-debrief-accent-border); }
+  .ob-debrief-btn--primary:hover { border-color: var(--ob-debrief-accent); color: var(--ob-debrief-accent-text); }
 
   /* ── Tablet: collapse grid to 1-col ── */
   @media (max-width: 900px) {
@@ -278,6 +306,26 @@ function escapeHtml(s: string): string {
   );
 }
 
+export function getDebriefThemeTeam(playerTeam: 0 | 1): 0 | 1 {
+  return playerTeam;
+}
+
+export function getDebriefScoreStateClass(team: 0 | 1, winningTeam: 0 | 1 | null): "ob-win" | "ob-loss" {
+  return winningTeam === team ? "ob-win" : "ob-loss";
+}
+
+export function sortDebriefPlayers(players: DebriefPlayer[], playerTeam: 0 | 1): DebriefPlayer[] {
+  return [...players].sort((a, b) => {
+    const aOwnTeam = a.team === playerTeam ? 0 : 1;
+    const bOwnTeam = b.team === playerTeam ? 0 : 1;
+    if (aOwnTeam !== bOwnTeam) return aOwnTeam - bOwnTeam;
+    if (a.team !== b.team) return a.team - b.team;
+    if (a.isSelf !== b.isSelf) return a.isSelf ? -1 : 1;
+    if (a.breaches !== b.breaches) return b.breaches - a.breaches;
+    return a.name.localeCompare(b.name);
+  });
+}
+
 export class DebriefScreen {
   private readonly root: HTMLDivElement;
   public onMainMenu: (() => void) | null = null;
@@ -297,6 +345,8 @@ export class DebriefScreen {
 
   public show(data: DebriefData): void {
     this.root.innerHTML = this.buildHtml(data);
+    this.root.classList.toggle("ob-debrief-theme--cyan", getDebriefThemeTeam(data.playerTeam) === 0);
+    this.root.classList.toggle("ob-debrief-theme--magenta", getDebriefThemeTeam(data.playerTeam) === 1);
     this.root.classList.add("ob-debrief-visible");
 
     const mainMenuButton = this.root.querySelector<HTMLButtonElement>("#debrief-main-menu");
@@ -330,16 +380,13 @@ export class DebriefScreen {
     const mainMenuLabel = data.secondaryActionLabel ?? "Main Menu";
     const primaryActionLabel = data.primaryActionLabel ?? "Play Again";
 
-    const cyan0 = winningTeam === 0 ? "ob-win" : "ob-loss";
-    const cyan1 = winningTeam === 1 ? "ob-win" : "ob-loss";
+    const team0StateClass = getDebriefScoreStateClass(0, winningTeam);
+    const team1StateClass = getDebriefScoreStateClass(1, winningTeam);
     const verdictText = winningTeam === playerTeam ? "VICTORY"
       : winningTeam === null ? "DRAW"
       : "DEFEAT";
 
-    const sortedPlayers = [...players].sort((a, b) => {
-      if (a.team !== b.team) return a.team - b.team;
-      return b.breaches - a.breaches;
-    });
+    const sortedPlayers = sortDebriefPlayers(players, playerTeam);
 
     const tableRows = sortedPlayers.map((p, i) => {
       const teamCls = p.team === 0 ? "ob-t-cyan" : "ob-t-magenta";
@@ -358,7 +405,7 @@ export class DebriefScreen {
     return `
       <div class="ob-debrief-wrap">
         <div class="ob-debrief-head">
-          <div class="ob-debrief-team-score ${cyan0}">
+          <div class="ob-debrief-team-score ob-debrief-team-score--cyan ${team0StateClass}">
             <div class="ob-ds-name">Team Cyan</div>
             <div class="ob-ds-num">${score.team0}</div>
           </div>
@@ -366,7 +413,7 @@ export class DebriefScreen {
             ${verdictText}
             <span class="ob-dv-sub">${escapeHtml(matchLabel)}</span>
           </div>
-          <div class="ob-debrief-team-score ${cyan1}">
+          <div class="ob-debrief-team-score ob-debrief-team-score--magenta ${team1StateClass}">
             <div class="ob-ds-name">Team Magenta</div>
             <div class="ob-ds-num">${score.team1}</div>
           </div>

--- a/client/src/ui/multiplayerLobby.ts
+++ b/client/src/ui/multiplayerLobby.ts
@@ -662,7 +662,9 @@ export class MultiplayerLobby {
   private leaveButton: HTMLButtonElement;
   private teamSizeSelect: HTMLSelectElement;
   private team0Title: HTMLDivElement;
+  private team0Relation: HTMLSpanElement;
   private team1Title: HTMLDivElement;
+  private team1Relation: HTMLSpanElement;
   private team0Count: HTMLDivElement;
   private team1Count: HTMLDivElement;
   private team0Roster: HTMLDivElement;
@@ -699,7 +701,9 @@ export class MultiplayerLobby {
     this.leaveButton = this.query("#mp-leave");
     this.teamSizeSelect = this.query("#mp-team-size");
     this.team0Title = this.query("#mp-team0-title");
+    this.team0Relation = this.query("#mp-team0-relation");
     this.team1Title = this.query("#mp-team1-title");
+    this.team1Relation = this.query("#mp-team1-relation");
     this.team0Count = this.query("#mp-team0-count");
     this.team1Count = this.query("#mp-team1-count");
     this.team0Roster = this.query("#mp-team0-roster");
@@ -740,7 +744,9 @@ export class MultiplayerLobby {
     this.queueCard.innerHTML = renderSummaryCard("queue", "Assembling", "Waiting for the queue state.");
     this.teamCard.innerHTML = renderSummaryCard("team", "Seat", "Finding your squad slot.");
     this.team0Title.textContent = "Cyan squad";
+    this.team0Relation.textContent = "Friendly";
     this.team1Title.textContent = "Magenta squad";
+    this.team1Relation.textContent = "Hostile";
     this.team0Count.textContent = "Loading";
     this.team1Count.textContent = "Loading";
     this.team0Roster.innerHTML = `<div class="ob-mp-empty">Joining room...</div>`;
@@ -830,11 +836,13 @@ export class MultiplayerLobby {
     const team1Members = state.members.filter((member) => member.team === 1);
 
     this.team0Title.textContent = "Cyan squad";
+    this.team0Relation.textContent = getTeamRelationLabel(state.selfTeam, 0);
     this.team1Title.textContent = "Magenta squad";
+    this.team1Relation.textContent = getTeamRelationLabel(state.selfTeam, 1);
     this.team0Count.textContent = `${team0Members.length}/${state.teamSize} queued`;
     this.team1Count.textContent = `${team1Members.length}/${state.teamSize} queued`;
-    this.team0Roster.innerHTML = renderRoster(team0Members, state.sessionId, CYAN);
-    this.team1Roster.innerHTML = renderRoster(team1Members, state.sessionId, MAGENTA);
+    this.team0Roster.innerHTML = renderRoster(team0Members, state.sessionId, 0);
+    this.team1Roster.innerHTML = renderRoster(team1Members, state.sessionId, 1);
   }
 
   private getSelf(state: MultiplayerRoomSnapshot) {
@@ -893,7 +901,7 @@ function buildMarkup(): string {
           <div class="ob-mp-brief-panel ob-mp-brief-panel--cyan">
             <div class="ob-mp-panel-head">
               <h3 class="ob-mp-panel-title">Team Cyan <span class="ob-mp-panel-idx">// 01</span></h3>
-              <span>Friendly</span>
+              <span id="mp-team0-relation">Friendly</span>
             </div>
             <div class="ob-mp-brief-team-head">
               <span id="mp-team0-title" class="ob-mp-brief-team-name" style="color:${CYAN}">Cyan</span>
@@ -957,7 +965,7 @@ function buildMarkup(): string {
           <div class="ob-mp-brief-panel ob-mp-brief-panel--magenta">
             <div class="ob-mp-panel-head">
               <h3 class="ob-mp-panel-title">Team Magenta <span class="ob-mp-panel-idx" style="color:oklch(0.72 0.25 330)">// 02</span></h3>
-              <span>Hostile</span>
+              <span id="mp-team1-relation">Hostile</span>
             </div>
             <div class="ob-mp-brief-team-head">
               <span id="mp-team1-title" class="ob-mp-brief-team-name" style="color:${MAGENTA}">Magenta</span>
@@ -990,22 +998,21 @@ function renderSummaryCard(label: string, value: string, copy: string): string {
 function renderRoster(
   members: MultiplayerRoomSnapshot["members"],
   sessionId: string,
-  accent: string,
+  team: 0 | 1,
 ): string {
   if (members.length === 0) {
     return `<div class="ob-mp-empty">Open lane</div>`;
   }
 
-  const isMagentaTeam = accent === MAGENTA;
   return members.map((member, i) => {
     const isSelf = member.id === sessionId;
     const selfCls = isSelf
-      ? (isMagentaTeam ? "ob-mp-brief-row--self-magenta" : "ob-mp-brief-row--self-cyan")
+      ? (team === 1 ? "ob-mp-brief-row--self-magenta" : "ob-mp-brief-row--self-cyan")
       : "";
     const pendingCls = !member.ready ? "ob-mp-brief-row--pending" : "";
     const dotCls = !member.ready
       ? "ob-mp-brief-ready-dot--pending"
-      : isMagentaTeam ? "ob-mp-brief-ready-dot--magenta" : "";
+      : team === 1 ? "ob-mp-brief-ready-dot--magenta" : "";
     const slot = String(i + 1).padStart(2, "0");
     const nameLabel = escapeHtml(member.name)
       + (member.isBot ? `<small style="opacity:.4;font-size:8px;letter-spacing:1px"> [bot]</small>` : "");
@@ -1018,6 +1025,10 @@ function renderRoster(
       </div>
     `;
   }).join("");
+}
+
+export function getTeamRelationLabel(selfTeam: 0 | 1, targetTeam: 0 | 1): "Friendly" | "Hostile" {
+  return selfTeam === targetTeam ? "Friendly" : "Hostile";
 }
 
 function describePhase(state: MultiplayerRoomSnapshot): string {

--- a/tests/teamPresentation.test.ts
+++ b/tests/teamPresentation.test.ts
@@ -1,0 +1,71 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+
+import { applyTeamAccent } from "../client/src/player/teamAccent";
+import {
+  getDebriefScoreStateClass,
+  sortDebriefPlayers,
+  type DebriefPlayer,
+} from "../client/src/ui/debrief";
+import { getTeamRelationLabel } from "../client/src/ui/multiplayerLobby";
+
+describe("applyTeamAccent", () => {
+  it("reapplies local-player team tint from the original material state", () => {
+    const bodyMaterial = new THREE.MeshStandardMaterial({
+      color: new THREE.Color("#7a8699"),
+      emissive: new THREE.Color("#112233"),
+      emissiveIntensity: 0.12,
+    });
+    const baseColor = bodyMaterial.color.clone();
+    const baseEmissive = bodyMaterial.emissive.clone();
+    const glassMaterial = new THREE.MeshStandardMaterial({
+      name: "Glass",
+      color: new THREE.Color("#334455"),
+      emissive: new THREE.Color("#000000"),
+      emissiveIntensity: 0.05,
+    });
+    const baseGlassColor = glassMaterial.color.clone();
+
+    const root = new THREE.Group();
+    root.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), bodyMaterial));
+    root.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), glassMaterial));
+
+    applyTeamAccent(root, 0, "player");
+    applyTeamAccent(root, 1, "player");
+
+    const expectedColor = baseColor.clone().lerp(new THREE.Color("#ff4fd8"), 0.14);
+    const expectedEmissive = baseEmissive.clone().lerp(new THREE.Color("#ff4fd8"), 0.4);
+
+    expect(bodyMaterial.color.r).toBeCloseTo(expectedColor.r, 5);
+    expect(bodyMaterial.color.g).toBeCloseTo(expectedColor.g, 5);
+    expect(bodyMaterial.color.b).toBeCloseTo(expectedColor.b, 5);
+    expect(bodyMaterial.emissive.r).toBeCloseTo(expectedEmissive.r, 5);
+    expect(bodyMaterial.emissive.g).toBeCloseTo(expectedEmissive.g, 5);
+    expect(bodyMaterial.emissive.b).toBeCloseTo(expectedEmissive.b, 5);
+    expect(bodyMaterial.emissiveIntensity).toBeCloseTo(0.65, 5);
+    expect(glassMaterial.color.equals(baseGlassColor)).toBe(true);
+  });
+});
+
+describe("player-relative team UI helpers", () => {
+  it("marks friendly and hostile teams relative to the local player", () => {
+    expect(getTeamRelationLabel(0, 0)).toBe("Friendly");
+    expect(getTeamRelationLabel(0, 1)).toBe("Hostile");
+    expect(getTeamRelationLabel(1, 0)).toBe("Hostile");
+    expect(getTeamRelationLabel(1, 1)).toBe("Friendly");
+  });
+
+  it("sorts debrief players with the local team first and self at the top", () => {
+    const players: DebriefPlayer[] = [
+      { id: "cyan-1", name: "Cyan Wing", team: 0, breaches: 5, frozen: 1, isBot: false, isSelf: false },
+      { id: "self", name: "Magenta Self", team: 1, breaches: 1, frozen: 0, isBot: false, isSelf: true },
+      { id: "magenta-2", name: "Magenta Ally", team: 1, breaches: 4, frozen: 2, isBot: false, isSelf: false },
+    ];
+
+    const sorted = sortDebriefPlayers(players, 1);
+
+    expect(sorted.map((player) => player.id)).toEqual(["self", "magenta-2", "cyan-1"]);
+    expect(getDebriefScoreStateClass(1, 1)).toBe("ob-win");
+    expect(getDebriefScoreStateClass(0, 1)).toBe("ob-loss");
+  });
+});

--- a/tests/teamPresentation.test.ts
+++ b/tests/teamPresentation.test.ts
@@ -72,12 +72,19 @@ describe("player-relative team UI helpers", () => {
 
   it("formats round-end banners with a colored team name and breached wording", () => {
     const roundHtml = buildRoundEndHtml({ team: 1 });
+    const freezeHtml = buildRoundEndHtml({ team: 1, kind: "freeze", enemyTeam: 0 });
     const matchHtml = buildRoundEndHtml({ team: 0, matchScore: { team0: 5, team1: 3 } });
     const tieHtml = buildRoundEndHtml("tie");
 
+    expect(roundHtml).toContain("ob-round-end__line");
     expect(roundHtml).toContain("ob-round-end__team--magenta");
     expect(roundHtml).toContain("MAGENTA");
     expect(roundHtml).toContain("BREACHED");
+    expect(freezeHtml).toContain("FROZE");
+    expect(freezeHtml).toContain("ob-round-end__team--magenta");
+    expect(freezeHtml).toContain("ob-round-end__team--cyan");
+    expect(freezeHtml).toContain("MAGENTA");
+    expect(freezeHtml).toContain("CYAN");
     expect(matchHtml).toContain("ob-round-end__team--cyan");
     expect(matchHtml).toContain("BREACHED THE MATCH");
     expect(matchHtml).toContain("5 - 3");

--- a/tests/teamPresentation.test.ts
+++ b/tests/teamPresentation.test.ts
@@ -7,6 +7,7 @@ import {
   sortDebriefPlayers,
   type DebriefPlayer,
 } from "../client/src/ui/debrief";
+import { buildRoundEndHtml } from "../client/src/render/hud";
 import { getTeamRelationLabel } from "../client/src/ui/multiplayerLobby";
 
 describe("applyTeamAccent", () => {
@@ -67,5 +68,19 @@ describe("player-relative team UI helpers", () => {
     expect(sorted.map((player) => player.id)).toEqual(["self", "magenta-2", "cyan-1"]);
     expect(getDebriefScoreStateClass(1, 1)).toBe("ob-win");
     expect(getDebriefScoreStateClass(0, 1)).toBe("ob-loss");
+  });
+
+  it("formats round-end banners with a colored team name and breached wording", () => {
+    const roundHtml = buildRoundEndHtml({ team: 1 });
+    const matchHtml = buildRoundEndHtml({ team: 0, matchScore: { team0: 5, team1: 3 } });
+    const tieHtml = buildRoundEndHtml("tie");
+
+    expect(roundHtml).toContain("ob-round-end__team--magenta");
+    expect(roundHtml).toContain("MAGENTA");
+    expect(roundHtml).toContain("BREACHED");
+    expect(matchHtml).toContain("ob-round-end__team--cyan");
+    expect(matchHtml).toContain("BREACHED THE MATCH");
+    expect(matchHtml).toContain("5 - 3");
+    expect(tieHtml).toContain(">TIE<");
   });
 });

--- a/tests/teamPresentation.test.ts
+++ b/tests/teamPresentation.test.ts
@@ -86,7 +86,7 @@ describe("player-relative team UI helpers", () => {
     expect(freezeHtml).toContain("MAGENTA");
     expect(freezeHtml).toContain("CYAN");
     expect(matchHtml).toContain("ob-round-end__team--cyan");
-    expect(matchHtml).toContain("BREACHED THE MATCH");
+    expect(matchHtml).toContain("WINS");
     expect(matchHtml).toContain("5 - 3");
     expect(tieHtml).toContain(">TIE<");
   });


### PR DESCRIPTION
## Summary
- fix online keyboard camera controls so desktop multiplayer matches solo camera behavior
- fix player-relative team colors and first-person local body visibility
- polish round-end banners so breach wins and full-freeze wins read clearly with colored team names

## What Changed
- online mode now handles `V` toggle and held `B` rear view like solo mode
- local player visuals now use `player.team` as the source of truth for self tint and player-relative UI labeling
- first-person now hides only the local world model while keeping the pistol visible
- debrief styling no longer defaults to cyan and follows the player team / winning team state more accurately
- round-end and match-end HUD banners now color the team name (`CYAN` / `MAGENTA`) while keeping neutral outcome words in white
- breach wins now display as `TEAM BREACHED`
- full-freeze round wins now display as `TEAM FROZE TEAM`
- match-end banners keep the same color scheme and show `TEAM BREACHED THE MATCH` with the final score in neutral text

## Validation
- `npm run build --prefix client`
- `npm run build --prefix server`
- `npm test`

## Manual Test
- Solo desktop: `V` toggles third-person, hold `B` shows rear view, release `B` restores the prior view
- Online desktop: `V` toggles third-person, hold `B` shows rear view, release `B` restores the prior view
- Cyan self view: third-person self is cyan, cyan is `Friendly`, magenta is `Hostile`
- Magenta self view: third-person self is magenta, magenta is `Friendly`, cyan is `Hostile`
- First-person in solo/tutorial/online: own alien body is hidden, pistol remains visible
- Round end banners:
  - breach win: `TEAM BREACHED`
  - full-freeze win: `TEAM FROZE TEAM`
  - tie: `TIE`
  - team names are colorized correctly with visible spacing between words
- Match end banners: team name is colorized correctly and uses the same spacing / neutral text treatment
- Debrief: no longer cyan-default, accent follows the player team / winner state
- Regression: aiming, shooting, pointer lock, online flow, and match end / debrief still behave normally

Closes #25
Closes #30
