### PR TITLE
Add camera setting and kill feed YOU label

### DIFF
--- a/client/src/arena/arena.ts
+++ b/client/src/arena/arena.ts
@@ -40,6 +40,7 @@ interface BreachRoom {
  *   obstacleCollision   — AABB bounce math
  */
 export class Arena {
+  private static readonly CAMERA_WALL_THICKNESS = 0.25;
   private obstaclesGroup = new THREE.Group();
   private goalPlanes: GoalPlane[] = [];
   private barObjects: BarObject[] = [];
@@ -168,6 +169,15 @@ export class Arena {
     return this.obstaclesGroup.children.map(c => new THREE.Box3().setFromObject(c as THREE.Mesh));
   }
 
+  public getThirdPersonCameraCollisionAABBs(): THREE.Box3[] {
+    return [
+      ...this.getObstacleAABBs(),
+      ...this.getArenaWallAABBs(),
+      ...this.getBreachRoomWallAABBs(),
+      ...this.getClosedPortalBarrierAABBs(),
+    ];
+  }
+
   /**
    * Thin world-space slabs at each breach room portal opening (BREACH_ROOM_W × BREACH_ROOM_H).
    * Include these alongside obstacle AABBs in projectileSystem.update() so bullets are killed
@@ -268,6 +278,144 @@ export class Arena {
   private clearGoalPlanes(): void {
     for (const g of this.goalPlanes) g.dispose();
     this.goalPlanes = [];
+  }
+
+  private getArenaWallAABBs(): THREE.Box3[] {
+    if (!this.currentLayout) return [];
+
+    const half = ARENA_SIZE / 2;
+    const thickness = Arena.CAMERA_WALL_THICKNESS;
+    const hw = BREACH_ROOM_W / 2;
+    const hh = BREACH_ROOM_H / 2;
+    const boxes: THREE.Box3[] = [];
+    const addBox = (min: THREE.Vector3, max: THREE.Vector3): void => {
+      boxes.push(new THREE.Box3(min, max));
+    };
+
+    if (this.currentLayout.goalAxis === 'z') {
+      addBox(new THREE.Vector3(-half - thickness, -half, -half), new THREE.Vector3(-half + thickness, half, half));
+      addBox(new THREE.Vector3(half - thickness, -half, -half), new THREE.Vector3(half + thickness, half, half));
+      addBox(new THREE.Vector3(-half, -half - thickness, -half), new THREE.Vector3(half, -half + thickness, half));
+      addBox(new THREE.Vector3(-half, half - thickness, -half), new THREE.Vector3(half, half + thickness, half));
+
+      for (const sign of [-1, 1] as const) {
+        const face = sign * half;
+        addBox(new THREE.Vector3(-half, hh, face - thickness), new THREE.Vector3(half, half, face + thickness));
+        addBox(new THREE.Vector3(-half, -half, face - thickness), new THREE.Vector3(half, -hh, face + thickness));
+        addBox(new THREE.Vector3(-half, -hh, face - thickness), new THREE.Vector3(-hw, hh, face + thickness));
+        addBox(new THREE.Vector3(hw, -hh, face - thickness), new THREE.Vector3(half, hh, face + thickness));
+      }
+
+      return boxes;
+    }
+
+    addBox(new THREE.Vector3(-half, -half - thickness, -half), new THREE.Vector3(half, -half + thickness, half));
+    addBox(new THREE.Vector3(-half, half - thickness, -half), new THREE.Vector3(half, half + thickness, half));
+    addBox(new THREE.Vector3(-half, -half, -half - thickness), new THREE.Vector3(half, half, -half + thickness));
+    addBox(new THREE.Vector3(-half, -half, half - thickness), new THREE.Vector3(half, half, half + thickness));
+
+    for (const sign of [-1, 1] as const) {
+      const face = sign * half;
+      addBox(new THREE.Vector3(face - thickness, hh, -half), new THREE.Vector3(face + thickness, half, half));
+      addBox(new THREE.Vector3(face - thickness, -half, -half), new THREE.Vector3(face + thickness, -hh, half));
+      addBox(new THREE.Vector3(face - thickness, -hh, -half), new THREE.Vector3(face + thickness, hh, -hw));
+      addBox(new THREE.Vector3(face - thickness, -hh, hw), new THREE.Vector3(face + thickness, hh, half));
+    }
+
+    return boxes;
+  }
+
+  private getBreachRoomWallAABBs(): THREE.Box3[] {
+    const thickness = Arena.CAMERA_WALL_THICKNESS;
+    const hh = BREACH_ROOM_H / 2;
+    const hw = BREACH_ROOM_W / 2;
+    const hd = BREACH_ROOM_D / 2;
+
+    return this.breachRooms.flatMap((room) => {
+      const boxes: THREE.Box3[] = [];
+      const addBox = (min: THREE.Vector3, max: THREE.Vector3): void => {
+        boxes.push(new THREE.Box3(min, max));
+      };
+
+      if (room.openAxis === 'z') {
+        addBox(
+          new THREE.Vector3(room.center.x - hw, room.center.y - hh - thickness, room.center.z - hd),
+          new THREE.Vector3(room.center.x + hw, room.center.y - hh + thickness, room.center.z + hd),
+        );
+        addBox(
+          new THREE.Vector3(room.center.x - hw, room.center.y + hh - thickness, room.center.z - hd),
+          new THREE.Vector3(room.center.x + hw, room.center.y + hh + thickness, room.center.z + hd),
+        );
+        addBox(
+          new THREE.Vector3(room.center.x - hw - thickness, room.center.y - hh, room.center.z - hd),
+          new THREE.Vector3(room.center.x - hw + thickness, room.center.y + hh, room.center.z + hd),
+        );
+        addBox(
+          new THREE.Vector3(room.center.x + hw - thickness, room.center.y - hh, room.center.z - hd),
+          new THREE.Vector3(room.center.x + hw + thickness, room.center.y + hh, room.center.z + hd),
+        );
+        const backZ = room.center.z + room.openSign * -hd;
+        addBox(
+          new THREE.Vector3(room.center.x - hw, room.center.y - hh, backZ - thickness),
+          new THREE.Vector3(room.center.x + hw, room.center.y + hh, backZ + thickness),
+        );
+        return boxes;
+      }
+
+      addBox(
+        new THREE.Vector3(room.center.x - hd, room.center.y - hh - thickness, room.center.z - hw),
+        new THREE.Vector3(room.center.x + hd, room.center.y - hh + thickness, room.center.z + hw),
+      );
+      addBox(
+        new THREE.Vector3(room.center.x - hd, room.center.y + hh - thickness, room.center.z - hw),
+        new THREE.Vector3(room.center.x + hd, room.center.y + hh + thickness, room.center.z + hw),
+      );
+      addBox(
+        new THREE.Vector3(room.center.x - hd, room.center.y - hh, room.center.z - hw - thickness),
+        new THREE.Vector3(room.center.x + hd, room.center.y + hh, room.center.z - hw + thickness),
+      );
+      addBox(
+        new THREE.Vector3(room.center.x - hd, room.center.y - hh, room.center.z + hw - thickness),
+        new THREE.Vector3(room.center.x + hd, room.center.y + hh, room.center.z + hw + thickness),
+      );
+      const backX = room.center.x + room.openSign * -hd;
+      addBox(
+        new THREE.Vector3(backX - thickness, room.center.y - hh, room.center.z - hw),
+        new THREE.Vector3(backX + thickness, room.center.y + hh, room.center.z + hw),
+      );
+      return boxes;
+    });
+  }
+
+  private getClosedPortalBarrierAABBs(): THREE.Box3[] {
+    return this.breachRooms.flatMap((room) => {
+      if (this.isGoalDoorOpen(room.team)) return [];
+
+      const sign = (-room.openSign) as 1 | -1;
+      const faceCoord = sign * (ARENA_SIZE / 2);
+      const slab = 0.15;
+      const hw = BREACH_ROOM_W / 2;
+      const hh = BREACH_ROOM_H / 2;
+      const min = new THREE.Vector3();
+      const max = new THREE.Vector3();
+
+      min.y = -hh;
+      max.y = hh;
+
+      if (room.openAxis === 'x') {
+        min.x = faceCoord - slab;
+        max.x = faceCoord + slab;
+        min.z = -hw;
+        max.z = hw;
+      } else {
+        min.z = faceCoord - slab;
+        max.z = faceCoord + slab;
+        min.x = -hw;
+        max.x = hw;
+      }
+
+      return [new THREE.Box3(min, max)];
+    });
   }
 
   private clearBreachRooms(): void {

--- a/client/src/camera.ts
+++ b/client/src/camera.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { bulletHitPoint } from './game/bulletCollision';
 import { clamp } from './util/math';
 
 /**
@@ -14,6 +15,12 @@ import { clamp } from './util/math';
  *     when they exited the breach room — own or enemy.
  */
 const TRANSITION_DURATION = 0.6;   // seconds — return-to-breach sweep duration
+
+const THIRD_PERSON_DISTANCE = 3.0;
+const THIRD_PERSON_HEIGHT = 0.5;
+const THIRD_PERSON_CAMERA_RADIUS = 0.2;
+const THIRD_PERSON_CAMERA_PADDING = 0.05;
+const THIRD_PERSON_MIN_DISTANCE = 0.9;
 
 export class CameraController {
   // ── Gravity mode state ────────────────────────────────────────────
@@ -153,13 +160,18 @@ export class CameraController {
 
   // ── Application ───────────────────────────────────────────────────
 
-  public apply(position: THREE.Vector3, isThirdPerson: boolean = false, isSelfie: boolean = false): void {
+  public apply(
+    position: THREE.Vector3,
+    isThirdPerson: boolean = false,
+    isSelfie: boolean = false,
+    collisionBoxes: readonly THREE.Box3[] = [],
+  ): void {
     const quat = this.getQuaternion();
 
     if (isSelfie) {
       // Selfie mode: look backwards at character
       const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(quat);
-      const camPos = position.clone().add(forward.multiplyScalar(3.0));
+      const camPos = position.clone().add(forward.multiplyScalar(THIRD_PERSON_DISTANCE));
       this.camera.position.copy(camPos);
 
       // Rotate camera to look exactly opposite
@@ -170,7 +182,10 @@ export class CameraController {
       // Third person: camera is behind and slightly up
       const backward = new THREE.Vector3(0, 0, 1).applyQuaternion(quat);
       const up = new THREE.Vector3(0, 1, 0).applyQuaternion(quat);
-      const camPos = position.clone().add(backward.multiplyScalar(3.0)).add(up.multiplyScalar(0.5));
+      const desiredCamPos = position.clone()
+        .add(backward.multiplyScalar(THIRD_PERSON_DISTANCE))
+        .add(up.multiplyScalar(THIRD_PERSON_HEIGHT));
+      const camPos = this.resolveThirdPersonCameraPosition(position, desiredCamPos, collisionBoxes);
       this.camera.position.copy(camPos);
       this.camera.quaternion.copy(quat);
 
@@ -216,5 +231,38 @@ export class CameraController {
     const qYaw   = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), this.yaw);
     const qPitch = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), this.pitch);
     return qYaw.multiply(qPitch);
+  }
+
+  private resolveThirdPersonCameraPosition(
+    target: THREE.Vector3,
+    desired: THREE.Vector3,
+    collisionBoxes: readonly THREE.Box3[],
+  ): THREE.Vector3 {
+    if (collisionBoxes.length === 0) return desired;
+
+    const offset = new THREE.Vector3().subVectors(desired, target);
+    const desiredDistance = offset.length();
+    if (desiredDistance < 1e-6) return desired;
+
+    const direction = offset.clone().divideScalar(desiredDistance);
+    let closestHitDistance = Infinity;
+
+    for (const box of collisionBoxes) {
+      const hit = bulletHitPoint(target, desired, box, THIRD_PERSON_CAMERA_RADIUS);
+      if (!hit) continue;
+      const hitDistance = hit.distanceTo(target);
+      if (hitDistance < closestHitDistance) {
+        closestHitDistance = hitDistance;
+      }
+    }
+
+    if (!Number.isFinite(closestHitDistance)) return desired;
+
+    const resolvedDistance = Math.max(
+      THIRD_PERSON_MIN_DISTANCE,
+      Math.min(desiredDistance, closestHitDistance - THIRD_PERSON_CAMERA_PADDING),
+    );
+
+    return target.clone().addScaledVector(direction, resolvedDistance);
   }
 }

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -679,6 +679,7 @@ export class App {
     this.playerUpdateTimer = 0;
     this.tutorial.beginRun();
     this.cursor.hide();
+    this.thirdPerson = this.sessionMenu.getSettings().defaultCameraMode === "third";
 
     if (!this.mobile) {
       this.input.lockPointer(this.sceneMgr.getRenderer().domElement);
@@ -1151,6 +1152,8 @@ export class App {
     this.onlineBreachReported = false;
     this.helpVisible = false;
     this.tutorial.beginRun();
+    this.killFeed.setLocalPlayerName(selection.name);
+    this.thirdPerson = this.sessionMenu.getSettings().defaultCameraMode === "third";
     if (this.matchEndHandle) {
       clearTimeout(this.matchEndHandle);
       this.matchEndHandle = null;
@@ -1190,6 +1193,7 @@ export class App {
   private async startOnlineLobby(selection: PlaySelection): Promise<void> {
     this.appMode = "online";
     this.onlinePlayerName = selection.name;
+    this.killFeed.setLocalPlayerName(selection.name);
     this.onlineGameActive = false;
     this.onlineRoundActive = false;
     this.onlineBreachReported = false;

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -480,7 +480,10 @@ export class App {
     }
     const isSelfie = FEATURE_FLAGS.thirdPersonLookBehind && this.input.isSelfieHeld();
 
-    this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie);
+    const cameraCollisionBoxes = this.thirdPerson
+      ? this.arena.getThirdPersonCameraCollisionAABBs()
+      : [];
+    this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie, cameraCollisionBoxes);
     this.updateGunVisibility(isSelfie);
     this.updateSoloHud(dt);
     this.renderDebugTuningOverlay();
@@ -537,7 +540,10 @@ export class App {
       this.thirdPerson = !this.thirdPerson;
     }
     const isSelfie = FEATURE_FLAGS.thirdPersonLookBehind && this.input.isSelfieHeld();
-    this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie);
+    const cameraCollisionBoxes = this.thirdPerson
+      ? this.arena.getThirdPersonCameraCollisionAABBs()
+      : [];
+    this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie, cameraCollisionBoxes);
     this.updateGunVisibility(isSelfie);
     this.updateOnlineHud(dt);
   }

--- a/client/src/ui/kill-feed.ts
+++ b/client/src/ui/kill-feed.ts
@@ -1,5 +1,10 @@
 export class KillFeed {
   private container: HTMLDivElement;
+  private localPlayerName = "";
+
+  public setLocalPlayerName(name: string): void {
+    this.localPlayerName = name;
+  }
 
   public constructor() {
     this.container = document.createElement("div");
@@ -27,11 +32,17 @@ export class KillFeed {
     const entry = document.createElement("div");
     const killerColor = killerTeam === 0 ? "#00ffff" : "#ff00ff";
     const victimColor = victimTeam === 0 ? "#00ffff" : "#ff00ff";
+    const killerLabel = this.localPlayerName && killerName === this.localPlayerName
+      ? `<span style="color:${killerColor};text-shadow:0 0 6px ${killerColor};font-weight:bold">YOU</span>`
+      : `<span style="color:${killerColor};text-shadow:0 0 6px ${killerColor}">${killerName}</span>`;
+    const victimLabel = this.localPlayerName && victimName === this.localPlayerName
+      ? `<span style="color:${victimColor};text-shadow:0 0 6px ${victimColor};font-weight:bold">YOU</span>`
+      : `<span style="color:${victimColor};text-shadow:0 0 6px ${victimColor}">${victimName}</span>`;
 
     entry.innerHTML =
-      `<span style="color:${killerColor};text-shadow:0 0 6px ${killerColor}">${killerName}</span>`
+      killerLabel
       + `<span style="color:#888;margin:0 6px">froze</span>`
-      + `<span style="color:${victimColor};text-shadow:0 0 6px ${victimColor}">${victimName}</span>`;
+      + victimLabel;
 
     Object.assign(entry.style, {
       background: "rgba(0,0,0,0.55)",
@@ -50,8 +61,9 @@ export class KillFeed {
   public addScore(scorerName: string, scorerTeam: 0 | 1): void {
     const color = scorerTeam === 0 ? "#00ffff" : "#ff00ff";
     const entry = document.createElement("div");
+    const displayName = this.localPlayerName && scorerName === this.localPlayerName ? "YOU" : scorerName;
     entry.innerHTML =
-      `<span style="color:${color};text-shadow:0 0 8px ${color};font-weight:bold">${scorerName} BREACHED!</span>`;
+      `<span style="color:${color};text-shadow:0 0 8px ${color};font-weight:bold">${displayName} BREACHED!</span>`;
 
     Object.assign(entry.style, {
       background: "rgba(0,0,0,0.65)",

--- a/client/src/ui/sessionMenu.ts
+++ b/client/src/ui/sessionMenu.ts
@@ -3,6 +3,7 @@ export interface SessionSettings {
   musicVolume: number;
   soundtrackEnabled: boolean;
   sfxVolume: number;
+  defaultCameraMode: "first" | "third";
 }
 
 export interface SessionMenuConfig {
@@ -19,6 +20,7 @@ const STORAGE_KEYS = {
   musicVolume: "orbital_music_volume",
   soundtrackEnabled: "orbital_soundtrack_enabled",
   sfxVolume: "orbital_sfx_volume",
+  defaultCameraMode: "orbital_default_camera_mode",
 } as const;
 
 const DEFAULT_SETTINGS: SessionSettings = {
@@ -26,6 +28,7 @@ const DEFAULT_SETTINGS: SessionSettings = {
   soundtrackEnabled: true,
   musicVolume: 60,
   sfxVolume: 50,
+  defaultCameraMode: "first",
 };
 
 const CSS = `
@@ -276,6 +279,26 @@ const CSS = `
     accent-color: #7ffcff;
   }
 
+  .ob-session-select {
+    width: 100%;
+    margin-top: 10px;
+    padding: 8px 10px;
+    border-radius: 0;
+    border: 1px solid rgba(210, 220, 240, 0.16);
+    background: rgba(255, 255, 255, 0.04);
+    color: #effcff;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    accent-color: #7ffcff;
+    cursor: pointer;
+  }
+
+  .ob-session-select:focus {
+    outline: 1px solid rgba(127, 252, 255, 0.4);
+  }
+
   @media (max-width: 640px) {
     .ob-session-actions {
       grid-template-columns: 1fr;
@@ -361,6 +384,7 @@ export class SessionMenu {
   private readonly musicValue: HTMLSpanElement;
   private readonly sfxInput: HTMLInputElement;
   private readonly sfxValue: HTMLSpanElement;
+  private readonly cameraSelect: HTMLSelectElement;
   private settings = loadSettings();
 
   public onLauncherRequest: (() => void) | null = null;
@@ -433,6 +457,16 @@ export class SessionMenu {
               </div>
               <input id="session-menu-sfx" class="ob-session-range" type="range" min="0" max="100" step="1" />
             </div>
+
+            <div class="ob-session-field">
+              <div class="ob-session-field-head">
+                <span class="ob-session-field-label">Default Camera</span>
+              </div>
+              <select id="session-menu-camera" class="ob-session-select">
+                <option value="first">First Person</option>
+                <option value="third">Third Person</option>
+              </select>
+            </div>
           </section>
         </div>
       </div>
@@ -451,6 +485,7 @@ export class SessionMenu {
     this.musicValue = this.query("#session-menu-music-value");
     this.sfxInput = this.query("#session-menu-sfx");
     this.sfxValue = this.query("#session-menu-sfx-value");
+    this.cameraSelect = this.query("#session-menu-camera");
 
     this.resumeButton.addEventListener("click", () => this.onResume?.());
     this.mainMenuButton.addEventListener("click", () => this.onMainMenu?.());
@@ -475,6 +510,12 @@ export class SessionMenu {
     });
     this.sfxInput.addEventListener("input", () => {
       this.settings.sfxVolume = Number(this.sfxInput.value);
+      this.persistSettings();
+      this.renderSettings();
+      this.onSettingsChange?.(this.getSettings());
+    });
+    this.cameraSelect.addEventListener("change", () => {
+      this.settings.defaultCameraMode = this.cameraSelect.value === "third" ? "third" : "first";
       this.persistSettings();
       this.renderSettings();
       this.onSettingsChange?.(this.getSettings());
@@ -530,6 +571,7 @@ export class SessionMenu {
     localStorage.setItem(STORAGE_KEYS.mouseSensitivity, String(this.settings.mouseSensitivity));
     localStorage.setItem(STORAGE_KEYS.musicVolume, String(this.settings.musicVolume));
     localStorage.setItem(STORAGE_KEYS.sfxVolume, String(this.settings.sfxVolume));
+    localStorage.setItem(STORAGE_KEYS.defaultCameraMode, this.settings.defaultCameraMode);
   }
 
   private renderSettings(): void {
@@ -541,6 +583,7 @@ export class SessionMenu {
     this.musicValue.textContent = `${Math.round(this.settings.musicVolume)}%`;
     this.sfxInput.value = String(this.settings.sfxVolume);
     this.sfxValue.textContent = `${Math.round(this.settings.sfxVolume)}%`;
+    this.cameraSelect.value = this.settings.defaultCameraMode;
   }
 
   private query<T extends HTMLElement>(selector: string): T {
@@ -555,12 +598,14 @@ function loadSettings(): SessionSettings {
   localStorage.removeItem(STORAGE_KEYS.soundtrackEnabled);
   const musicVolume = Number(localStorage.getItem(STORAGE_KEYS.musicVolume) ?? DEFAULT_SETTINGS.musicVolume);
   const sfxVolume = Number(localStorage.getItem(STORAGE_KEYS.sfxVolume) ?? DEFAULT_SETTINGS.sfxVolume);
+  const savedCameraMode = localStorage.getItem(STORAGE_KEYS.defaultCameraMode);
 
   return {
     mouseSensitivity: Number.isFinite(sensitivity) ? clamp(sensitivity, 0.0005, 0.004) : DEFAULT_SETTINGS.mouseSensitivity,
     soundtrackEnabled: true,
     musicVolume: Number.isFinite(musicVolume) ? clamp(musicVolume, 0, 100) : DEFAULT_SETTINGS.musicVolume,
     sfxVolume: Number.isFinite(sfxVolume) ? clamp(sfxVolume, 0, 100) : DEFAULT_SETTINGS.sfxVolume,
+    defaultCameraMode: savedCameraMode === "third" ? "third" : "first",
   };
 }
 


### PR DESCRIPTION
## Summary
- Add bold `YOU` display in kill feed for local player freeze/breach actions.
- Add default camera perspective setting with First person / Third person options.

Closes #40
Closes #44

## Testing
- Verify local player freeze/breach events show `YOU` while other players still show names.
- Verify default camera setting persists and applies on gameplay start.
- Verify V toggle, B rear view, and mobile camera controls still work.
- Run client/server builds and test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Third-person camera now collides with obstacles and arena walls instead of clipping through the environment
  * New camera mode setting allows you to save your preferred view (first-person or third-person) and automatically apply it on next session
  * Kill feed displays "YOU" in place of your name to help you quickly spot your actions and achievements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->