### PR TITLE
DOT-7: place tutorial return portal on back wall

### DIFF
--- a/client/src/game/portal/vibeJamPortal.ts
+++ b/client/src/game/portal/vibeJamPortal.ts
@@ -1,8 +1,7 @@
 import * as THREE from "three";
-import { PLAYER_RADIUS } from "../../../../shared/constants";
+import { BREACH_ROOM_D, PLAYER_RADIUS } from "../../../../shared/constants";
 import { computeBreachSpawnPosition } from "../../player/playerSpawn";
 import { parsePortalParams, type PortalParams } from "./parsePortalParams";
-import { computeBreachRoomPortalTransform } from "./portalPlacement";
 
 const OUTBOUND_URL = "https://vibej.am/portal/2026";
 const PORTAL_RADIUS = 1.3;
@@ -220,10 +219,11 @@ function clearTriggers(type?: PortalTrigger["type"]): void {
 }
 
 function buildReturnPortalTransform(): { normal: THREE.Vector3; position: THREE.Vector3 } {
-  const center = arrivalSpawnConfigured ? arrivalCenter : DEFAULT_ARRIVAL_CENTER;
-  const openAxis = arrivalSpawnConfigured ? arrivalOpenAxis : "z";
-  const openSign = arrivalSpawnConfigured ? arrivalOpenSign : 1;
-  return computeBreachRoomPortalTransform(center, openAxis, openSign);
+  return computeBackWallPortalTransform(
+    arrivalSpawnConfigured ? arrivalCenter : DEFAULT_ARRIVAL_CENTER,
+    arrivalSpawnConfigured ? arrivalOpenAxis : "z",
+    arrivalSpawnConfigured ? arrivalOpenSign : 1,
+  );
 }
 
 function buildOutboundPortalTransform(): { normal: THREE.Vector3; position: THREE.Vector3 } {
@@ -233,11 +233,22 @@ function buildOutboundPortalTransform(): { normal: THREE.Vector3; position: THRE
     openSign: -1 as const,
   };
 
-  return computeBreachRoomPortalTransform(
-    transform.center,
-    transform.openAxis,
-    transform.openSign,
-  );
+  return computeBackWallPortalTransform(transform.center, transform.openAxis, transform.openSign);
+}
+
+export function computeBackWallPortalTransform(
+  center: THREE.Vector3,
+  openAxis: "x" | "y" | "z",
+  openSign: 1 | -1,
+): { normal: THREE.Vector3; position: THREE.Vector3 } {
+  const normal = new THREE.Vector3();
+  normal[openAxis] = openSign;
+
+  const position = center.clone();
+  position[openAxis] = center[openAxis] - openSign * (BREACH_ROOM_D / 2 - 0.08);
+  position.y = center.y + 0.2;
+
+  return { normal, position };
 }
 
 function createPortal(

--- a/tests/vibeJamPortal.test.ts
+++ b/tests/vibeJamPortal.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { BREACH_ROOM_D } from "../shared/constants";
+import { computeBackWallPortalTransform } from "../client/src/game/portal/vibeJamPortal";
+
+describe("computeBackWallPortalTransform", () => {
+  it("places tutorial return portals on the breach-room back wall and faces them into the room", () => {
+    const center = new THREE.Vector3(0, 0, -23);
+    const transform = computeBackWallPortalTransform(center, "z", 1);
+
+    expect(transform.position.x).toBe(0);
+    expect(transform.position.y).toBeCloseTo(0.2);
+    expect(transform.position.z).toBeCloseTo(center.z - (BREACH_ROOM_D / 2 - 0.08));
+    expect(transform.normal.toArray()).toEqual([0, 0, 1]);
+  });
+
+  it("matches the existing enemy breach outbound portal wall placement style", () => {
+    const center = new THREE.Vector3(0, 0, 23);
+    const transform = computeBackWallPortalTransform(center, "z", -1);
+
+    expect(transform.position.x).toBe(0);
+    expect(transform.position.y).toBeCloseTo(0.2);
+    expect(transform.position.z).toBeCloseTo(center.z + (BREACH_ROOM_D / 2 - 0.08));
+    expect(transform.normal.toArray()).toEqual([0, 0, -1]);
+  });
+});


### PR DESCRIPTION
## Summary
- reuse a shared back-wall portal transform for breach-room mounted portals
- place the tutorial Vibe Jam return portal on the back wall instead of the side wall
- add a regression test covering tutorial and enemy breach portal placement geometry

## Validation
- `npm run build --prefix client`
- `npx --yes vitest run`