### PR TITLE
Add credits page and external links

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -376,6 +376,9 @@ export class App {
     this.menu.onOpenSettings = () => {
       this.openSessionMenu();
     };
+    this.menu.onOpenCredits = () => {
+      this.openSessionMenu("credits");
+    };
     this.menu.onPlayTutorial = (selection) => {
       this.startTutorialMatch(selection);
     };
@@ -1016,7 +1019,7 @@ export class App {
     this.menu.show();
   }
 
-  private openSessionMenu(): void {
+  private openSessionMenu(view: "settings" | "credits" = "settings"): void {
     if (this.sessionMenu.isOpen() || this.debrief.isVisible() || this.onlineMatchConcluding) return;
 
     const inMenu = this.appMode === "menu";
@@ -1057,7 +1060,7 @@ export class App {
       subtitle,
       resumeLabel,
       mainMenuLabel,
-    });
+    }, view);
   }
 
   private closeSessionMenu(): void {

--- a/client/src/ui/creditsContent.ts
+++ b/client/src/ui/creditsContent.ts
@@ -1,0 +1,26 @@
+export const GITHUB_REPO_URL = "https://github.com/DotanVG/Zero-G-Arena";
+export const ITCH_IO_URL = "https://dotanv.itch.io/";
+export const NOAM_SOUNDCLOUD_URL = "https://soundcloud.com/ouzana";
+
+export interface CreditEntry {
+  title: string;
+  detail: string;
+}
+
+export const ASSET_CREDITS: CreditEntry[] = [
+  {
+    title: "Alien Model",
+    detail: "Alien.glb and Alien_Helmet.glb power the player and bot character rigs.",
+  },
+  {
+    title: "Freeze Pistol Model",
+    detail: "Ray Gun.glb is used for the first-person and third-person freeze pistol.",
+  },
+];
+
+export const AUDIO_CREDITS: CreditEntry[] = [
+  {
+    title: "Noam Ouzana",
+    detail: "Music and sound effects, including the main theme, laser shots, and countdown audio.",
+  },
+];

--- a/client/src/ui/menu.ts
+++ b/client/src/ui/menu.ts
@@ -19,6 +19,7 @@ export class MainMenu {
   public onPlaySolo: ((selection: PlaySelection) => void) | null = null;
   public onPlayOnline: ((selection: PlaySelection) => void) | null = null;
   public onOpenSettings: (() => void) | null = null;
+  public onOpenCredits: (() => void) | null = null;
   public onPlayTutorial: ((selection: PlaySelection) => void) | null = null;
 
   public show(): void {
@@ -60,6 +61,9 @@ export class MainMenu {
     });
     elements.openSettingsButton.addEventListener('click', () => {
       this.onOpenSettings?.();
+    });
+    elements.openCreditsButton.addEventListener('click', () => {
+      this.onOpenCredits?.();
     });
     elements.playTutorialButton.addEventListener('click', () => {
       if (!this.checkNameBeforePlay(elements)) return;

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -1,5 +1,6 @@
 import { isTouchDevice } from "../../platform";
 import type { MatchTeamSize } from "../../../../shared/match";
+import { GITHUB_REPO_URL, ITCH_IO_URL } from "../creditsContent";
 import { injectDesignTokens } from "../designTokens";
 import { SESSION_MENU_GEAR_ICON } from "../sessionMenu";
 
@@ -345,6 +346,38 @@ const CSS = `
   .ob-btn-corner.ob-br { bottom: 4px; right: 4px; border-left:  none; border-top:    none; }
 
   /* ── TUTORIAL BUTTON ── */
+  .ob-link-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+    width: 100%;
+  }
+  .ob-link-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 42px;
+    padding: 0 18px;
+    border: 1px solid rgba(210,220,240,.16);
+    background: rgba(10,14,26,.44);
+    color: var(--ob-fg-dim);
+    text-decoration: none;
+    font-family: var(--ob-mono);
+    font-size: 10px;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    transition: border-color .25s, color .25s, transform .25s, background .25s;
+  }
+  .ob-link-chip:hover {
+    border-color: rgba(140,225,255,.42);
+    color: var(--ob-cyan);
+    background: rgba(12,20,36,.74);
+    transform: translateY(-1px);
+  }
+  .ob-link-chip:focus-visible { outline: 2px solid var(--ob-cyan); outline-offset: 3px; }
+  .ob-link-chip-arrow { font-family: var(--ob-serif); font-size: 14px; letter-spacing: 0; }
+
   .ob-tutorial-btn {
     position: relative;
     display: flex;
@@ -419,6 +452,7 @@ const CSS = `
     .ob-match-grid   { grid-template-columns: repeat(3, 1fr); }
     .ob-launch-row   { flex-direction: column; align-items: center; }
     .ob-settings-row { margin-top: 0; }
+    .ob-link-row     { gap: 8px; }
     .ob-callsign-box { min-width: 0; width: 90vw; }
     .menu-root       { cursor: auto; overflow-y: auto; align-items: start; }
 
@@ -495,6 +529,7 @@ export interface MenuElements {
   playSoloButton: HTMLButtonElement;
   playOnlineButton: HTMLButtonElement;
   openSettingsButton: HTMLButtonElement;
+  openCreditsButton: HTMLButtonElement;
   playTutorialButton: HTMLButtonElement;
 }
 
@@ -541,6 +576,19 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
         <span class="ob-btn-corner ob-bl"></span><span class="ob-btn-corner ob-br"></span>
         <span class="ob-btn-label">${label} ${adornment}</span>
       </button>`;
+  }
+
+  function externalLink(label: string, href: string): string {
+    return `
+      <a
+        class="ob-link-chip"
+        href="${href}"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        <span>${label}</span>
+        <span class="ob-link-chip-arrow">&nearr;</span>
+      </a>`;
   }
 
   const container = document.createElement("div") as HTMLDivElement;
@@ -670,6 +718,11 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
         </div>
         <div class="ob-settings-row">
           ${btn("btn-open-settings", "utility", "Settings", SESSION_MENU_GEAR_ICON)}
+          ${btn("btn-open-credits", "utility", "Credits")}
+        </div>
+        <div class="ob-link-row" aria-label="External project links">
+          ${externalLink("GitHub", GITHUB_REPO_URL)}
+          ${externalLink("itch.io", ITCH_IO_URL)}
         </div>
       </div>
 
@@ -713,6 +766,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
     playSoloButton:    container.querySelector<HTMLButtonElement>("#btn-play-solo")!,
     playOnlineButton:  container.querySelector<HTMLButtonElement>("#btn-play-online")!,
     openSettingsButton:container.querySelector<HTMLButtonElement>("#btn-open-settings")!,
+    openCreditsButton: container.querySelector<HTMLButtonElement>("#btn-open-credits")!,
     playTutorialButton:container.querySelector<HTMLButtonElement>("#btn-play-tutorial")!,
   };
 }

--- a/client/src/ui/sessionMenu.ts
+++ b/client/src/ui/sessionMenu.ts
@@ -1,3 +1,11 @@
+import {
+  ASSET_CREDITS,
+  AUDIO_CREDITS,
+  GITHUB_REPO_URL,
+  ITCH_IO_URL,
+  NOAM_SOUNDCLOUD_URL,
+} from "./creditsContent";
+
 export interface SessionSettings {
   mouseSensitivity: number;
   musicVolume: number;
@@ -12,6 +20,8 @@ export interface SessionMenuConfig {
   subtitle: string;
   title: string;
 }
+
+type SessionMenuView = "settings" | "credits";
 
 export const SESSION_MENU_GEAR_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
 
@@ -299,6 +309,111 @@ const CSS = `
     outline: 1px solid rgba(127, 252, 255, 0.4);
   }
 
+  .ob-session-view[hidden] {
+    display: none !important;
+  }
+
+  .ob-session-card-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 16px;
+  }
+
+  .ob-session-inline-button {
+    min-height: 42px;
+    padding: 0 16px;
+    border: 1px solid rgba(127, 252, 255, 0.22);
+    background: rgba(127, 252, 255, 0.05);
+    color: #effcff;
+    cursor: pointer;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    transition: border-color 0.2s, background 0.2s, transform 0.2s;
+  }
+
+  .ob-session-inline-button:hover {
+    border-color: rgba(127, 252, 255, 0.48);
+    background: rgba(127, 252, 255, 0.1);
+    transform: translateY(-1px);
+  }
+
+  .ob-session-inline-button--ghost {
+    border-color: rgba(210, 220, 240, 0.16);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .ob-session-inline-button--ghost:hover {
+    border-color: rgba(210, 220, 240, 0.3);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .ob-session-credit-list {
+    display: grid;
+    gap: 12px;
+    margin-top: 16px;
+  }
+
+  .ob-session-credit-item {
+    padding: 14px 16px;
+    border: 1px solid rgba(210, 220, 240, 0.08);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .ob-session-credit-name {
+    color: #effcff;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .ob-session-credit-detail {
+    margin-top: 8px;
+    color: #cfe3ed;
+    font-size: 16px;
+    line-height: 1.45;
+  }
+
+  .ob-session-link-grid {
+    display: grid;
+    gap: 12px;
+    margin-top: 16px;
+  }
+
+  .ob-session-link {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px 16px;
+    border: 1px solid rgba(210, 220, 240, 0.08);
+    background: rgba(255, 255, 255, 0.02);
+    color: #effcff;
+    text-decoration: none;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    transition: border-color 0.2s, background 0.2s, transform 0.2s;
+  }
+
+  .ob-session-link:hover {
+    border-color: rgba(127, 252, 255, 0.42);
+    background: rgba(127, 252, 255, 0.06);
+    transform: translateY(-1px);
+  }
+
+  .ob-session-link:focus-visible {
+    outline: 1px solid rgba(127, 252, 255, 0.5);
+    outline-offset: 2px;
+  }
+
   @media (max-width: 640px) {
     .ob-session-actions {
       grid-template-columns: 1fr;
@@ -376,6 +491,10 @@ export class SessionMenu {
   private readonly subtitle: HTMLDivElement;
   private readonly resumeButton: HTMLButtonElement;
   private readonly mainMenuButton: HTMLButtonElement;
+  private readonly settingsView: HTMLDivElement;
+  private readonly creditsView: HTMLDivElement;
+  private readonly openCreditsButton: HTMLButtonElement;
+  private readonly backToSettingsButton: HTMLButtonElement;
   private readonly sensitivityInput: HTMLInputElement;
   private readonly sensitivityValue: HTMLSpanElement;
   private readonly soundtrackInput: HTMLInputElement;
@@ -386,6 +505,7 @@ export class SessionMenu {
   private readonly sfxValue: HTMLSpanElement;
   private readonly cameraSelect: HTMLSelectElement;
   private settings = loadSettings();
+  private currentConfig: SessionMenuConfig | null = null;
 
   public onLauncherRequest: (() => void) | null = null;
   public onMainMenu: (() => void) | null = null;
@@ -419,55 +539,117 @@ export class SessionMenu {
         </div>
 
         <div class="ob-session-settings">
-          <section class="ob-session-settings-card">
-            <div class="ob-session-settings-title">Flight Settings</div>
-            <div class="ob-session-note">Changes apply immediately. Soundtrack toggle mutes music while preserving the level setting.</div>
+          <div id="session-menu-settings-view" class="ob-session-view">
+            <section class="ob-session-settings-card">
+              <div class="ob-session-settings-title">Flight Settings</div>
+              <div class="ob-session-note">Changes apply immediately. Soundtrack toggle mutes music while preserving the level setting.</div>
 
-            <div class="ob-session-field">
-              <div class="ob-session-field-head">
-                <span class="ob-session-field-label">Mouse Sensitivity</span>
-                <span id="session-menu-sensitivity-value" class="ob-session-value"></span>
+              <div class="ob-session-field">
+                <div class="ob-session-field-head">
+                  <span class="ob-session-field-label">Mouse Sensitivity</span>
+                  <span id="session-menu-sensitivity-value" class="ob-session-value"></span>
+                </div>
+                <input id="session-menu-sensitivity" class="ob-session-range" type="range" min="5" max="40" step="1" />
               </div>
-              <input id="session-menu-sensitivity" class="ob-session-range" type="range" min="5" max="40" step="1" />
-            </div>
 
-            <div class="ob-session-field">
-              <div class="ob-session-field-head">
-                <span class="ob-session-field-label">Soundtrack</span>
-                <span id="session-menu-soundtrack-value" class="ob-session-value"></span>
+              <div class="ob-session-field">
+                <div class="ob-session-field-head">
+                  <span class="ob-session-field-label">Soundtrack</span>
+                  <span id="session-menu-soundtrack-value" class="ob-session-value"></span>
+                </div>
+                <label class="ob-session-toggle">
+                  <span class="ob-session-toggle-copy">Keep the soundtrack channel armed once the music pass lands.</span>
+                  <input id="session-menu-soundtrack" class="ob-session-checkbox" type="checkbox" />
+                </label>
               </div>
-              <label class="ob-session-toggle">
-                <span class="ob-session-toggle-copy">Keep the soundtrack channel armed once the music pass lands.</span>
-                <input id="session-menu-soundtrack" class="ob-session-checkbox" type="checkbox" />
-              </label>
-            </div>
 
-            <div class="ob-session-field">
-              <div class="ob-session-field-head">
-                <span class="ob-session-field-label">Music Level</span>
-                <span id="session-menu-music-value" class="ob-session-value"></span>
+              <div class="ob-session-field">
+                <div class="ob-session-field-head">
+                  <span class="ob-session-field-label">Music Level</span>
+                  <span id="session-menu-music-value" class="ob-session-value"></span>
+                </div>
+                <input id="session-menu-music" class="ob-session-range" type="range" min="0" max="100" step="1" />
               </div>
-              <input id="session-menu-music" class="ob-session-range" type="range" min="0" max="100" step="1" />
-            </div>
 
-            <div class="ob-session-field">
-              <div class="ob-session-field-head">
-                <span class="ob-session-field-label">SFX Level</span>
-                <span id="session-menu-sfx-value" class="ob-session-value"></span>
+              <div class="ob-session-field">
+                <div class="ob-session-field-head">
+                  <span class="ob-session-field-label">SFX Level</span>
+                  <span id="session-menu-sfx-value" class="ob-session-value"></span>
+                </div>
+                <input id="session-menu-sfx" class="ob-session-range" type="range" min="0" max="100" step="1" />
               </div>
-              <input id="session-menu-sfx" class="ob-session-range" type="range" min="0" max="100" step="1" />
-            </div>
 
-            <div class="ob-session-field">
-              <div class="ob-session-field-head">
-                <span class="ob-session-field-label">Default Camera</span>
+              <div class="ob-session-field">
+                <div class="ob-session-field-head">
+                  <span class="ob-session-field-label">Default Camera</span>
+                </div>
+                <select id="session-menu-camera" class="ob-session-select">
+                  <option value="first">First Person</option>
+                  <option value="third">Third Person</option>
+                </select>
               </div>
-              <select id="session-menu-camera" class="ob-session-select">
-                <option value="first">First Person</option>
-                <option value="third">Third Person</option>
-              </select>
-            </div>
-          </section>
+            </section>
+
+            <section class="ob-session-settings-card">
+              <div class="ob-session-settings-title">Credits</div>
+              <div class="ob-session-note">Review model, audio, and project-link credits without leaving the build.</div>
+              <div class="ob-session-card-actions">
+                <button id="session-menu-open-credits" type="button" class="ob-session-inline-button">Open Credits</button>
+              </div>
+            </section>
+          </div>
+
+          <div id="session-menu-credits-view" class="ob-session-view" hidden>
+            <section class="ob-session-settings-card">
+              <div class="ob-session-settings-title">Asset Credits</div>
+              <div class="ob-session-note">Bundled 3D model assets used by the current browser build.</div>
+              <div class="ob-session-credit-list">
+                ${ASSET_CREDITS.map((credit) => `
+                  <article class="ob-session-credit-item">
+                    <div class="ob-session-credit-name">${escapeHtml(credit.title)}</div>
+                    <div class="ob-session-credit-detail">${escapeHtml(credit.detail)}</div>
+                  </article>
+                `).join("")}
+              </div>
+            </section>
+
+            <section class="ob-session-settings-card">
+              <div class="ob-session-settings-title">Audio Credits</div>
+              <div class="ob-session-note">Original soundtrack and sound design for Orbital Breach.</div>
+              <div class="ob-session-credit-list">
+                ${AUDIO_CREDITS.map((credit) => `
+                  <article class="ob-session-credit-item">
+                    <div class="ob-session-credit-name">${escapeHtml(credit.title)}</div>
+                    <div class="ob-session-credit-detail">${escapeHtml(credit.detail)}</div>
+                  </article>
+                `).join("")}
+              </div>
+              <div class="ob-session-link-grid">
+                <a class="ob-session-link" href="${NOAM_SOUNDCLOUD_URL}" target="_blank" rel="noreferrer noopener">
+                  <span>Noam Ouzana SoundCloud</span>
+                  <span>&nearr;</span>
+                </a>
+              </div>
+            </section>
+
+            <section class="ob-session-settings-card">
+              <div class="ob-session-settings-title">Project Links</div>
+              <div class="ob-session-note">External pages open in a new tab.</div>
+              <div class="ob-session-link-grid">
+                <a class="ob-session-link" href="${GITHUB_REPO_URL}" target="_blank" rel="noreferrer noopener">
+                  <span>GitHub Repository</span>
+                  <span>&nearr;</span>
+                </a>
+                <a class="ob-session-link" href="${ITCH_IO_URL}" target="_blank" rel="noreferrer noopener">
+                  <span>itch.io Page</span>
+                  <span>&nearr;</span>
+                </a>
+              </div>
+              <div class="ob-session-card-actions">
+                <button id="session-menu-back-to-settings" type="button" class="ob-session-inline-button ob-session-inline-button--ghost">Back To Settings</button>
+              </div>
+            </section>
+          </div>
         </div>
       </div>
     `;
@@ -477,6 +659,10 @@ export class SessionMenu {
     this.subtitle = this.query("#session-menu-subtitle");
     this.resumeButton = this.query("#session-menu-resume");
     this.mainMenuButton = this.query("#session-menu-main");
+    this.settingsView = this.query("#session-menu-settings-view");
+    this.creditsView = this.query("#session-menu-credits-view");
+    this.openCreditsButton = this.query("#session-menu-open-credits");
+    this.backToSettingsButton = this.query("#session-menu-back-to-settings");
     this.sensitivityInput = this.query("#session-menu-sensitivity");
     this.sensitivityValue = this.query("#session-menu-sensitivity-value");
     this.soundtrackInput = this.query("#session-menu-soundtrack");
@@ -489,6 +675,8 @@ export class SessionMenu {
 
     this.resumeButton.addEventListener("click", () => this.onResume?.());
     this.mainMenuButton.addEventListener("click", () => this.onMainMenu?.());
+    this.openCreditsButton.addEventListener("click", () => this.showView("credits"));
+    this.backToSettingsButton.addEventListener("click", () => this.showView("settings"));
 
     this.sensitivityInput.addEventListener("input", () => {
       this.settings.mouseSensitivity = Number(this.sensitivityInput.value) / 10000;
@@ -532,7 +720,8 @@ export class SessionMenu {
     return this.root.style.display === "flex";
   }
 
-  public open(config: SessionMenuConfig): void {
+  public open(config: SessionMenuConfig, initialView: SessionMenuView = "settings"): void {
+    this.currentConfig = config;
     this.title.textContent = config.title;
     this.subtitle.textContent = config.subtitle;
 
@@ -556,10 +745,12 @@ export class SessionMenu {
       !config.resumeLabel || !config.mainMenuLabel,
     );
 
+    this.showView(initialView);
     this.root.style.display = "flex";
   }
 
   public close(): void {
+    this.showView("settings");
     this.root.style.display = "none";
   }
 
@@ -586,9 +777,38 @@ export class SessionMenu {
     this.cameraSelect.value = this.settings.defaultCameraMode;
   }
 
+  private showView(view: SessionMenuView): void {
+    this.settingsView.hidden = view !== "settings";
+    this.creditsView.hidden = view !== "credits";
+
+    if (!this.currentConfig) return;
+
+    if (view === "credits") {
+      this.title.textContent = "Credits";
+      this.subtitle.textContent = "Asset, audio, and external-link acknowledgements for Orbital Breach.";
+      return;
+    }
+
+    this.title.textContent = this.currentConfig.title;
+    this.subtitle.textContent = this.currentConfig.subtitle;
+  }
+
   private query<T extends HTMLElement>(selector: string): T {
     return this.root.querySelector<T>(selector) as T;
   }
+}
+
+function escapeHtml(raw: string): string {
+  return raw.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case "&": return "&amp;";
+      case "<": return "&lt;";
+      case ">": return "&gt;";
+      case '"': return "&quot;";
+      case "'": return "&#39;";
+      default: return ch;
+    }
+  });
 }
 
 function loadSettings(): SessionSettings {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,6 +4,7 @@
     "useDefineForClassFields": false,
     "module": "CommonJS",
     "moduleResolution": "Node",
+    "ignoreDeprecations": "5.0",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/tests/creditsContent.test.ts
+++ b/tests/creditsContent.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  ASSET_CREDITS,
+  AUDIO_CREDITS,
+  GITHUB_REPO_URL,
+  ITCH_IO_URL,
+  NOAM_SOUNDCLOUD_URL,
+} from "../client/src/ui/creditsContent";
+
+describe("credits content", () => {
+  it("publishes the required external URLs", () => {
+    expect(GITHUB_REPO_URL).toBe("https://github.com/DotanVG/Zero-G-Arena");
+    expect(ITCH_IO_URL).toBe("https://dotanv.itch.io/");
+    expect(NOAM_SOUNDCLOUD_URL).toBe("https://soundcloud.com/ouzana");
+  });
+
+  it("includes alien and pistol asset credits", () => {
+    expect(ASSET_CREDITS.some((credit) => /alien/i.test(credit.title))).toBe(true);
+    expect(ASSET_CREDITS.some((credit) => /pistol/i.test(credit.title))).toBe(true);
+  });
+
+  it("includes the Noam Ouzana audio credit", () => {
+    expect(AUDIO_CREDITS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Noam Ouzana",
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add shared credits/link content for the GitHub repo, itch.io page, asset credits, and Noam Ouzana SoundCloud credit
- add main menu GitHub/itch.io external links plus a direct Credits button
- add a dedicated credits view inside the shared session/settings menu and keep coverage green with a credits-content test

## Validation
- `npm run build` (client)
- `npm run build` (server)
- `$env:NODE_PATH='C:\Users\dotan\code\orbital-breach-workspaces\DOT-8\client\node_modules;C:\Users\dotan\code\orbital-breach-workspaces\DOT-8\server\node_modules'; npx vitest run`
