### PR TITLE
[codex] Add winning team victory dance

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -266,6 +266,7 @@ export class App {
       }
 
       if (event.matchWinner !== null && event.finalScore) {
+        this.setCelebratingTeam(event.matchWinner);
         this.onlineMatchConcluding = true;
         this.pendingOnlineDebrief = this.buildOnlineDebrief(event.matchWinner, event.finalScore);
         this.sessionMenu.close();
@@ -682,6 +683,7 @@ export class App {
       return;
     }
 
+    this.clearCelebrationState();
     this.onlineGameActive = true;
     this.onlineRoundActive = snapshot.phase === "PLAYING";
     this.onlineBreachReported = false;
@@ -741,6 +743,7 @@ export class App {
   private endOnlineGame(): void {
     this.sound.stopCountdown();
     this.closeSessionMenu();
+    this.clearCelebrationState();
     this.onlineGameActive = false;
     this.onlineRoundActive = false;
     this.onlineBreachReported = false;
@@ -872,6 +875,7 @@ export class App {
   // ── Solo round lifecycle ────────────────────────────────────────────────────
 
   private beginNewRound(): void {
+    this.clearCelebrationState();
     this.hud.hideRoundEnd();
     this.projectiles.clear();
     clearVibeJamPortals();
@@ -944,6 +948,7 @@ export class App {
     finalScore: { team0: number; team1: number },
   ): void {
     this.matchOver = true;
+    this.setCelebratingTeam(winningTeam);
     this.round.cancelPendingRestart();
     if (this.matchEndHandle) clearTimeout(this.matchEndHandle);
     this.matchEndHandle = setTimeout(() => {
@@ -1000,6 +1005,7 @@ export class App {
   private returnToMenuFromSolo(): void {
     this.sound.stopCountdown();
     this.closeSessionMenu();
+    this.clearCelebrationState();
     this.debrief.hide();
     this.appMode = "menu";
     this.cursor.show();
@@ -1161,6 +1167,7 @@ export class App {
   private startSoloMatch(selection: PlaySelection): void {
     this.lastSoloSelection = selection;
     this.debrief.hide();
+    this.clearCelebrationState();
     this.appMode = "solo";
     this.cursor.hide();
     this.matchOver = false;
@@ -1263,6 +1270,7 @@ export class App {
   private async returnToMenuFromOnline(): Promise<void> {
     this.closeSessionMenu();
     this.debrief.hide();
+    this.clearCelebrationState();
     this.appMode = "menu";
     this.onlineGameActive = false;
     this.onlineRoundActive = false;
@@ -1373,6 +1381,7 @@ export class App {
   }
 
   private returnToOnlineLobbyFromDebrief(): void {
+    this.clearCelebrationState();
     this.onlineMatchConcluding = false;
     this.onlineGameActive = false;
     this.onlineRoundActive = false;
@@ -1408,6 +1417,18 @@ export class App {
     this.sound.playLocalShot();
     this.player.triggerArmRecoil();
     this.tutorial.noteShotFired();
+  }
+
+  private setCelebratingTeam(team: 0 | 1): void {
+    this.player.setVictoryDanceActive(this.player.team === team && !this.player.damage.frozen);
+    this.match.setCelebratingTeam(team);
+    this.onlineMatch.setCelebratingTeam(team);
+  }
+
+  private clearCelebrationState(): void {
+    this.player.setVictoryDanceActive(false);
+    this.match.setCelebratingTeam(null);
+    this.onlineMatch.setCelebratingTeam(null);
   }
 
   // ── Gun tuning overlays ─────────────────────────────────────────────────────

--- a/client/src/match/localMatch.ts
+++ b/client/src/match/localMatch.ts
@@ -124,6 +124,7 @@ interface ActorDescriptor {
 export class LocalMatch {
   private barGraph: BarRouteGraph = buildBarGraph([]);
   private bots: BotState[] = [];
+  private celebratingTeam: 0 | 1 | null = null;
   private config: SoloMatchConfig = { humanName: "You", humanTeam: 0, teamSize: 1 };
   private roundResolved = false;
   private roundSeed = 0;
@@ -135,6 +136,7 @@ export class LocalMatch {
 
   public startNewGame(config: SoloMatchConfig): void {
     this.config = config;
+    this.celebratingTeam = null;
     this.score = { team0: 0, team1: 0 };
     this.roundResolved = false;
     this.roundSeed = 0;
@@ -146,6 +148,7 @@ export class LocalMatch {
     player: LocalPlayer,
     humanSpawnOverride?: { x: number; y: number; z: number },
   ): void {
+    this.celebratingTeam = null;
     this.roundResolved = false;
     this.roundSeed += 1;
 
@@ -182,6 +185,10 @@ export class LocalMatch {
       bot.avatar.dispose(this.scene);
     }
     this.bots = [];
+  }
+
+  public setCelebratingTeam(team: 0 | 1 | null): void {
+    this.celebratingTeam = team;
   }
 
   public getScore(): { team0: number; team1: number } {
@@ -355,7 +362,15 @@ export class LocalMatch {
     this.resolveActorOverlap(player);
 
     for (const bot of this.bots) {
-      bot.avatar.update(bot.phys.pos, bot.damage, bot.phase, bot.rot.yaw, dt, bot.phys.vel.length());
+      bot.avatar.update(
+        bot.phys.pos,
+        bot.damage,
+        bot.phase,
+        bot.rot.yaw,
+        dt,
+        bot.phys.vel.length(),
+        this.celebratingTeam === bot.team,
+      );
     }
 
     return shots;

--- a/client/src/match/onlineMatch.ts
+++ b/client/src/match/onlineMatch.ts
@@ -29,6 +29,7 @@ interface RemoteActorTrack {
 }
 
 export class OnlineMatch {
+  private celebratingTeam: 0 | 1 | null = null;
   private tracks = new Map<string, RemoteActorTrack>();
 
   public constructor(private scene: THREE.Scene) {}
@@ -121,8 +122,13 @@ export class OnlineMatch {
         track.renderYaw,
         dt,
         track.renderVel.length(),
+        this.celebratingTeam === track.snapshot.team,
       );
     }
+  }
+
+  public setCelebratingTeam(team: 0 | 1 | null): void {
+    this.celebratingTeam = team;
   }
 
   public triggerRemoteShot(actorId: string): void {
@@ -210,6 +216,7 @@ export class OnlineMatch {
       track.avatar.dispose(this.scene);
     }
     this.tracks.clear();
+    this.celebratingTeam = null;
   }
 }
 

--- a/client/src/match/simulatedPlayerAvatar.ts
+++ b/client/src/match/simulatedPlayerAvatar.ts
@@ -13,6 +13,7 @@ import {
 import { PlayerDamageGlow } from "../player/playerDamageGlow";
 import { applyBarHoldPose } from "../player/playerGrabPose";
 import { applyArmRecoil, RECOIL_DURATION } from "../player/playerAimPose";
+import { applyVictoryDancePose } from "../player/playerVictoryDance";
 import { ThirdPersonGun } from "../player/playerThirdPersonGun";
 import { PlayerNameTag } from "../render/playerNameTag";
 
@@ -27,6 +28,7 @@ export class SimulatedPlayerAvatar {
   private recoilTimer = 0;
   private ready = false;
   private readonly root = new THREE.Group();
+  private victoryDanceElapsed = 0;
 
   public constructor(scene: THREE.Scene, team: 0 | 1, name = "") {
     this.damageGlow = new PlayerDamageGlow(team);
@@ -60,6 +62,7 @@ export class SimulatedPlayerAvatar {
     yaw: number,
     dt: number,
     moveSpeed: number,
+    celebrating = false,
   ): void {
     this.root.position.copy(pos);
     this.root.rotation.set(0, yaw, 0);
@@ -71,7 +74,10 @@ export class SimulatedPlayerAvatar {
 
     if (!this.ready) return;
 
-    const animation = selectAnimation(phase, moveSpeed);
+    const shouldCelebrate = celebrating && !damage.frozen;
+    const animation = shouldCelebrate
+      ? ANIM_STANDING
+      : selectAnimation(phase, moveSpeed);
     this.animation.setTargetAnimation(animation);
 
     // Hold the frozen pose: once the crossfade into ANIM_DEATH settles, tick
@@ -87,13 +93,18 @@ export class SimulatedPlayerAvatar {
       : dt;
     this.animation.tickMixers(animationDt);
 
-    if (phase === "GRABBING" || phase === "AIMING") {
+    if (!shouldCelebrate && (phase === "GRABBING" || phase === "AIMING")) {
       applyBarHoldPose(this.animation.getRigs());
       this.animation.resetBreathing();
+    } else if (shouldCelebrate) {
+      this.animation.resetBreathing();
+      this.victoryDanceElapsed += dt;
+      applyVictoryDancePose(this.animation.getRigs(), this.victoryDanceElapsed);
     } else if (animation === ANIM_IDLE_HOLD) {
       this.animation.tickBreathing(dt);
     } else {
       this.animation.resetBreathing();
+      this.victoryDanceElapsed = 0;
     }
 
     this.recoilTimer = Math.max(0, this.recoilTimer - dt);

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -40,6 +40,7 @@ import {
   measureLeftHandGripOffset,
 } from './playerGrabPose';
 import { PlayerDamageGlow } from './playerDamageGlow';
+import { applyVictoryDancePose } from './playerVictoryDance';
 import { loadAlienRenderClone } from './alienRenderAsset';
 import { applyTeamAccent } from './teamAccent';
 import {
@@ -116,6 +117,8 @@ export class LocalPlayer {
   // ticking mixers so the death pose holds instead of looping flails.
   private frozenHoldTimer = 0;
   private floatLimbTuningEnabled = false;
+  private victoryDanceActive = false;
+  private victoryDanceElapsed = 0;
 
   public constructor(scene: THREE.Scene) {
     this.mesh = new THREE.Group();
@@ -170,6 +173,7 @@ export class LocalPlayer {
     arena: Arena,
     dt: number,
   ): void {
+    const celebrating = this.victoryDanceActive && !this.damage.frozen;
     switch (this.phase) {
       case 'FROZEN':
         this.updateFrozen(arena, dt);
@@ -193,7 +197,7 @@ export class LocalPlayer {
     this.updateAnimation(input, cam, dt);
     this.damageGlow.update(this.damage, this.phase, dt);
     const visualQuat = this.computeVisualQuaternion(cam, dt);
-    if (this.phase === 'GRABBING' || this.phase === 'AIMING') {
+    if (!celebrating && (this.phase === 'GRABBING' || this.phase === 'AIMING')) {
       this.lockGripToBar(visualQuat);
     }
     this.mesh.position.copy(this.phys.pos);
@@ -404,7 +408,9 @@ export class LocalPlayer {
   }
 
   private updateAnimation(input: InputManager, cam: CameraController, dt: number): void {
-    if (this.phase === 'GRABBING' || this.phase === 'AIMING') {
+    const celebrating = this.victoryDanceActive && !this.damage.frozen;
+
+    if (!celebrating && (this.phase === 'GRABBING' || this.phase === 'AIMING')) {
       this.animation.resetBreathing();
       if (!this.grabPoseLocked) {
         this.lockGrabPose();
@@ -463,14 +469,20 @@ export class LocalPlayer {
 
     this.lastKnownAnimation = nextAnimation;
 
-    if (this.isBreachIdle(input)) {
+    if (celebrating) {
+      this.animation.resetBreathing();
+      this.victoryDanceElapsed += dt;
+      applyVictoryDancePose(this.animation.getRigs(), this.victoryDanceElapsed);
+    } else if (this.isBreachIdle(input)) {
       this.animation.tickBreathing(dt);
     } else {
       this.animation.resetBreathing();
+      this.victoryDanceElapsed = 0;
     }
   }
 
   private selectAnimation(input: InputManager): string {
+    if (this.victoryDanceActive && !this.damage.frozen) return ANIM_STANDING;
     if (this.phase === 'FROZEN') return ANIM_DEATH;
     if (this.phase === 'FLOATING') return ANIM_FLOAT;
     if (this.phase === 'RESPAWNING') return ANIM_STANDING;
@@ -502,7 +514,10 @@ export class LocalPlayer {
   private computeVisualQuaternion(cam: CameraController, dt: number): THREE.Quaternion {
     const cameraQuat = cam.getQuaternion();
 
-    if (this.phase !== 'GRABBING' && this.phase !== 'AIMING') {
+    if (
+      this.victoryDanceActive
+      || (this.phase !== 'GRABBING' && this.phase !== 'AIMING')
+    ) {
       this.visualQuaternion.copy(cameraQuat);
       return this.visualQuaternion;
     }
@@ -608,6 +623,8 @@ export class LocalPlayer {
     this.breachEntryCarryTimer = 0;
     this.currentBreachTeam = this.team;
     this.phys.vel.set(0, 0, 0);
+    this.victoryDanceActive = false;
+    this.victoryDanceElapsed = 0;
 
     const spawn = spawnOverride ?? (() => {
       const center = arena.getBreachRoomCenter(this.team);
@@ -665,6 +682,13 @@ export class LocalPlayer {
     this.team = team;
     this.damageGlow.setTeam(team);
     this.applyTeamVisuals();
+  }
+
+  public setVictoryDanceActive(active: boolean): void {
+    this.victoryDanceActive = active;
+    if (!active) {
+      this.victoryDanceElapsed = 0;
+    }
   }
 
   public setWorldModelVisible(visible: boolean): void {

--- a/client/src/player/playerVictoryDance.ts
+++ b/client/src/player/playerVictoryDance.ts
@@ -1,0 +1,51 @@
+import * as THREE from 'three';
+import type { AnimatedRig, PoseBoneName } from './playerTypes';
+
+const DANCE_SWAY_SPEED = 7.5;
+const DANCE_BOUNCE_SPEED = 15;
+const DANCE_TWIST_SPEED = 11;
+
+export function applyVictoryDancePose(rigs: AnimatedRig[], elapsed: number): void {
+  const sway = Math.sin(elapsed * DANCE_SWAY_SPEED);
+  const bounce = 0.5 + 0.5 * Math.sin(elapsed * DANCE_BOUNCE_SPEED);
+  const twist = Math.sin(elapsed * DANCE_TWIST_SPEED);
+
+  for (const rig of rigs) {
+    rotateBone(rig.bones.Hips, 0, 0.28 * sway, 0.06 * twist);
+    rotateBone(rig.bones.Torso, 0.12 + 0.1 * bounce, 0, 0.1 * sway);
+    rotateBone(rig.bones.Abdomen, 0.08 * bounce, 0.08 * sway, 0);
+    rotateBone(rig.bones.Neck, -0.08 * sway, 0.12 * sway, 0);
+
+    rotateBone(rig.bones.ShoulderL, 0.55 + 0.18 * sway, 0, -0.3 - 0.08 * bounce);
+    rotateBone(rig.bones.UpperArmL, 0.65 + 0.22 * sway, 0.18, -0.5 - 0.08 * bounce);
+    rotateBone(rig.bones.LowerArmL, 0.24 + 0.1 * bounce, -0.12, -0.22);
+    rotateBone(rig.bones.PalmL, 0.18 * bounce, 0, -0.12 * sway);
+
+    rotateBone(rig.bones.ShoulderR, 0.55 - 0.18 * sway, 0, 0.3 + 0.08 * bounce);
+    rotateBone(rig.bones.UpperArmR, 0.65 - 0.22 * sway, -0.18, 0.5 + 0.08 * bounce);
+    rotateBone(rig.bones.LowerArmR, 0.24 + 0.1 * bounce, 0.12, 0.22);
+    rotateBone(rig.bones.PalmR, 0.18 * bounce, 0, 0.12 * sway);
+
+    rotateBone(rig.bones.UpperLegL, 0.1 + 0.16 * bounce, 0, -0.16 * sway);
+    rotateBone(rig.bones.LowerLegL, -0.22 * bounce, 0, 0.06 * sway);
+    rotateBone(rig.bones.FootL, -0.05 - 0.08 * bounce, 0, 0);
+
+    rotateBone(rig.bones.UpperLegR, 0.1 + 0.16 * (1 - bounce), 0, 0.16 * sway);
+    rotateBone(rig.bones.LowerLegR, -0.22 * (1 - bounce), 0, -0.06 * sway);
+    rotateBone(rig.bones.FootR, -0.05 - 0.08 * (1 - bounce), 0, 0);
+  }
+}
+
+function rotateBone(
+  bone: THREE.Bone | undefined,
+  x: number,
+  y: number,
+  z: number,
+): void {
+  if (!bone) return;
+  bone.quaternion.multiply(quatFromEuler(x, y, z));
+}
+
+function quatFromEuler(x: number, y: number, z: number): THREE.Quaternion {
+  return new THREE.Quaternion().setFromEuler(new THREE.Euler(x, y, z, 'XYZ'));
+}

--- a/tests/localMatch.test.ts
+++ b/tests/localMatch.test.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as THREE from "three";
 
+const avatarUpdate = vi.fn();
+
 vi.mock("../client/src/match/simulatedPlayerAvatar", () => ({
   SimulatedPlayerAvatar: class {
-    public constructor() {}
+    private readonly team: 0 | 1;
+    public constructor(_scene: THREE.Scene, team: 0 | 1) {
+      this.team = team;
+    }
     public dispose(): void {}
-    public update(): void {}
+    public update(...args: unknown[]): void {
+      avatarUpdate(this.team, ...args);
+    }
   },
 }));
 
@@ -48,6 +55,7 @@ describe("LocalMatch", () => {
   let match: LocalMatch;
 
   beforeEach(() => {
+    avatarUpdate.mockClear();
     events = [];
     match = new LocalMatch(new THREE.Scene());
     match.onEvent = (event) => events.push(event);
@@ -229,6 +237,47 @@ describe("LocalMatch", () => {
   });
 
   // ── Breach detection: phase-dependent query selection ──────────────────────
+
+  it("routes celebration only to winning-team bots", () => {
+    match.dispose();
+    match = new LocalMatch(new THREE.Scene());
+    match.startNewGame({
+      humanName: "Pilot",
+      humanTeam: 0,
+      teamSize: 2,
+    });
+
+    const player = createFakePlayer();
+    const arena = {
+      bounceObstacles: () => {},
+      getAllBarGrabPoints: () => [],
+      getBreachOpenAxis: () => "x" as const,
+      getBreachOpenSign: (team: 0 | 1) => (team === 0 ? -1 : 1) as 1 | -1,
+      getBreachRoomCenter: (team: 0 | 1) => new THREE.Vector3(team === 0 ? -18 : 18, 0, 0),
+      getNearestBar: () => null,
+      isDeepInBreachRoom: () => false,
+      isGoalDoorOpen: () => false,
+      isInBreachRoom: () => true,
+    };
+
+    match.resetForRound(arena as never, player as never);
+    avatarUpdate.mockClear();
+
+    match.setCelebratingTeam(0);
+    match.tick(1 / 60, arena as never, player as never, false);
+
+    const ownTeamFlags = avatarUpdate.mock.calls
+      .filter(([team]) => team === 0)
+      .map((call) => call.at(-1));
+    const enemyFlags = avatarUpdate.mock.calls
+      .filter(([team]) => team === 1)
+      .map((call) => call.at(-1));
+
+    expect(ownTeamFlags.length).toBeGreaterThan(0);
+    expect(enemyFlags.length).toBeGreaterThan(0);
+    expect(ownTeamFlags.every((flag) => flag === true)).toBe(true);
+    expect(enemyFlags.every((flag) => flag === false)).toBe(true);
+  });
 
   it("does not score breach for BREACH-phase player when isInBreachRoom returns false", () => {
     const player = createFakePlayer();

--- a/tests/onlineMatch.test.ts
+++ b/tests/onlineMatch.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as THREE from "three";
+import type { OnlineActorSnapshot } from "../shared/multiplayer";
+
+const avatarUpdate = vi.fn();
+
+vi.mock("../client/src/match/simulatedPlayerAvatar", () => ({
+  SimulatedPlayerAvatar: class {
+    private readonly team: 0 | 1;
+    public constructor(_scene: THREE.Scene, team: 0 | 1) {
+      this.team = team;
+    }
+    public dispose(): void {}
+    public triggerArmRecoil(): void {}
+    public update(...args: unknown[]): void {
+      avatarUpdate(this.team, ...args);
+    }
+  },
+}));
+
+import { OnlineMatch } from "../client/src/match/onlineMatch";
+
+describe("OnlineMatch", () => {
+  beforeEach(() => {
+    avatarUpdate.mockClear();
+  });
+
+  it("routes celebration only to remote actors on the winning team", () => {
+    const match = new OnlineMatch(new THREE.Scene());
+    match.applySnapshot(
+      [
+        createActor("remote-cyan", 0),
+        createActor("remote-magenta", 1),
+      ],
+      "local-player",
+    );
+
+    avatarUpdate.mockClear();
+    match.setCelebratingTeam(1);
+    match.update(1 / 60);
+
+    const team0Flags = avatarUpdate.mock.calls
+      .filter(([team]) => team === 0)
+      .map((call) => call.at(-1));
+    const team1Flags = avatarUpdate.mock.calls
+      .filter(([team]) => team === 1)
+      .map((call) => call.at(-1));
+
+    expect(team0Flags).toEqual([false]);
+    expect(team1Flags).toEqual([true]);
+
+    match.dispose();
+  });
+});
+
+function createActor(id: string, team: 0 | 1): OnlineActorSnapshot {
+  return {
+    id,
+    name: id,
+    team,
+    isBot: false,
+    posX: team === 0 ? -5 : 5,
+    posY: 0,
+    posZ: 0,
+    velX: 0,
+    velY: 0,
+    velZ: 0,
+    yaw: 0,
+    phase: "BREACH",
+    frozen: false,
+    leftArm: false,
+    rightArm: false,
+    leftLeg: false,
+    rightLeg: false,
+    kills: 0,
+    deaths: 0,
+  };
+}


### PR DESCRIPTION
## Summary
- add a lightweight victory dance pose overlay for player rigs and simulated avatars
- trigger the celebration only when a match winner is known, and only for unfrozen actors on the winning team
- clear celebration state when a new round starts or the app returns to lobby/menu so it cannot leak between sessions

## Why
The end-of-match flow already surfaced the winning team but did not animate the winners, so match conclusions felt visually flat.

## Validation
- `npm run build --prefix client`
- `npm run build --prefix server`
- `npx --yes vitest run --config vitest.config.ts`
