### PR TITLE
Fix combat freeze behavior and render artifacts

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -497,10 +497,6 @@ export class App {
     const { dx, dy } = this.input.consumeMouseDelta();
     this.cam.applyMouseDelta(dx, dy, this.input.mouseSensitivity);
 
-    if (this.player.isAttachedToBar()) {
-      this.input.consumeGrab();
-    }
-
     this.input.updateFireCooldown(dt);
     this.player.update(this.input, this.cam, this.arena, dt);
     this.arena.update(dt);

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -67,6 +67,7 @@ export class App {
   private previousOnlinePhase: MultiplayerRoomSnapshot["phase"] | null = null;
   private onlinePlayerName = "Pilot";
   private onlineBreachReported = false;
+  private combatPresentationActive = false;
   private portalArrivalPending = false;
   private portalUrlCleaned = false;
 
@@ -411,6 +412,7 @@ export class App {
   private loop(timestamp: number): void {
     const dt = Math.min((timestamp - this.lastTime) / 1000, 0.033);
     this.lastTime = timestamp;
+    const gameplayActive = this.isGameplaySceneActive();
 
     if (this.input.consumeMenuToggle()) {
       if (this.sessionMenu.isOpen()) {
@@ -424,12 +426,13 @@ export class App {
       this.helpVisible = !this.helpVisible;
     }
 
-    if (this.appMode === "solo") {
+    if (gameplayActive && this.appMode === "solo") {
       this.tickSoloGame(dt);
-    } else if (this.appMode === "online" && this.onlineGameActive) {
+    } else if (gameplayActive && this.appMode === "online" && this.onlineGameActive) {
       this.tickOnlineGame(dt);
     }
 
+    this.syncCombatPresentation(gameplayActive);
     this.sceneMgr.render();
     requestAnimationFrame((nextTimestamp) => this.loop(nextTimestamp));
   }
@@ -1519,5 +1522,30 @@ export class App {
     const selfActor = snapshot.actors.find((actor) => actor.id === snapshot.sessionId);
     if (!selfActor) return;
     this.player.applyAuthoritativeOnlineState(selfActor);
+  }
+
+  private isGameplaySceneActive(): boolean {
+    return !this.debrief.isVisible()
+      && (
+        this.appMode === "solo"
+        || (this.appMode === "online" && this.onlineGameActive)
+      );
+  }
+
+  private syncCombatPresentation(gameplayActive: boolean): void {
+    if (!gameplayActive) {
+      if (this.combatPresentationActive) {
+        this.projectiles.clear();
+        clearVibeJamPortals();
+        this.arena.setPortalDoorsOpen(false);
+      }
+      this.gun.setVisible(false);
+      this.gun.setFrozenTint(null);
+      this.player.setWorldModelVisible(false);
+      this.player.setThirdPersonGunVisible(false);
+      this.player.setThirdPersonGunFrozenTint(null);
+    }
+
+    this.combatPresentationActive = gameplayActive;
   }
 }

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -497,6 +497,10 @@ export class App {
     const { dx, dy } = this.input.consumeMouseDelta();
     this.cam.applyMouseDelta(dx, dy, this.input.mouseSensitivity);
 
+    if (this.player.isAttachedToBar()) {
+      this.input.consumeGrab();
+    }
+
     this.input.updateFireCooldown(dt);
     this.player.update(this.input, this.cam, this.arena, dt);
     this.arena.update(dt);

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -191,6 +191,7 @@ export class App {
       if (this.onlineMatchConcluding) {
         this.onlineRoundActive = false;
         if (this.onlineGameActive) {
+          this.syncLocalOnlineActor(snapshot);
           this.arena.setPortalDoorsOpen(snapshot.phase === "PLAYING");
           this.onlineMatch.applySnapshot(snapshot.actors, snapshot.sessionId);
         }
@@ -220,6 +221,7 @@ export class App {
 
       if (this.onlineGameActive) {
         this.onlineRoundActive = snapshot.phase === "PLAYING";
+        this.syncLocalOnlineActor(snapshot);
         this.arena.setPortalDoorsOpen(snapshot.phase === "PLAYING");
         this.onlineMatch.applySnapshot(snapshot.actors, snapshot.sessionId);
       }
@@ -232,14 +234,7 @@ export class App {
 
     this.net.onFreezeEvent = (event) => {
       if (this.isUserExitingOnline || this.appMode !== "online") return;
-      const sessionId = this.net.getSessionId();
       this.killFeed.addKill(event.killerName, event.killerTeam, event.victimName, event.victimTeam);
-
-      if (this.onlineGameActive && sessionId && event.targetId === sessionId) {
-        this.player.damage.frozen = true;
-        this.player.phase = "FROZEN";
-        this.player.deaths += 1;
-      }
     };
 
     this.net.onRoundResultEvent = (event) => {
@@ -586,8 +581,11 @@ export class App {
     }
 
     if (hit.ownerId === localActorId) {
+      const zone = this.onlineMatch.classifyHitZone(hit.targetId, hit.impactPoint);
+      if (!zone) return;
       this.net.sendHitReport({
         targetId: hit.targetId,
+        zone,
         impX: 0,
         impY: 0,
         impZ: 0,
@@ -611,15 +609,6 @@ export class App {
       return;
     }
 
-    if (hit.ownerId === "local-player") {
-      this.net.sendHitReport({
-        targetId: hit.targetId,
-        impX: 0,
-        impY: 0,
-        impZ: 0,
-      });
-      this.hud.triggerHitConfirm(this.player.team);
-    }
   }
 
   private checkOnlineBreachScore(): void {
@@ -710,6 +699,9 @@ export class App {
         ? { x: selfActor.posX, y: selfActor.posY, z: selfActor.posZ }
         : undefined,
     );
+    if (selfActor) {
+      this.player.applyAuthoritativeOnlineState(selfActor);
+    }
 
     const openAxis = this.arena.getBreachOpenAxis(this.player.team);
     const openSign = this.arena.getBreachOpenSign(this.player.team);
@@ -1521,5 +1513,11 @@ export class App {
     const tint = incapacitated ? enemyColor : null;
     this.gun.setFrozenTint(tint);
     this.player.setThirdPersonGunFrozenTint(tint);
+  }
+
+  private syncLocalOnlineActor(snapshot: MultiplayerRoomSnapshot): void {
+    const selfActor = snapshot.actors.find((actor) => actor.id === snapshot.sessionId);
+    if (!selfActor) return;
+    this.player.applyAuthoritativeOnlineState(selfActor);
   }
 }

--- a/client/src/match/onlineMatch.ts
+++ b/client/src/match/onlineMatch.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import { HITBOX_OFFSET_Y, HITBOX_RADIUS } from "../../../shared/constants";
 import type { OnlineActorSnapshot } from "../../../shared/multiplayer";
+import { classifyHitZone, type HitZone } from "../../../shared/player-logic";
 import type { PlayerPhase } from "../../../shared/schema";
 import {
   predictPosition,
@@ -126,6 +127,31 @@ export class OnlineMatch {
 
   public triggerRemoteShot(actorId: string): void {
     this.tracks.get(actorId)?.avatar.triggerArmRecoil();
+  }
+
+  public classifyHitZone(actorId: string, impactPoint: THREE.Vector3): HitZone | null {
+    const track = this.tracks.get(actorId);
+    if (!track) return null;
+
+    return classifyHitZone(
+      {
+        x: impactPoint.x,
+        y: impactPoint.y,
+        z: impactPoint.z,
+      },
+      {
+        x: track.renderPos.x,
+        y: track.renderPos.y,
+        z: track.renderPos.z,
+      },
+      {
+        x: -Math.sin(track.renderYaw),
+        y: 0,
+        z: -Math.cos(track.renderYaw),
+      },
+      HITBOX_OFFSET_Y,
+      HITBOX_RADIUS,
+    );
   }
 
   public getProjectileTargets(): OnlineProjectileTarget[] {

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -312,11 +312,9 @@ export class LocalPlayer {
 
     this.phys.vel.set(0, 0, 0);
 
-    if (input.consumeGrab()) {
-      this.phase = 'FLOATING';
-      this.grabbedBarPos = null;
-      return;
-    }
+    // Consume grab presses while attached so desktop E and mobile GRAB cannot
+    // act as a detach shortcut in any game mode.
+    input.consumeGrab();
 
     if (input.isAiming()) {
       this.phase = 'AIMING';

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -55,6 +55,7 @@ import {
   type FloatArmTuningState,
   type FloatLimbTuningTarget,
 } from './playerAimPose';
+import { shouldPreserveLocalOnlineGrab } from './onlineGrabSync';
 import { ThirdPersonGun, type ThirdPersonGunTuningState } from './playerThirdPersonGun';
 
 const GRAB_ROTATION_SMOOTHING = 0.0008;
@@ -633,11 +634,19 @@ export class LocalPlayer {
     this.deaths = actor.deaths;
     this.launchPower = clamp(this.launchPower, 0, this.maxLaunchPower());
 
-    const nextPhase = this.damage.frozen
+    const authoritativePhase = this.damage.frozen
       ? 'FROZEN'
       : this.normalizeOnlinePhase(actor.phase);
+    const preserveLocalGrab = shouldPreserveLocalOnlineGrab({
+      authoritativePhase,
+      frozen: this.damage.frozen,
+      leftArmDisabled: this.damage.leftArm,
+      localHasGrab: this.grabbedBarPos !== null,
+      localPhase: this.phase,
+    });
+    const nextPhase = preserveLocalGrab ? this.phase : authoritativePhase;
 
-    if (nextPhase !== 'GRABBING' && nextPhase !== 'AIMING') {
+    if (!preserveLocalGrab && nextPhase !== 'GRABBING' && nextPhase !== 'AIMING') {
       this.grabbedBarPos = null;
       this.grabHandGripLocal = null;
       this.grabPoseLocked = false;
@@ -767,6 +776,11 @@ export class LocalPlayer {
 
   public getFrozenTimer(): number {
     return 0;
+  }
+
+  public isAttachedToBar(): boolean {
+    return this.grabbedBarPos !== null
+      && (this.phase === 'GRABBING' || this.phase === 'AIMING');
   }
 
   private normalizeOnlinePhase(phase: string): PlayerPhase {

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -8,6 +8,7 @@ import {
   PLAYER_RADIUS,
 } from '../../../shared/constants';
 import { clamp } from '../util/math';
+import type { OnlineActorSnapshot } from '../../../shared/multiplayer';
 import { type DamageState, type PlayerPhase } from '../../../shared/schema';
 import { CameraController } from '../camera';
 import { InputManager } from '../input';
@@ -619,6 +620,32 @@ export class LocalPlayer {
     this.phase = 'BREACH';
   }
 
+  public applyAuthoritativeOnlineState(actor: Pick<
+    OnlineActorSnapshot,
+    'deaths' | 'frozen' | 'kills' | 'leftArm' | 'leftLeg' | 'phase' | 'rightArm' | 'rightLeg'
+  >): void {
+    this.damage.frozen = actor.frozen;
+    this.damage.leftArm = actor.leftArm;
+    this.damage.rightArm = actor.rightArm;
+    this.damage.leftLeg = actor.leftLeg;
+    this.damage.rightLeg = actor.rightLeg;
+    this.kills = actor.kills;
+    this.deaths = actor.deaths;
+    this.launchPower = clamp(this.launchPower, 0, this.maxLaunchPower());
+
+    const nextPhase = this.damage.frozen
+      ? 'FROZEN'
+      : this.normalizeOnlinePhase(actor.phase);
+
+    if (nextPhase !== 'GRABBING' && nextPhase !== 'AIMING') {
+      this.grabbedBarPos = null;
+      this.grabHandGripLocal = null;
+      this.grabPoseLocked = false;
+    }
+
+    this.phase = nextPhase;
+  }
+
   public getPosition(): THREE.Vector3 {
     return this.phys.pos;
   }
@@ -740,6 +767,22 @@ export class LocalPlayer {
 
   public getFrozenTimer(): number {
     return 0;
+  }
+
+  private normalizeOnlinePhase(phase: string): PlayerPhase {
+    switch (phase) {
+      case 'AIMING':
+      case 'BREACH':
+      case 'FLOATING':
+      case 'FROZEN':
+      case 'GRABBING':
+      case 'RESPAWNING':
+        return this.damage.leftArm && (phase === 'GRABBING' || phase === 'AIMING')
+          ? 'FLOATING'
+          : phase;
+      default:
+        return 'FLOATING';
+    }
   }
 
   private applyTeamVisuals(): void {

--- a/client/src/player/onlineGrabSync.ts
+++ b/client/src/player/onlineGrabSync.ts
@@ -1,0 +1,19 @@
+import type { PlayerPhase } from "../../../shared/schema";
+
+export interface OnlineGrabSyncInput {
+  authoritativePhase: PlayerPhase;
+  frozen: boolean;
+  leftArmDisabled: boolean;
+  localHasGrab: boolean;
+  localPhase: PlayerPhase;
+}
+
+export function shouldPreserveLocalOnlineGrab(input: OnlineGrabSyncInput): boolean {
+  if (input.frozen || input.leftArmDisabled) return false;
+
+  const localAnchored = input.localHasGrab
+    && (input.localPhase === "GRABBING" || input.localPhase === "AIMING");
+  if (!localAnchored) return false;
+
+  return input.authoritativePhase !== "GRABBING" && input.authoritativePhase !== "AIMING";
+}

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -215,7 +215,7 @@ export class HUD {
       show = true;
       promptText = IS_MOBILE
         ? 'Hold LAUNCH and drag down to charge'
-        : 'Hold [SPACE] to aim - [E] to release bar';
+        : 'Hold [SPACE] to aim';
       el.style.fontSize = IS_MOBILE ? '13px' : '15px';
       el.style.color = '#aaffff';
       el.style.textShadow = '0 0 8px #00ffff';

--- a/client/src/ui/mobileControls.ts
+++ b/client/src/ui/mobileControls.ts
@@ -170,6 +170,7 @@ export class MobileControls {
 
   private styleEl: HTMLStyleElement | null = null;
   private input: InputManager;
+  private phase = '';
 
   constructor(input: InputManager) {
     this.input = input;
@@ -244,8 +245,9 @@ export class MobileControls {
 
   /** Called every frame from gameApp to sync controls to player state. */
   public setPhase(phase: string): void {
+    this.phase = phase;
     const inGravity = phase === 'BREACH';
-    const onBar = phase === 'GRABBING' || phase === 'AIMING';
+    const onBar = isAttachedToBar(phase);
 
     // Joystick: only in gravity (BREACH) walk mode
     this.joystickZone.style.display = inGravity ? '' : 'none';
@@ -259,12 +261,19 @@ export class MobileControls {
     const showJump = inGravity || onBar;
     this.jumpBtn.style.display = showJump ? 'flex' : 'none';
     this.jumpBtn.textContent = onBar ? 'LAUNCH' : 'JUMP';
+    if (onBar) {
+      this.grabBtn.style.display = 'none';
+      this.grabBtn.classList.remove('mob-pressed');
+    }
   }
 
   /** Called every frame — show GRAB button only when the player can grab a nearby bar. */
   public setNearBar(near: boolean, canGrab: boolean): void {
-    const showGrab = near && canGrab;
+    const showGrab = near && canGrab && !isAttachedToBar(this.phase);
     this.grabBtn.style.display = showGrab ? 'flex' : 'none';
+    if (!showGrab) {
+      this.grabBtn.classList.remove('mob-pressed');
+    }
   }
 
   /** Called every frame — updates view toggle label to show the opposite of current mode. */
@@ -482,4 +491,8 @@ export class MobileControls {
     this.grabBtn.addEventListener('pointerup', end);
     this.grabBtn.addEventListener('pointercancel', end);
   }
+}
+
+function isAttachedToBar(phase: string): boolean {
+  return phase === 'GRABBING' || phase === 'AIMING';
 }

--- a/server/src/colyseus/OrbitalLobbyRoom.ts
+++ b/server/src/colyseus/OrbitalLobbyRoom.ts
@@ -35,6 +35,7 @@ import {
   PLAYER_RADIUS,
 } from "../../../shared/constants";
 import type { PlayerPhase } from "../../../shared/schema";
+import { applyHitToOnlineActor, isHitZone, normalizeAuthoritativePhase } from "./actorDamage";
 import { ActorState, LobbyMemberState, OrbitalLobbyState } from "./state";
 
 type RoomClient = Client;
@@ -258,14 +259,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     actor.velZ = clampFinite(Number(message.velZ), -VEL_CLAMP, VEL_CLAMP);
     actor.yaw = clampFinite(Number(message.yaw), -Math.PI * 2, Math.PI * 2);
     const rawPhase = String(message.phase ?? "");
-    actor.phase = (VALID_PHASES.has(rawPhase) ? rawPhase : "FLOATING") as PlayerPhase;
-    actor.frozen = Boolean(message.frozen);
-    actor.leftArm = Boolean(message.leftArm);
-    actor.rightArm = Boolean(message.rightArm);
-    actor.leftLeg = Boolean(message.leftLeg);
-    actor.rightLeg = Boolean(message.rightLeg);
-    actor.kills = Math.min(MAX_KILLS, Math.max(0, Math.trunc(Number(message.kills)) || 0));
-    actor.deaths = Math.min(MAX_KILLS, Math.max(0, Math.trunc(Number(message.deaths)) || 0));
+    actor.phase = normalizeAuthoritativePhase(rawPhase, actor);
   }
 
   private handleShotEventMessage(client: RoomClient, message: ShotEventMessage): void {
@@ -303,12 +297,21 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     const targetId = String(message.targetId ?? "").slice(0, 64);
     const target = this.state.actors.get(targetId);
     if (!target || target.frozen || target.team === shooter.team) return;
+    if (!isHitZone(message.zone)) return;
 
-    target.frozen = true;
-    target.phase = "FROZEN";
-    target.deaths += 1;
+    if (target.isBot) {
+      target.frozen = true;
+      target.phase = "FROZEN";
+      target.deaths += 1;
+    } else {
+      const frozen = applyHitToOnlineActor(target, message.zone);
+      if (!frozen) {
+        return;
+      }
+    }
+
     target.frozenTimer = BOT_RESPAWN_SECONDS;
-    shooter.kills += 1;
+    shooter.kills = Math.min(MAX_KILLS, shooter.kills + 1);
 
     const freezeEvent: FreezeEventMessage = {
       targetId: target.id,
@@ -543,6 +546,10 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
       actor.isBot = member.isBot;
       actor.phase = "BREACH";
       actor.frozen = false;
+      actor.leftArm = false;
+      actor.rightArm = false;
+      actor.leftLeg = false;
+      actor.rightLeg = false;
       actor.kills = 0;
       actor.deaths = 0;
 
@@ -574,6 +581,10 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
         if (actor.frozenTimer <= 0) {
           actor.frozen = false;
           actor.phase = "BREACH";
+          actor.leftArm = false;
+          actor.rightArm = false;
+          actor.leftLeg = false;
+          actor.rightLeg = false;
         }
         continue;
       }

--- a/server/src/colyseus/actorDamage.ts
+++ b/server/src/colyseus/actorDamage.ts
@@ -1,0 +1,89 @@
+import { applyHit, type HitZone } from "../../../shared/player-logic";
+import type { PlayerPhase } from "../../../shared/schema";
+
+export interface OnlineActorDamageState {
+  deaths: number;
+  frozen: boolean;
+  leftArm: boolean;
+  leftLeg: boolean;
+  phase: string;
+  rightArm: boolean;
+  rightLeg: boolean;
+  velX: number;
+  velY: number;
+  velZ: number;
+}
+
+const VALID_PHASES = new Set<PlayerPhase>([
+  "AIMING",
+  "BREACH",
+  "FLOATING",
+  "FROZEN",
+  "GRABBING",
+  "RESPAWNING",
+]);
+
+export function applyHitToOnlineActor(actor: OnlineActorDamageState, zone: HitZone): boolean {
+  const scratch = {
+    damage: {
+      frozen: actor.frozen,
+      leftArm: actor.leftArm,
+      leftLeg: actor.leftLeg,
+      rightArm: actor.rightArm,
+      rightLeg: actor.rightLeg,
+    },
+    deaths: actor.deaths,
+    grabbedBarPos: actor.phase === "GRABBING" || actor.phase === "AIMING"
+      ? { x: 0, y: 0, z: 0 }
+      : null,
+    launchPower: 0,
+    phase: normalizePhase(actor.phase),
+    vel: {
+      x: actor.velX,
+      y: actor.velY,
+      z: actor.velZ,
+    },
+  };
+
+  const frozen = applyHit(scratch, zone, { x: 0, y: 0, z: 0 });
+
+  actor.deaths = scratch.deaths;
+  actor.frozen = scratch.damage.frozen;
+  actor.leftArm = scratch.damage.leftArm;
+  actor.leftLeg = scratch.damage.leftLeg;
+  actor.phase = scratch.phase;
+  actor.rightArm = scratch.damage.rightArm;
+  actor.rightLeg = scratch.damage.rightLeg;
+  actor.velX = scratch.vel.x;
+  actor.velY = scratch.vel.y;
+  actor.velZ = scratch.vel.z;
+
+  return frozen;
+}
+
+export function normalizeAuthoritativePhase(
+  requestedPhase: string,
+  actor: Pick<OnlineActorDamageState, "frozen" | "leftArm">,
+): PlayerPhase {
+  if (actor.frozen) return "FROZEN";
+  const phase = normalizePhase(requestedPhase);
+  if (actor.leftArm && (phase === "GRABBING" || phase === "AIMING")) {
+    return "FLOATING";
+  }
+  return phase;
+}
+
+export function isHitZone(value: unknown): value is HitZone {
+  return value === "head"
+    || value === "body"
+    || value === "leftArm"
+    || value === "rightArm"
+    || value === "leftLeg"
+    || value === "rightLeg";
+}
+
+function normalizePhase(phase: string): PlayerPhase {
+  return VALID_PHASES.has(phase as PlayerPhase)
+    ? phase as PlayerPhase
+    : "FLOATING";
+}

--- a/shared/multiplayer.ts
+++ b/shared/multiplayer.ts
@@ -1,4 +1,5 @@
 import { MATCH_TEAM_SIZES, type MatchTeamSize } from "./match";
+import type { HitZone } from "./player-logic";
 
 export const MULTIPLAYER_ROOM_NAME = "orbital_lobby";
 export const MULTIPLAYER_COUNTDOWN_SECONDS = 5;
@@ -82,6 +83,7 @@ export interface PlayerUpdateMessage {
 
 export interface HitReportMessage {
   targetId: string;
+  zone: HitZone;
   impX: number;
   impY: number;
   impZ: number;

--- a/tests/onlineActorDamage.test.ts
+++ b/tests/onlineActorDamage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { applyHitToOnlineActor, normalizeAuthoritativePhase } from "../server/src/colyseus/actorDamage";
+
+describe("applyHitToOnlineActor", () => {
+  it("keeps a single leg hit as limb damage instead of full freeze", () => {
+    const actor = {
+      deaths: 0,
+      frozen: false,
+      leftArm: false,
+      leftLeg: false,
+      phase: "FLOATING",
+      rightArm: false,
+      rightLeg: false,
+      velX: 0,
+      velY: 0,
+      velZ: 0,
+    };
+
+    const frozen = applyHitToOnlineActor(actor, "leftLeg");
+
+    expect(frozen).toBe(false);
+    expect(actor.frozen).toBe(false);
+    expect(actor.leftLeg).toBe(true);
+    expect(actor.phase).toBe("FLOATING");
+    expect(actor.deaths).toBe(0);
+  });
+
+  it("matches solo behavior when both legs are damaged", () => {
+    const actor = {
+      deaths: 0,
+      frozen: false,
+      leftArm: false,
+      leftLeg: true,
+      phase: "FLOATING",
+      rightArm: false,
+      rightLeg: false,
+      velX: 0,
+      velY: 0,
+      velZ: 0,
+    };
+
+    const frozen = applyHitToOnlineActor(actor, "rightLeg");
+
+    expect(frozen).toBe(false);
+    expect(actor.frozen).toBe(false);
+    expect(actor.leftLeg).toBe(true);
+    expect(actor.rightLeg).toBe(true);
+    expect(actor.phase).toBe("FLOATING");
+    expect(actor.deaths).toBe(0);
+  });
+});
+
+describe("normalizeAuthoritativePhase", () => {
+  it("keeps frozen players in FROZEN even if client updates say otherwise", () => {
+    expect(normalizeAuthoritativePhase("FLOATING", { frozen: true, leftArm: false })).toBe("FROZEN");
+  });
+
+  it("kicks left-arm-damaged players out of anchored phases", () => {
+    expect(normalizeAuthoritativePhase("AIMING", { frozen: false, leftArm: true })).toBe("FLOATING");
+    expect(normalizeAuthoritativePhase("GRABBING", { frozen: false, leftArm: true })).toBe("FLOATING");
+  });
+});

--- a/tests/onlineGrabSync.test.ts
+++ b/tests/onlineGrabSync.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { shouldPreserveLocalOnlineGrab } from "../client/src/player/onlineGrabSync";
+
+describe("shouldPreserveLocalOnlineGrab", () => {
+  it("preserves a fresh local bar attach while the online snapshot still lags behind", () => {
+    expect(shouldPreserveLocalOnlineGrab({
+      authoritativePhase: "FLOATING",
+      frozen: false,
+      leftArmDisabled: false,
+      localHasGrab: true,
+      localPhase: "GRABBING",
+    })).toBe(true);
+  });
+
+  it("does not preserve once the authoritative snapshot is also anchored", () => {
+    expect(shouldPreserveLocalOnlineGrab({
+      authoritativePhase: "AIMING",
+      frozen: false,
+      leftArmDisabled: false,
+      localHasGrab: true,
+      localPhase: "GRABBING",
+    })).toBe(false);
+  });
+
+  it("does not preserve grab state for frozen or left-arm-disabled players", () => {
+    expect(shouldPreserveLocalOnlineGrab({
+      authoritativePhase: "FLOATING",
+      frozen: true,
+      leftArmDisabled: false,
+      localHasGrab: true,
+      localPhase: "GRABBING",
+    })).toBe(false);
+
+    expect(shouldPreserveLocalOnlineGrab({
+      authoritativePhase: "FLOATING",
+      frozen: false,
+      leftArmDisabled: true,
+      localHasGrab: true,
+      localPhase: "AIMING",
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix online limb-based freeze to match solo behavior.
- Fix ghost pistol / cyan render artifacts where possible.
- Fix online bar grab reliability and prevent repeated `E` from detaching while already hanging.

Closes #43
Closes #41
Closes #51

## Testing
- Verify online limb hits no longer always full-body freeze.
- Verify solo freeze behavior remains unchanged.
- Verify online bar grabbing works with one `E` press near a valid bar.
- Verify spamming `E` while hanging does not detach the player.
- Verify launching from a bar still detaches normally.
- Verify first-person / transition artifacts are improved or at least not regressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hit zone classification system enhances projectile accuracy
  * Improved player state synchronization in online matches

* **Bug Fixes**
  * Fixed grab and bar attachment state consistency
  * Better freeze and limb damage state management

* **Tests**
  * Added damage and grab sync validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->