### PR TITLE
Fix post-round debrief and online round-end behavior

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -245,7 +245,11 @@ export class App {
       if (this.isUserExitingOnline || this.appMode !== "online") return;
       if (!this.onlineGameActive) return;
 
-      this.onlineRoundActive = false;
+      if (event.reason === "breach") {
+        this.disableOnlineProjectiles();
+      } else {
+        this.onlineRoundActive = false;
+      }
       this.projectiles.clear();
       this.onlineBreachReported = false;
 
@@ -303,7 +307,7 @@ export class App {
 
     this.net.onShotEvent = (event) => {
       if (this.isUserExitingOnline || this.appMode !== "online") return;
-      if (!this.onlineGameActive) return;
+      if (!this.onlineGameActive || !this.onlineRoundActive) return;
       if (event.ownerId === this.getOnlineLocalActorId()) return;
 
       this.projectiles.spawn(
@@ -626,11 +630,17 @@ export class App {
     this.player.currentBreachTeam = enemyTeam;
     this.player.phase = "BREACH";
     this.onlineBreachReported = true;
+    this.disableOnlineProjectiles();
 
     this.net.sendBreachReport({
       scorerTeam: this.player.team,
       scorerName: this.onlinePlayerName,
     });
+  }
+
+  private disableOnlineProjectiles(): void {
+    this.onlineRoundActive = false;
+    this.projectiles.clear();
   }
 
   private sendOnlinePlayerUpdate(): void {
@@ -960,8 +970,8 @@ export class App {
       score: finalScore,
       players: [...ownPlayers, ...enemyPlayers],
       playerTeam,
+      secondaryActionLabel: "Main Menu",
       primaryActionLabel: "Play Again",
-      showSecondaryAction: false,
       matchLabel: `${sizeLabelMap[teamSize] ?? "Solo"} · ${finalScore.team0} – ${finalScore.team1}`,
     };
 
@@ -1329,8 +1339,8 @@ export class App {
       score: finalScore,
       players,
       playerTeam,
+      secondaryActionLabel: "Main Menu",
       primaryActionLabel: "Return To Lobby",
-      showSecondaryAction: false,
       matchLabel: `${sizeLabelMap[teamSize] ?? `${teamSize}v${teamSize}`} Online · ${finalScore.team0} – ${finalScore.team1}`,
     };
   }

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -954,8 +954,8 @@ export class App {
       score: finalScore,
       players: [...ownPlayers, ...enemyPlayers],
       playerTeam,
-      primaryActionLabel: "Return To Room",
-      secondaryActionLabel: "Main Menu",
+      primaryActionLabel: "Play Again",
+      showSecondaryAction: false,
       matchLabel: `${sizeLabelMap[teamSize] ?? "Solo"} · ${finalScore.team0} – ${finalScore.team1}`,
     };
 
@@ -1321,6 +1321,8 @@ export class App {
       score: finalScore,
       players,
       playerTeam,
+      primaryActionLabel: "Return To Lobby",
+      showSecondaryAction: false,
       matchLabel: `${sizeLabelMap[teamSize] ?? `${teamSize}v${teamSize}`} Online · ${finalScore.team0} – ${finalScore.team1}`,
     };
   }

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -1340,6 +1340,8 @@ export class App {
     this.onlineGameActive = false;
     this.onlineRoundActive = false;
     this.input.setUiBlocked(false);
+    this.onlineMatch.dispose();
+    this.projectiles.clear();
     this.sessionMenu.setLauncherVisible(true);
     this.hud.hideRoundEnd();
 

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -52,6 +52,7 @@ const ONLINE_MATCH_DEBRIEF_DELAY_MS = 4000;
 export class App {
   private appMode: "menu" | "solo" | "online" = "menu";
   private onlineGameActive = false;
+  private onlineRoundActive = false;
   private onlineSessionToken = 0;
   private isUserExitingOnline = false;
   private matchOver = false;
@@ -187,6 +188,7 @@ export class App {
       this.previousOnlinePhase = snapshot.phase;
 
       if (this.onlineMatchConcluding) {
+        this.onlineRoundActive = false;
         if (this.onlineGameActive) {
           this.arena.setPortalDoorsOpen(snapshot.phase === "PLAYING");
           this.onlineMatch.applySnapshot(snapshot.actors, snapshot.sessionId);
@@ -216,6 +218,7 @@ export class App {
       }
 
       if (this.onlineGameActive) {
+        this.onlineRoundActive = snapshot.phase === "PLAYING";
         this.arena.setPortalDoorsOpen(snapshot.phase === "PLAYING");
         this.onlineMatch.applySnapshot(snapshot.actors, snapshot.sessionId);
       }
@@ -242,6 +245,7 @@ export class App {
       if (this.isUserExitingOnline || this.appMode !== "online") return;
       if (!this.onlineGameActive) return;
 
+      this.onlineRoundActive = false;
       this.projectiles.clear();
       this.onlineBreachReported = false;
 
@@ -538,7 +542,7 @@ export class App {
       || this.player.phase === "GRABBING"
       || this.player.phase === "AIMING";
 
-    if (!this.onlineGameActive) return;
+    if (!this.onlineGameActive || !this.onlineRoundActive) return;
     if (!this.input.canControlGame() || !inZeroG) return;
     if (!this.player.canFire() || !this.input.consumeFire()) return;
 
@@ -659,6 +663,7 @@ export class App {
     }
 
     this.onlineGameActive = true;
+    this.onlineRoundActive = snapshot.phase === "PLAYING";
     this.onlineBreachReported = false;
     this.playerUpdateTimer = 0;
     this.tutorial.beginRun();
@@ -713,6 +718,7 @@ export class App {
     this.sound.stopCountdown();
     this.closeSessionMenu();
     this.onlineGameActive = false;
+    this.onlineRoundActive = false;
     this.onlineBreachReported = false;
 
     this.onlineMatch.dispose();
@@ -1170,6 +1176,7 @@ export class App {
     this.appMode = "online";
     this.onlinePlayerName = selection.name;
     this.onlineGameActive = false;
+    this.onlineRoundActive = false;
     this.onlineBreachReported = false;
     this.onlineMatchConcluding = false;
     this.pendingOnlineDebrief = null;
@@ -1223,6 +1230,7 @@ export class App {
     this.debrief.hide();
     this.appMode = "menu";
     this.onlineGameActive = false;
+    this.onlineRoundActive = false;
     this.cursor.show();
     this.onlineBreachReported = false;
     this.onlineMatchConcluding = false;
@@ -1330,6 +1338,7 @@ export class App {
   private returnToOnlineLobbyFromDebrief(): void {
     this.onlineMatchConcluding = false;
     this.onlineGameActive = false;
+    this.onlineRoundActive = false;
     this.input.setUiBlocked(false);
     this.sessionMenu.setLauncherVisible(true);
     this.hud.hideRoundEnd();

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
-import { GRAB_RADIUS, HITBOX_OFFSET_Y, HITBOX_RADIUS } from "../../../shared/constants";
+import { GRAB_RADIUS, HITBOX_OFFSET_Y, HITBOX_RADIUS, MATCH_POINT_TARGET } from "../../../shared/constants";
 import { generateArenaLayout } from "../../../shared/arena-gen";
+import { findMatchWinner } from "../../../shared/match-flow";
 import type { MultiplayerRoomSnapshot } from "../../../shared/multiplayer";
 import { Arena } from "../arena/arena";
 import { CameraController } from "../camera";
@@ -905,10 +906,14 @@ export class App {
   private onRoundWin(team: 0 | 1, reason: "breach" | "fullFreeze"): void {
     if (!this.round.isPlaying()) return;
     this.projectiles.clear();
+    const score = this.match.getScore();
+    const matchWinner = findMatchWinner(score, MATCH_POINT_TARGET);
     this.hud.showRoundEnd(
-      reason === "fullFreeze"
-        ? buildRoundEndHtml({ team, kind: "freeze", enemyTeam: (1 - team) as 0 | 1 })
-        : buildRoundEndHtml({ team }),
+      matchWinner !== null
+        ? buildRoundEndHtml({ team, matchScore: score })
+        : reason === "fullFreeze"
+          ? buildRoundEndHtml({ team, kind: "freeze", enemyTeam: (1 - team) as 0 | 1 })
+          : buildRoundEndHtml({ team }),
     );
     this.round.endRound();
   }

--- a/client/src/ui/debrief.ts
+++ b/client/src/ui/debrief.ts
@@ -18,6 +18,8 @@ export interface DebriefData {
   matchLabel: string;
   primaryActionLabel?: string;
   secondaryActionLabel?: string;
+  showPrimaryAction?: boolean;
+  showSecondaryAction?: boolean;
 }
 
 const CSS = `
@@ -377,6 +379,8 @@ export class DebriefScreen {
 
   private buildHtml(data: DebriefData): string {
     const { score, winningTeam, players, playerTeam, matchLabel } = data;
+    const showSecondaryAction = data.showSecondaryAction ?? true;
+    const showPrimaryAction = data.showPrimaryAction ?? true;
     const mainMenuLabel = data.secondaryActionLabel ?? "Main Menu";
     const primaryActionLabel = data.primaryActionLabel ?? "Play Again";
 
@@ -401,6 +405,12 @@ export class DebriefScreen {
     }).join("");
 
     const awards = this.buildAwards(players);
+    const secondaryAction = showSecondaryAction
+      ? `<button class="ob-debrief-btn" id="debrief-main-menu">${escapeHtml(mainMenuLabel)} -></button>`
+      : "";
+    const primaryAction = showPrimaryAction
+      ? `<button class="ob-debrief-btn ob-debrief-btn--primary" id="debrief-play-again">${escapeHtml(primaryActionLabel)} -></button>`
+      : "";
 
     return `
       <div class="ob-debrief-wrap">
@@ -436,8 +446,8 @@ export class DebriefScreen {
           <div class="ob-debrief-side">
             <div class="ob-awards">${awards}</div>
             <div class="ob-debrief-actions">
-              <button class="ob-debrief-btn" id="debrief-main-menu">Main Menu →</button>
-              <button class="ob-debrief-btn ob-debrief-btn--primary" id="debrief-play-again">Play Again →</button>
+              ${secondaryAction}
+              ${primaryAction}
             </div>
           </div>
         </div>

--- a/client/src/ui/debrief.ts
+++ b/client/src/ui/debrief.ts
@@ -353,11 +353,11 @@ export class DebriefScreen {
 
     const mainMenuButton = this.root.querySelector<HTMLButtonElement>("#debrief-main-menu");
     if (mainMenuButton && data.secondaryActionLabel) {
-      mainMenuButton.textContent = `${data.secondaryActionLabel} ->`;
+      mainMenuButton.textContent = data.secondaryActionLabel;
     }
     const primaryActionButton = this.root.querySelector<HTMLButtonElement>("#debrief-play-again");
     if (primaryActionButton && data.primaryActionLabel) {
-      primaryActionButton.textContent = `${data.primaryActionLabel} ->`;
+      primaryActionButton.textContent = data.primaryActionLabel;
     }
 
     mainMenuButton?.addEventListener("click", () => { this.hide(); this.onMainMenu?.(); });
@@ -406,10 +406,10 @@ export class DebriefScreen {
 
     const awards = this.buildAwards(players);
     const secondaryAction = showSecondaryAction
-      ? `<button class="ob-debrief-btn" id="debrief-main-menu">${escapeHtml(mainMenuLabel)} -></button>`
+      ? `<button class="ob-debrief-btn" id="debrief-main-menu">${escapeHtml(mainMenuLabel)}</button>`
       : "";
     const primaryAction = showPrimaryAction
-      ? `<button class="ob-debrief-btn ob-debrief-btn--primary" id="debrief-play-again">${escapeHtml(primaryActionLabel)} -></button>`
+      ? `<button class="ob-debrief-btn ob-debrief-btn--primary" id="debrief-play-again">${escapeHtml(primaryActionLabel)}</button>`
       : "";
 
     return `

--- a/server/src/colyseus/OrbitalLobbyRoom.ts
+++ b/server/src/colyseus/OrbitalLobbyRoom.ts
@@ -241,7 +241,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
   // ── Match message handlers ──────────────────────────────────────────────────
 
   private handlePlayerUpdateMessage(client: RoomClient, message: PlayerUpdateMessage): void {
-    if (this.state.phase !== "PLAYING") return;
+    if (this.state.phase !== "PLAYING" && this.state.phase !== "ROUND_END") return;
     const actor = this.state.actors.get(client.sessionId);
     if (!actor || actor.isBot) return;
 
@@ -439,7 +439,6 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     this.state.phase = "ROUND_END";
     this.state.countdownRemaining = 0;
     this.state.roundTimeRemaining = 0;
-    this.clearActors();
 
     this.roundEndTimer = setTimeout(() => {
       this.roundEndTimer = null;


### PR DESCRIPTION
## Summary
- **Issue #35** — Debrief actions now match mode: solo shows only `PLAY AGAIN`, online shows only `RETURN TO LOBBY`.
- **Issue #34** — Online firing is gated by an official live-round state, so shots cannot be created after a round result or while returning from breach/end states.
- **Issue #36** — Online actors remain in the room snapshot through `ROUND_END`, and movement updates continue there so players do not disappear between rounds.

## Root cause
- Debrief always rendered both action buttons, and online relied on the play-again callback to return to lobby while solo labeled the same callback incorrectly.
- `onlineGameActive` meant the arena was mounted, but it was also used as the firing gate during the post-result delay.
- The server cleared all actors immediately when entering `ROUND_END`, so clients received an empty actor snapshot and remote players vanished.

## Test plan
- [ ] Solo: start a solo match, end the match, and confirm debrief shows only `PLAY AGAIN`.
- [x] Solo: click `PLAY AGAIN` and confirm it restarts the same solo playlist.
- [x] Solo: confirm shooting behavior remains unchanged before and after debrief.
- [x] Online: start an online match with two clients, end at 5 points, and confirm debrief shows only `RETURN TO LOBBY`.
- [x] Online: click `RETURN TO LOBBY` and confirm it returns to the online lobby/session flow.
- [x] Online: after a round result or breach/end state, click fire and confirm no shot, no local projectile, and no shot sound.
- [x] Online: start the next online round and confirm shooting works again only once the round is live.
- [x] Online: confirm players remain visible during `ROUND_END` before the next round/debrief transition.
- [x] Online: confirm players can still move during `ROUND_END` where the current controls allow it.
- [x] Online: confirm no flicker/disappearance during the round-end to countdown/lobby/debrief transition.
- [x] `npm run build --prefix client` → passed
- [x] `npm run build --prefix server` → passed
- [x] `npm test` → 20 files / 164 tests passed
- [x] `cd client && node_modules/.bin/tsc --noEmit` → zero errors
- [x] `cd server && node_modules/.bin/tsc --noEmit` → zero errors

## Merge notes
- Merging this PR should close **#34**, **#35**, and **#36** automatically.

Closes #34
Closes #35
Closes #36