### PR TITLE
Add room browser, private lobbies, and invite sharing

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,9 +13,13 @@
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "colyseus.js": "^0.16.22",
+        "qrcode": "^1.5.4",
         "three": "^0.179.1",
         "typescript": "^5.9.3",
         "vite": "^7.1.3"
+      },
+      "devDependencies": {
+        "@types/qrcode": "^1.5.6"
       }
     },
     "node_modules/@better-auth/utils": {
@@ -979,6 +983,26 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
@@ -1092,6 +1116,68 @@
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/colyseus.js": {
       "version": "0.16.22",
       "resolved": "https://registry.npmjs.org/colyseus.js/-/colyseus.js-0.16.22.tgz",
@@ -1111,6 +1197,15 @@
         "url": "https://github.com/sponsors/endel"
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1120,6 +1215,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -1185,6 +1292,19 @@
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "license": "MIT"
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1197,6 +1317,36 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/meshoptimizer": {
@@ -1260,6 +1410,51 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1276,6 +1471,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -1305,6 +1509,38 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -1356,6 +1592,12 @@
       "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
       "license": "MIT"
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
@@ -1369,6 +1611,32 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/three": {
@@ -1411,6 +1679,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.2",
@@ -1486,6 +1761,26 @@
         }
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -1505,6 +1800,47 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -14,8 +14,12 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "colyseus.js": "^0.16.22",
+    "qrcode": "^1.5.4",
     "three": "^0.179.1",
     "typescript": "^5.9.3",
     "vite": "^7.1.3"
+  },
+  "devDependencies": {
+    "@types/qrcode": "^1.5.6"
   }
 }

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -2,7 +2,12 @@ import * as THREE from "three";
 import { GRAB_RADIUS, HITBOX_OFFSET_Y, HITBOX_RADIUS, MATCH_POINT_TARGET } from "../../../shared/constants";
 import { generateArenaLayout } from "../../../shared/arena-gen";
 import { findMatchWinner } from "../../../shared/match-flow";
-import type { MultiplayerRoomSnapshot } from "../../../shared/multiplayer";
+import {
+  getInviteRoomIdFromSearch,
+  MULTIPLAYER_INVITE_PARAM,
+  type MultiplayerJoinTarget,
+  type MultiplayerRoomSnapshot,
+} from "../../../shared/multiplayer";
 import { Arena } from "../arena/arena";
 import { CameraController } from "../camera";
 import { FEATURE_FLAGS } from "../featureFlags";
@@ -20,6 +25,7 @@ import { KillFeed } from "../ui/kill-feed";
 import { initGlobalCursor, type GlobalCursor } from "../ui/globalCursor";
 import { MainMenu } from "../ui/menu";
 import { MobileControls } from "../ui/mobileControls";
+import { RoomBrowser } from "../ui/roomBrowser";
 import { WelcomeScreen } from "../ui/welcome";
 import { SessionMenu, type SessionSettings } from "../ui/sessionMenu";
 import { SoundEngine } from "../audio/SoundEngine";
@@ -64,6 +70,7 @@ export class App {
   private lastSoloSelection: PlaySelection | null = null;
   private matchEndHandle: ReturnType<typeof setTimeout> | null = null;
   private pendingOnlineDebrief: DebriefData | null = null;
+  private pendingOnlineRoomSelection: PlaySelection | null = null;
   private onlineMatchConcluding = false;
   private playerUpdateTimer = 0;
   private latestOnlineSnapshot: MultiplayerRoomSnapshot | null = null;
@@ -88,6 +95,7 @@ export class App {
   private match: LocalMatch;
   private menu: MainMenu;
   private readonly matchStats = new MatchStatsTracker();
+  private roomBrowser = new RoomBrowser();
   private welcome!: WelcomeScreen;
   private debrief = new DebriefScreen();
   private multiplayer = new MultiplayerLobby();
@@ -357,6 +365,23 @@ export class App {
     this.multiplayer.onTeamSizeChange = (teamSize) => {
       this.net.setTeamSize(teamSize);
     };
+    this.roomBrowser.onJoinRoom = (roomId) => {
+      if (!this.pendingOnlineRoomSelection) return;
+      const selection = this.pendingOnlineRoomSelection;
+      this.menu.fadeOut(() => {
+        void this.startOnlineLobby(selection, { kind: "roomId", roomId });
+      });
+    };
+    this.roomBrowser.onCreateRoom = (target) => {
+      if (!this.pendingOnlineRoomSelection) return;
+      const selection = this.pendingOnlineRoomSelection;
+      this.menu.fadeOut(() => {
+        void this.startOnlineLobby(selection, target);
+      });
+    };
+    this.roomBrowser.onClose = () => {
+      this.pendingOnlineRoomSelection = null;
+    };
 
     if (this.mobile) {
       this.mobileControls = new MobileControls(this.input);
@@ -381,6 +406,13 @@ export class App {
     };
     this.menu.onPlayOnline = (selection) => {
       void this.startOnlineLobby(selection);
+    };
+    this.menu.onBrowseOnline = (selection) => {
+      this.pendingOnlineRoomSelection = selection;
+      void this.roomBrowser.show({
+        inviteRoomId: this.getInviteRoomId(),
+        defaultTeamSize: selection.teamSize,
+      });
     };
     this.menu.onOpenSettings = () => {
       this.openSessionMenu();
@@ -1215,7 +1247,16 @@ export class App {
 
   // ── Online lobby start ──────────────────────────────────────────────────────
 
-  private async startOnlineLobby(selection: PlaySelection): Promise<void> {
+  private async startOnlineLobby(
+    selection: PlaySelection,
+    target?: MultiplayerJoinTarget,
+  ): Promise<void> {
+    this.pendingOnlineRoomSelection = null;
+    this.roomBrowser.hide();
+    const resolvedTarget = target ?? this.getInviteJoinTarget() ?? { kind: "quick" };
+    if (resolvedTarget.kind === "roomId") {
+      this.clearInviteRoomIdFromUrl();
+    }
     this.appMode = "online";
     this.onlinePlayerName = selection.name;
     this.killFeed.setLocalPlayerName(selection.name);
@@ -1243,7 +1284,10 @@ export class App {
     const myToken = ++this.onlineSessionToken;
 
     try {
-      const snapshot = await this.net.connect({ name: selection.name });
+      const snapshot = await this.net.connect({
+        name: selection.name,
+        target: resolvedTarget,
+      });
       if (myToken !== this.onlineSessionToken || this.isUserExitingOnline || this.appMode !== "online") {
         try { await this.net.disconnect(); } catch { /* ignore */ }
         return;
@@ -1272,6 +1316,8 @@ export class App {
   }
 
   private async returnToMenuFromOnline(): Promise<void> {
+    this.pendingOnlineRoomSelection = null;
+    this.roomBrowser.hide();
     this.closeSessionMenu();
     this.debrief.hide();
     this.clearCelebrationState();
@@ -1316,6 +1362,25 @@ export class App {
     });
     const timeout = new Promise<void>((resolve) => setTimeout(resolve, 1500));
     await Promise.race([disconnectPromise, timeout]);
+  }
+
+  private getInviteRoomId(): string | null {
+    return getInviteRoomIdFromSearch(window.location.search);
+  }
+
+  private getInviteJoinTarget(): MultiplayerJoinTarget | null {
+    const roomId = this.getInviteRoomId();
+    return roomId ? { kind: "roomId", roomId } : null;
+  }
+
+  private clearInviteRoomIdFromUrl(): void {
+    const url = new URL(window.location.href);
+    if (!url.searchParams.has(MULTIPLAYER_INVITE_PARAM)) {
+      return;
+    }
+
+    url.searchParams.delete(MULTIPLAYER_INVITE_PARAM);
+    window.history.replaceState({}, "", url);
   }
 
   // ── Weapon fire (solo) ──────────────────────────────────────────────────────

--- a/client/src/net/client.ts
+++ b/client/src/net/client.ts
@@ -2,6 +2,8 @@ import { Client as ColyseusClient, type Room } from "@colyseus/sdk";
 import { getColyseusEndpoint } from "./endpoint";
 import { isMatchTeamSize, type MatchTeamSize } from "../../../shared/match";
 import {
+  getMaxPlayersForTeamSize,
+  MULTIPLAYER_BROWSER_ROOM_NAME,
   MULTIPLAYER_DEFAULT_TEAM_SIZE,
   MULTIPLAYER_ROOM_NAME,
   type BreachReportMessage,
@@ -28,6 +30,9 @@ import {
 const SERVER_URL = getColyseusEndpoint();
 
 type ColyseusRoomState = {
+  roomName: string;
+  visibility: string;
+  listing: string;
   phase: string;
   matchComplete: boolean;
   countdownRemaining: number;
@@ -35,6 +40,7 @@ type ColyseusRoomState = {
   scoreTeam0: number;
   scoreTeam1: number;
   teamSize: number;
+  maxPlayers: number;
   roundNumber: number;
   members: unknown;
   actors: unknown;
@@ -60,9 +66,7 @@ export class NetClient {
       );
     }
 
-    const room = await this.client.joinOrCreate(MULTIPLAYER_ROOM_NAME, {
-      name: options.name,
-    });
+    const room = await this.connectToTarget(options);
 
     this.room = room;
     room.onStateChange((state) => {
@@ -93,6 +97,34 @@ export class NetClient {
     this.room = null;
     if (room) {
       await room.leave(consented);
+    }
+  }
+
+  private async connectToTarget(options: MultiplayerJoinOptions): Promise<Room> {
+    if (!this.client) {
+      throw new Error("Online multiplayer endpoint not configured.");
+    }
+
+    const target = options.target ?? { kind: "quick" as const };
+    switch (target.kind) {
+      case "roomId":
+        return this.client.joinById(target.roomId, {
+          name: options.name,
+        });
+      case "create":
+        return this.client.create(MULTIPLAYER_BROWSER_ROOM_NAME, {
+          name: options.name,
+          listing: target.listing,
+          visibility: target.visibility,
+          roomName: target.roomName,
+          teamSize: target.teamSize,
+        });
+      case "quick":
+      default:
+        return this.client.joinOrCreate(MULTIPLAYER_ROOM_NAME, {
+          name: options.name,
+          listing: "quick",
+        });
     }
   }
 
@@ -150,10 +182,13 @@ function buildSnapshot(
 
   return {
     roomId: room.roomId,
+    roomName: String(state.roomName ?? "Orbital Lobby"),
     sessionId: room.sessionId,
     selfTeam: self?.team ?? 0,
     phase: toRoomPhase(state.phase),
     matchComplete: Boolean(state.matchComplete),
+    visibility: state.visibility === "private" ? "private" : "public",
+    listing: state.listing === "browser" ? "browser" : "quick",
     countdownRemaining: Number(state.countdownRemaining ?? 0),
     roundTimeRemaining: Number(state.roundTimeRemaining ?? 0),
     score: {
@@ -162,6 +197,7 @@ function buildSnapshot(
     },
     roundNumber: Number(state.roundNumber ?? 0),
     teamSize,
+    maxPlayers: Number(state.maxPlayers ?? getMaxPlayersForTeamSize(teamSize)),
     members,
     actors,
   };

--- a/client/src/net/roomDirectory.ts
+++ b/client/src/net/roomDirectory.ts
@@ -1,0 +1,39 @@
+import { getColyseusEndpoint } from "./endpoint";
+import type { MultiplayerRoomDirectoryEntry } from "../../../shared/multiplayer";
+
+interface RoomDirectoryResponse {
+  ok?: boolean;
+  rooms?: MultiplayerRoomDirectoryEntry[];
+}
+
+export async function fetchPublicRoomDirectory(): Promise<MultiplayerRoomDirectoryEntry[]> {
+  const url = getRoomDirectoryUrl();
+  if (!url) {
+    throw new Error("Online room directory is unavailable because the multiplayer endpoint is not configured.");
+  }
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Accept": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Room directory request failed with ${response.status}.`);
+  }
+
+  const data = await response.json() as RoomDirectoryResponse;
+  return Array.isArray(data.rooms) ? data.rooms : [];
+}
+
+function getRoomDirectoryUrl(): string | null {
+  const endpoint = getColyseusEndpoint();
+  if (!endpoint) {
+    return null;
+  }
+
+  const httpBase = endpoint.replace(/^ws(s?):\/\//i, (_match, secure) => `http${secure}://`);
+  return `${httpBase}/rooms`;
+}

--- a/client/src/ui/menu.ts
+++ b/client/src/ui/menu.ts
@@ -18,6 +18,7 @@ export class MainMenu {
 
   public onPlaySolo: ((selection: PlaySelection) => void) | null = null;
   public onPlayOnline: ((selection: PlaySelection) => void) | null = null;
+  public onBrowseOnline: ((selection: PlaySelection) => void) | null = null;
   public onOpenSettings: (() => void) | null = null;
   public onOpenCredits: (() => void) | null = null;
   public onPlayTutorial: ((selection: PlaySelection) => void) | null = null;
@@ -58,6 +59,10 @@ export class MainMenu {
       if (!this.checkNameBeforePlay(elements)) return;
       const selection = this.saveSelection();
       this.fadeOut(() => this.onPlayOnline?.(selection));
+    });
+    elements.browseRoomsButton.addEventListener('click', () => {
+      if (!this.checkNameBeforePlay(elements)) return;
+      this.onBrowseOnline?.(this.saveSelection());
     });
     elements.openSettingsButton.addEventListener('click', () => {
       this.onOpenSettings?.();

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -528,6 +528,7 @@ export interface MenuElements {
   matchSizeSelect: HTMLSelectElement;
   playSoloButton: HTMLButtonElement;
   playOnlineButton: HTMLButtonElement;
+  browseRoomsButton: HTMLButtonElement;
   openSettingsButton: HTMLButtonElement;
   openCreditsButton: HTMLButtonElement;
   playTutorialButton: HTMLButtonElement;
@@ -717,6 +718,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
           ${btn("btn-play-online", "secondary", "Join Online")}
         </div>
         <div class="ob-settings-row">
+          ${btn("btn-browse-rooms", "utility", "Rooms & Invites")}
           ${btn("btn-open-settings", "utility", "Settings", SESSION_MENU_GEAR_ICON)}
           ${btn("btn-open-credits", "utility", "Credits")}
         </div>
@@ -765,6 +767,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
     matchSizeSelect:   matchSelect,
     playSoloButton:    container.querySelector<HTMLButtonElement>("#btn-play-solo")!,
     playOnlineButton:  container.querySelector<HTMLButtonElement>("#btn-play-online")!,
+    browseRoomsButton: container.querySelector<HTMLButtonElement>("#btn-browse-rooms")!,
     openSettingsButton:container.querySelector<HTMLButtonElement>("#btn-open-settings")!,
     openCreditsButton: container.querySelector<HTMLButtonElement>("#btn-open-credits")!,
     playTutorialButton:container.querySelector<HTMLButtonElement>("#btn-play-tutorial")!,

--- a/client/src/ui/multiplayerLobby.ts
+++ b/client/src/ui/multiplayerLobby.ts
@@ -1,9 +1,11 @@
 import { MATCH_TEAM_SIZES, type MatchTeamSize } from "../../../shared/match";
 import {
+  buildInviteUrl,
   getLobbyMemberCounts,
   type LobbyEventMessage,
   type MultiplayerRoomSnapshot,
 } from "../../../shared/multiplayer";
+import QRCode from "qrcode";
 
 const CYAN = "#7ffcff";
 const MAGENTA = "#ff7df8";
@@ -161,6 +163,79 @@ const CSS = `
     margin-top: 16px;
     padding: 14px;
     border-radius: 0;
+  }
+
+  .ob-mp-invite {
+    margin-top: 16px;
+    padding: 16px;
+    border: 1px solid rgba(127, 252, 255, 0.12);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .ob-mp-invite-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+    align-items: baseline;
+  }
+
+  .ob-mp-invite-title {
+    margin-top: 6px;
+    font-size: 24px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .ob-mp-invite-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 170px;
+    gap: 16px;
+    align-items: start;
+    margin-top: 14px;
+  }
+
+  .ob-mp-invite-main {
+    display: grid;
+    gap: 10px;
+  }
+
+  .ob-mp-invite-url {
+    min-height: 44px;
+    width: 100%;
+    padding: 0 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: #effcff;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    letter-spacing: 0.04em;
+  }
+
+  .ob-mp-invite-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .ob-mp-invite-note {
+    color: #c7d6ec;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .ob-mp-qr-card {
+    display: grid;
+    gap: 10px;
+    justify-items: center;
+    padding: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .ob-mp-qr-card img {
+    width: 140px;
+    height: 140px;
+    background: white;
   }
 
   .ob-mp-select-wrap {
@@ -475,6 +550,10 @@ const CSS = `
     .ob-mp-roster-badges {
       justify-content: flex-start;
     }
+
+    .ob-mp-invite-grid {
+      grid-template-columns: 1fr;
+    }
   }
 
   /* ===== BRIEFING 3-COLUMN LAYOUT ===== */
@@ -660,6 +739,12 @@ export class MultiplayerLobby {
   private clearBotsButton: HTMLButtonElement;
   private settingsButton: HTMLButtonElement;
   private leaveButton: HTMLButtonElement;
+  private inviteUrlInput: HTMLInputElement;
+  private copyInviteButton: HTMLButtonElement;
+  private shareInviteButton: HTMLButtonElement;
+  private inviteQrImage: HTMLImageElement;
+  private inviteNote: HTMLDivElement;
+  private inviteQrMeta: HTMLDivElement;
   private teamSizeSelect: HTMLSelectElement;
   private team0Title: HTMLDivElement;
   private team0Relation: HTMLSpanElement;
@@ -670,6 +755,7 @@ export class MultiplayerLobby {
   private team0Roster: HTMLDivElement;
   private team1Roster: HTMLDivElement;
   private latestState: MultiplayerRoomSnapshot | null = null;
+  private latestInviteUrl = "";
 
   public onLeaveLobby: (() => void) | null = null;
   public onReadyChange: ((ready: boolean) => void) | null = null;
@@ -699,6 +785,12 @@ export class MultiplayerLobby {
     this.clearBotsButton = this.query("#mp-clear-bots");
     this.settingsButton = this.query("#mp-settings");
     this.leaveButton = this.query("#mp-leave");
+    this.inviteUrlInput = this.query("#mp-invite-url");
+    this.copyInviteButton = this.query("#mp-copy-invite");
+    this.shareInviteButton = this.query("#mp-share-invite");
+    this.inviteQrImage = this.query("#mp-invite-qr");
+    this.inviteNote = this.query("#mp-invite-note");
+    this.inviteQrMeta = this.query("#mp-invite-qr-meta");
     this.teamSizeSelect = this.query("#mp-team-size");
     this.team0Title = this.query("#mp-team0-title");
     this.team0Relation = this.query("#mp-team0-relation");
@@ -727,6 +819,12 @@ export class MultiplayerLobby {
     this.clearBotsButton.addEventListener("click", () => this.onFillBots?.(false));
     this.settingsButton.addEventListener("click", () => this.onOpenSettings?.());
     this.leaveButton.addEventListener("click", () => this.onLeaveLobby?.());
+    this.copyInviteButton.addEventListener("click", () => {
+      void this.copyInviteUrl();
+    });
+    this.shareInviteButton.addEventListener("click", () => {
+      void this.shareInviteUrl();
+    });
     this.teamSizeSelect.addEventListener("change", () => {
       const teamSize = Number(this.teamSizeSelect.value);
       if (MATCH_TEAM_SIZES.includes(teamSize as MatchTeamSize)) {
@@ -751,6 +849,12 @@ export class MultiplayerLobby {
     this.team1Count.textContent = "Loading";
     this.team0Roster.innerHTML = `<div class="ob-mp-empty">Joining room...</div>`;
     this.team1Roster.innerHTML = `<div class="ob-mp-empty">Joining room...</div>`;
+    this.inviteUrlInput.value = "";
+    this.inviteQrImage.removeAttribute("src");
+    this.inviteNote.textContent = "Invite tools will activate as soon as the room session is established.";
+    this.inviteQrMeta.textContent = "Waiting for room id";
+    this.copyInviteButton.disabled = true;
+    this.shareInviteButton.disabled = true;
     this.setStatus(`Connecting ${escapeHtml(playerName)} to the live queue...`, "info");
   }
 
@@ -786,7 +890,7 @@ export class MultiplayerLobby {
 
     this.phase.textContent = describePhase(state);
     this.meta.textContent =
-      `Room ${state.roomId} · ${playlistLabel(state.teamSize)} · Round ${Math.max(1, state.roundNumber || 1)}`;
+      `${state.roomName} · ${state.roomId} · ${playlistLabel(state.teamSize)} · Round ${Math.max(1, state.roundNumber || 1)}`;
     this.score.textContent = `${state.score.team0} - ${state.score.team1}`;
     this.teamSizeSelect.value = String(state.teamSize);
 
@@ -843,10 +947,72 @@ export class MultiplayerLobby {
     this.team1Count.textContent = `${team1Members.length}/${state.teamSize} queued`;
     this.team0Roster.innerHTML = renderRoster(team0Members, state.sessionId, 0);
     this.team1Roster.innerHTML = renderRoster(team1Members, state.sessionId, 1);
+    void this.renderInvite(state);
   }
 
   private getSelf(state: MultiplayerRoomSnapshot) {
     return state.members.find((member) => member.id === state.sessionId) ?? null;
+  }
+
+  private async renderInvite(state: MultiplayerRoomSnapshot): Promise<void> {
+    const inviteUrl = buildInviteUrl(state.roomId, window.location.origin, window.location.pathname);
+    this.latestInviteUrl = inviteUrl;
+    this.inviteUrlInput.value = inviteUrl;
+    this.inviteNote.textContent = state.visibility === "private"
+      ? "Private lobbies stay off the public room list. Share this URL, the native share sheet, or the QR code to bring other pilots in."
+      : "Public lobbies stay visible in the room browser, and this direct invite still drops friends into the same room.";
+    this.inviteQrMeta.textContent = `${state.visibility === "private" ? "Private" : "Public"} · ${state.maxPlayers} Max Players`;
+    this.copyInviteButton.disabled = false;
+    this.shareInviteButton.disabled = false;
+
+    try {
+      this.inviteQrImage.src = await QRCode.toDataURL(inviteUrl, {
+        margin: 1,
+        width: 140,
+        color: {
+          dark: "#06121d",
+          light: "#ffffff",
+        },
+      });
+    } catch {
+      this.inviteQrImage.removeAttribute("src");
+      this.inviteQrMeta.textContent = "QR generation unavailable";
+    }
+  }
+
+  private async copyInviteUrl(): Promise<void> {
+    if (!this.latestInviteUrl || !navigator.clipboard) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(this.latestInviteUrl);
+      this.setStatus("Invite URL copied to the clipboard.", "info");
+    } catch {
+      this.setStatus("Copy failed for the invite URL.", "error");
+    }
+  }
+
+  private async shareInviteUrl(): Promise<void> {
+    if (!this.latestInviteUrl) {
+      return;
+    }
+
+    if (typeof navigator.share === "function") {
+      try {
+        await navigator.share({
+          title: "Orbital Breach Invite",
+          text: "Join my Orbital Breach room.",
+          url: this.latestInviteUrl,
+        });
+        this.setStatus("Invite sent through the system share sheet.", "info");
+      } catch {
+        this.setStatus("Share cancelled or unavailable for this room invite.", "error");
+      }
+      return;
+    }
+
+    await this.copyInviteUrl();
   }
 
   private query<T extends HTMLElement>(selector: string): T {
@@ -888,6 +1054,32 @@ function buildMarkup(): string {
           <button id="mp-clear-bots" class="ob-mp-button ob-mp-button--clear">Humans Only</button>
           <button id="mp-settings" class="ob-mp-button ob-mp-button--settings">Settings</button>
           <button id="mp-leave" class="ob-mp-button ob-mp-button--leave">Main Menu</button>
+        </div>
+
+        <div class="ob-mp-invite">
+          <div class="ob-mp-invite-head">
+            <div>
+              <div class="ob-mp-card-label">Invite</div>
+              <div class="ob-mp-invite-title">Share This Room</div>
+            </div>
+            <div id="mp-invite-qr-meta" class="ob-mp-roster-meta">Waiting for room id</div>
+          </div>
+
+          <div class="ob-mp-invite-grid">
+            <div class="ob-mp-invite-main">
+              <span class="ob-mp-select-label">Direct URL</span>
+              <input id="mp-invite-url" class="ob-mp-invite-url" readonly />
+              <div class="ob-mp-invite-actions">
+                <button id="mp-copy-invite" class="ob-mp-button">Copy Link</button>
+                <button id="mp-share-invite" class="ob-mp-button">Share</button>
+              </div>
+              <div id="mp-invite-note" class="ob-mp-invite-note"></div>
+            </div>
+
+            <div class="ob-mp-qr-card">
+              <img id="mp-invite-qr" alt="Room invite QR code" />
+            </div>
+          </div>
         </div>
 
         <div style="display:none">

--- a/client/src/ui/roomBrowser.ts
+++ b/client/src/ui/roomBrowser.ts
@@ -1,0 +1,586 @@
+import { MATCH_TEAM_SIZES, type MatchTeamSize } from "../../../shared/match";
+import {
+  getMaxPlayersForTeamSize,
+  getRoomStatus,
+  getTeamSizeForMaxPlayers,
+  sanitizeRoomName,
+  type MultiplayerCreateRoomTarget,
+  type MultiplayerRoomDirectoryEntry,
+  type MultiplayerRoomVisibility,
+} from "../../../shared/multiplayer";
+import { fetchPublicRoomDirectory } from "../net/roomDirectory";
+import { injectDesignTokens } from "./designTokens";
+
+const MAX_PLAYER_OPTIONS = MATCH_TEAM_SIZES.map((teamSize) => getMaxPlayersForTeamSize(teamSize));
+
+const CSS = `
+  .ob-rb-root {
+    position: fixed;
+    inset: 0;
+    z-index: 360;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 18px;
+    background: rgba(2, 6, 16, 0.78);
+    backdrop-filter: blur(16px);
+    color: #ebf7ff;
+  }
+
+  .ob-rb-root * {
+    box-sizing: border-box;
+  }
+
+  .ob-rb-shell {
+    width: min(1100px, calc(100vw - 28px));
+    max-height: calc(100dvh - 28px);
+    overflow: auto;
+    padding: 22px;
+    border: 1px solid rgba(210, 220, 240, 0.16);
+    background:
+      radial-gradient(circle at top left, rgba(127, 252, 255, 0.08), rgba(127, 252, 255, 0) 22%),
+      radial-gradient(circle at bottom right, rgba(255, 125, 248, 0.08), rgba(255, 125, 248, 0) 26%),
+      rgba(6, 10, 20, 0.96);
+    box-shadow: 0 26px 72px rgba(0, 0, 0, 0.45);
+  }
+
+  .ob-rb-topbar,
+  .ob-rb-panel,
+  .ob-rb-room {
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .ob-rb-topbar {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px 18px;
+    margin-bottom: 16px;
+  }
+
+  .ob-rb-kicker,
+  .ob-rb-meta,
+  .ob-rb-label,
+  .ob-rb-button,
+  .ob-rb-field input,
+  .ob-rb-field select,
+  .ob-rb-status,
+  .ob-rb-badge,
+  .ob-rb-empty {
+    font-family: "JetBrains Mono", monospace;
+    text-transform: uppercase;
+  }
+
+  .ob-rb-kicker,
+  .ob-rb-label,
+  .ob-rb-meta,
+  .ob-rb-status {
+    color: #9aa5b8;
+    font-size: 11px;
+    letter-spacing: 0.12em;
+  }
+
+  .ob-rb-title {
+    margin-top: 8px;
+    font-size: clamp(30px, 4vw, 42px);
+    font-family: "Cormorant Garamond", serif;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .ob-rb-copy {
+    margin-top: 8px;
+    max-width: 560px;
+    color: #d6edf5;
+    line-height: 1.55;
+  }
+
+  .ob-rb-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: flex-start;
+    justify-content: flex-end;
+  }
+
+  .ob-rb-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.9fr);
+    gap: 16px;
+  }
+
+  .ob-rb-panel {
+    padding: 16px;
+  }
+
+  .ob-rb-panel-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: baseline;
+  }
+
+  .ob-rb-panel-title {
+    font-size: 22px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .ob-rb-status {
+    margin-top: 12px;
+    min-height: 18px;
+  }
+
+  .ob-rb-room-list {
+    display: grid;
+    gap: 12px;
+    margin-top: 14px;
+  }
+
+  .ob-rb-room {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 12px;
+    padding: 14px;
+  }
+
+  .ob-rb-room-head {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: baseline;
+  }
+
+  .ob-rb-room-name {
+    font-size: 20px;
+    font-family: "Cormorant Garamond", serif;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .ob-rb-room-meta {
+    margin-top: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .ob-rb-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 28px;
+    padding: 0 10px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+  }
+
+  .ob-rb-badge--open {
+    color: #dffcff;
+    border-color: rgba(127, 252, 255, 0.22);
+    background: rgba(127, 252, 255, 0.08);
+  }
+
+  .ob-rb-badge--busy {
+    color: #ffd8b2;
+    border-color: rgba(255, 190, 140, 0.22);
+    background: rgba(255, 190, 140, 0.08);
+  }
+
+  .ob-rb-room-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: stretch;
+    min-width: 156px;
+  }
+
+  .ob-rb-empty {
+    margin-top: 14px;
+    padding: 18px;
+    border: 1px dashed rgba(255, 255, 255, 0.12);
+    color: #c9d5e8;
+    letter-spacing: 0.08em;
+  }
+
+  .ob-rb-form {
+    display: grid;
+    gap: 14px;
+    margin-top: 16px;
+  }
+
+  .ob-rb-field {
+    display: grid;
+    gap: 6px;
+  }
+
+  .ob-rb-field input,
+  .ob-rb-field select {
+    min-height: 44px;
+    padding: 0 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: #effcff;
+    outline: none;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+  }
+
+  .ob-rb-field select option {
+    color: #effcff;
+    background: #071019;
+  }
+
+  .ob-rb-button {
+    min-height: 44px;
+    padding: 0 14px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: #effcff;
+    cursor: pointer;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    transition: transform 0.14s ease, border-color 0.18s ease, background 0.18s ease;
+  }
+
+  .ob-rb-button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    border-color: rgba(255, 255, 255, 0.24);
+    background: rgba(255, 255, 255, 0.07);
+  }
+
+  .ob-rb-button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .ob-rb-button--primary {
+    border-color: rgba(127, 252, 255, 0.26);
+    background: rgba(127, 252, 255, 0.08);
+  }
+
+  .ob-rb-button--danger {
+    border-color: rgba(255, 125, 248, 0.28);
+  }
+
+  .ob-rb-button--wide {
+    width: 100%;
+  }
+
+  .ob-rb-invite {
+    margin-top: 14px;
+    padding: 14px;
+    border: 1px solid rgba(127, 252, 255, 0.16);
+    background: rgba(127, 252, 255, 0.05);
+  }
+
+  .ob-rb-invite-copy {
+    margin-top: 8px;
+    color: #d8f7ff;
+    line-height: 1.5;
+  }
+
+  .ob-rb-invite-code {
+    margin-top: 10px;
+    font-size: 12px;
+    color: #7ffcff;
+    letter-spacing: 0.12em;
+  }
+
+  @media (max-width: 880px) {
+    .ob-rb-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .ob-rb-room {
+      grid-template-columns: 1fr;
+    }
+
+    .ob-rb-room-actions,
+    .ob-rb-actions {
+      justify-content: flex-start;
+    }
+  }
+`;
+
+export class RoomBrowser {
+  private readonly root: HTMLDivElement;
+  private readonly status: HTMLDivElement;
+  private readonly roomList: HTMLDivElement;
+  private readonly inviteCard: HTMLDivElement;
+  private readonly roomNameInput: HTMLInputElement;
+  private readonly visibilitySelect: HTMLSelectElement;
+  private readonly maxPlayersSelect: HTMLSelectElement;
+  private readonly createButton: HTMLButtonElement;
+  private readonly refreshButton: HTMLButtonElement;
+  private inviteRoomId: string | null = null;
+
+  public onJoinRoom: ((roomId: string) => void) | null = null;
+  public onCreateRoom: ((target: MultiplayerCreateRoomTarget) => void) | null = null;
+  public onClose: (() => void) | null = null;
+
+  public constructor() {
+    injectStyle();
+
+    this.root = document.createElement("div");
+    this.root.className = "ob-rb-root";
+    this.root.innerHTML = buildMarkup();
+    document.body.appendChild(this.root);
+
+    this.status = this.query("#rb-status");
+    this.roomList = this.query("#rb-room-list");
+    this.inviteCard = this.query("#rb-invite");
+    this.roomNameInput = this.query("#rb-room-name");
+    this.visibilitySelect = this.query("#rb-visibility");
+    this.maxPlayersSelect = this.query("#rb-max-players");
+    this.createButton = this.query("#rb-create");
+    this.refreshButton = this.query("#rb-refresh");
+
+    this.maxPlayersSelect.innerHTML = MAX_PLAYER_OPTIONS
+      .map((players) => `<option value="${players}">${players} Players</option>`)
+      .join("");
+
+    this.query<HTMLButtonElement>("#rb-close").addEventListener("click", () => {
+      this.hide();
+      this.onClose?.();
+    });
+    this.refreshButton.addEventListener("click", () => {
+      void this.refresh();
+    });
+    this.createButton.addEventListener("click", () => {
+      this.handleCreate();
+    });
+    this.inviteCard.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      if (target.closest("[data-join-invite]") && this.inviteRoomId) {
+        this.onJoinRoom?.(this.inviteRoomId);
+      }
+    });
+    this.roomList.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      const button = target.closest<HTMLButtonElement>("[data-room-id]");
+      const roomId = button?.dataset["roomId"];
+      if (roomId) {
+        this.onJoinRoom?.(roomId);
+      }
+    });
+  }
+
+  public async show(options?: { inviteRoomId?: string | null; defaultTeamSize?: MatchTeamSize }): Promise<void> {
+    this.inviteRoomId = options?.inviteRoomId?.trim() || null;
+    if (options?.defaultTeamSize) {
+      this.maxPlayersSelect.value = String(getMaxPlayersForTeamSize(options.defaultTeamSize));
+    }
+
+    this.renderInviteCard();
+    this.root.style.display = "flex";
+    await this.refresh();
+  }
+
+  public hide(): void {
+    this.root.style.display = "none";
+    this.setStatus("");
+  }
+
+  private async refresh(): Promise<void> {
+    this.refreshButton.disabled = true;
+    this.roomList.innerHTML = `<div class="ob-rb-empty">Refreshing room directory...</div>`;
+    this.setStatus("Fetching public lobbies...");
+
+    try {
+      const rooms = await fetchPublicRoomDirectory();
+      this.renderRoomList(rooms);
+      this.setStatus(rooms.length > 0 ? "Public rooms updated." : "No public rooms are currently advertised.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Room directory request failed.";
+      this.roomList.innerHTML = `<div class="ob-rb-empty">${escapeHtml(message)}</div>`;
+      this.setStatus(message);
+    } finally {
+      this.refreshButton.disabled = false;
+    }
+  }
+
+  private handleCreate(): void {
+    const teamSize = getTeamSizeForMaxPlayers(Number(this.maxPlayersSelect.value));
+    if (!teamSize) {
+      this.setStatus("Choose a supported player cap before creating a room.");
+      return;
+    }
+
+    const visibility = this.visibilitySelect.value === "private" ? "private" : "public";
+    this.onCreateRoom?.({
+      kind: "create",
+      listing: "browser",
+      visibility,
+      roomName: sanitizeRoomName(this.roomNameInput.value),
+      teamSize,
+    });
+  }
+
+  private renderInviteCard(): void {
+    if (!this.inviteRoomId) {
+      this.inviteCard.style.display = "none";
+      this.inviteCard.innerHTML = "";
+      return;
+    }
+
+    this.inviteCard.style.display = "block";
+    this.inviteCard.innerHTML = `
+      <div class="ob-rb-label">Invite Link Detected</div>
+      <div class="ob-rb-invite-copy">
+        A direct room invite is active in this URL. Join the targeted lobby immediately or browse the public list first.
+      </div>
+      <div class="ob-rb-invite-code">${escapeHtml(this.inviteRoomId)}</div>
+      <div class="ob-rb-actions" style="margin-top:12px;justify-content:flex-start;">
+        <button class="ob-rb-button ob-rb-button--primary" data-join-invite>Join Invite</button>
+      </div>
+    `;
+  }
+
+  private renderRoomList(rooms: MultiplayerRoomDirectoryEntry[]): void {
+    if (rooms.length === 0) {
+      this.roomList.innerHTML = `<div class="ob-rb-empty">No public custom rooms are currently available. Create one to start the directory.</div>`;
+      return;
+    }
+
+    this.roomList.innerHTML = rooms.map((room) => renderRoomCard(room)).join("");
+  }
+
+  private setStatus(text: string): void {
+    this.status.textContent = text;
+  }
+
+  private query<T extends HTMLElement>(selector: string): T {
+    return this.root.querySelector<T>(selector) as T;
+  }
+}
+
+function injectStyle(): void {
+  injectDesignTokens();
+  if (document.getElementById("orbital-room-browser-style")) {
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.id = "orbital-room-browser-style";
+  style.textContent = CSS;
+  document.head.appendChild(style);
+}
+
+function buildMarkup(): string {
+  return `
+    <div class="ob-rb-shell">
+      <div class="ob-rb-topbar">
+        <div>
+          <div class="ob-rb-kicker">Server Browser</div>
+          <div class="ob-rb-title">Rooms & Invites</div>
+          <div class="ob-rb-copy">
+            Browse public custom lobbies, create your own room, or join a direct invite without losing the existing quick-join flow.
+          </div>
+        </div>
+
+        <div class="ob-rb-actions">
+          <button id="rb-refresh" class="ob-rb-button">Refresh</button>
+          <button id="rb-close" class="ob-rb-button ob-rb-button--danger">Close</button>
+        </div>
+      </div>
+
+      <div class="ob-rb-grid">
+        <section class="ob-rb-panel">
+          <div class="ob-rb-panel-head">
+            <div>
+              <div class="ob-rb-kicker">Public Rooms</div>
+              <div class="ob-rb-panel-title">Join A Lobby</div>
+            </div>
+            <div id="rb-status" class="ob-rb-status"></div>
+          </div>
+
+          <div id="rb-invite" class="ob-rb-invite" style="display:none"></div>
+          <div id="rb-room-list" class="ob-rb-room-list"></div>
+        </section>
+
+        <section class="ob-rb-panel">
+          <div class="ob-rb-kicker">Create Room</div>
+          <div class="ob-rb-panel-title">Advertise Or Go Private</div>
+
+          <div class="ob-rb-form">
+            <label class="ob-rb-field">
+              <span class="ob-rb-label">Room Name</span>
+              <input id="rb-room-name" maxlength="24" value="Orbital Lobby" />
+            </label>
+
+            <label class="ob-rb-field">
+              <span class="ob-rb-label">Visibility</span>
+              <select id="rb-visibility">
+                <option value="public">Public Listing</option>
+                <option value="private">Private Invite Only</option>
+              </select>
+            </label>
+
+            <label class="ob-rb-field">
+              <span class="ob-rb-label">Max Players</span>
+              <select id="rb-max-players"></select>
+            </label>
+
+            <button id="rb-create" class="ob-rb-button ob-rb-button--primary ob-rb-button--wide">Create Room</button>
+          </div>
+        </section>
+      </div>
+    </div>
+  `;
+}
+
+function renderRoomCard(room: MultiplayerRoomDirectoryEntry): string {
+  const status = getRoomStatus(room.phase, room.currentPlayers, room.maxPlayers, !room.joinable);
+  const badgeClass = room.joinable ? "ob-rb-badge ob-rb-badge--open" : "ob-rb-badge ob-rb-badge--busy";
+
+  return `
+    <div class="ob-rb-room">
+      <div>
+        <div class="ob-rb-room-head">
+          <div class="ob-rb-room-name">${escapeHtml(room.roomName)}</div>
+          <span class="${badgeClass}">${escapeHtml(status)}</span>
+        </div>
+        <div class="ob-rb-room-meta">
+          <span class="ob-rb-badge">${room.currentPlayers}/${room.maxPlayers} Players</span>
+          <span class="ob-rb-badge">${room.teamSize}v${room.teamSize}</span>
+          <span class="ob-rb-badge">${escapeHtml(room.roomId)}</span>
+        </div>
+      </div>
+
+      <div class="ob-rb-room-actions">
+        <button class="ob-rb-button ${room.joinable ? "ob-rb-button--primary" : ""}" data-room-id="${escapeHtml(room.roomId)}" ${room.joinable ? "" : "disabled"}>
+          ${room.joinable ? "Join Room" : "Unavailable"}
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+function escapeHtml(raw: string): string {
+  return raw.replace(/[&<>\"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case "\"":
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return char;
+    }
+  });
+}

--- a/server/src/colyseus/OrbitalLobbyRoom.ts
+++ b/server/src/colyseus/OrbitalLobbyRoom.ts
@@ -3,18 +3,22 @@ import {
   buildBotName,
   canJoinMultiplayerRoom,
   canStartLobbyRound,
+  getMaxPlayersForTeamSize,
   getPreferredJoinTeam,
   isMatchTeamSizeValue,
   MULTIPLAYER_COUNTDOWN_SECONDS,
   MULTIPLAYER_DEFAULT_TEAM_SIZE,
   MULTIPLAYER_ROUND_END_SECONDS,
   MULTIPLAYER_ROUND_SECONDS,
+  sanitizeRoomName,
   type BreachReportMessage,
   type FillBotsMessage,
   type FreezeEventMessage,
   type HitReportMessage,
   type LobbyTeam,
+  type MultiplayerRoomListing,
   type MultiplayerRoomPhase,
+  type MultiplayerRoomVisibility,
   type PlayerUpdateMessage,
   type RoundResultEventMessage,
   type SetReadyMessage,
@@ -40,6 +44,7 @@ import {
 import type { PlayerPhase } from "../../../shared/schema";
 import { generateSpawnPositions, resolveActorCollisions, type CollisionBody } from "../../../shared/player-logic";
 import { applyHitToOnlineActor, isHitZone, normalizeAuthoritativePhase } from "./actorDamage";
+import type { OrbitalRoomMetadata } from "./roomDirectory";
 import { ActorState, LobbyMemberState, OrbitalLobbyState } from "./state";
 
 type RoomClient = Client;
@@ -52,6 +57,13 @@ const VEL_CLAMP = MAX_SPEED * 4;
 const PLAYER_UPDATE_MIN_MS = 40;
 
 const VALID_PHASES = new Set<string>(["BREACH", "FLOATING", "GRABBING", "AIMING", "FROZEN", "RESPAWNING"]);
+
+interface OrbitalLobbyCreateOptions {
+  roomName?: string;
+  listing?: MultiplayerRoomListing;
+  visibility?: MultiplayerRoomVisibility;
+  teamSize?: MatchTeamSize;
+}
 
 export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
   public maxClients = 32;
@@ -71,10 +83,23 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
   private countdownPreparedRound = false;
   private roundResolved = false;
   private lastPlayerUpdate = new Map<string, number>();
+  private listing: MultiplayerRoomListing = "quick";
+  private visibility: MultiplayerRoomVisibility = "public";
 
-  public onCreate(): void {
+  public onCreate(options?: OrbitalLobbyCreateOptions): void {
     this.state = new OrbitalLobbyState();
-    this.state.teamSize = MULTIPLAYER_DEFAULT_TEAM_SIZE;
+    this.listing = options?.listing === "browser" ? "browser" : "quick";
+    this.visibility = options?.visibility === "private" ? "private" : "public";
+    this.state.roomName = sanitizeRoomName(options?.roomName);
+    this.state.listing = this.listing;
+    this.state.visibility = this.visibility;
+    this.state.teamSize = isMatchTeamSizeValue(Number(options?.teamSize))
+      ? Number(options?.teamSize)
+      : MULTIPLAYER_DEFAULT_TEAM_SIZE;
+    this.state.maxPlayers = getMaxPlayersForTeamSize(this.state.teamSize as MatchTeamSize);
+    this.maxClients = this.state.maxPlayers;
+    void this.setPrivate(this.visibility === "private");
+    void this.refreshRoomMetadata();
 
     this.onMessage("ready", (client, message: SetReadyMessage) => {
       this.handleReadyMessage(client, message);
@@ -229,6 +254,8 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     }
 
     this.state.teamSize = nextTeamSize;
+    this.state.maxPlayers = getMaxPlayersForTeamSize(nextTeamSize);
+    this.maxClients = this.state.maxPlayers;
     this.trimBotsToTeamSize();
     this.syncLobbyFlow();
   }
@@ -356,6 +383,8 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
   // ── Round flow ──────────────────────────────────────────────────────────────
 
   private syncLobbyFlow(): void {
+    void this.refreshRoomMetadata();
+
     if (this.state.phase === "ROUND_END") {
       return;
     }
@@ -385,6 +414,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     this.state.phase = "COUNTDOWN";
     this.state.countdownRemaining = MULTIPLAYER_COUNTDOWN_SECONDS;
     void this.lock();
+    void this.refreshRoomMetadata();
 
     this.countdownTimer = setInterval(() => {
       this.state.countdownRemaining = Math.max(0, this.state.countdownRemaining - 1);
@@ -402,6 +432,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     this.state.countdownRemaining = 0;
     this.state.roundTimeRemaining = 0;
     void this.unlock();
+    void this.refreshRoomMetadata();
   }
 
   private prepareCountdownRound(): void {
@@ -425,6 +456,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     this.state.countdownRemaining = 0;
     this.state.roundTimeRemaining = MULTIPLAYER_ROUND_SECONDS;
     this.roundResolved = false;
+    void this.refreshRoomMetadata();
 
     this.roundTimer = setInterval(() => {
       this.state.roundTimeRemaining = Math.max(0, this.state.roundTimeRemaining - 1);
@@ -458,6 +490,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     this.state.phase = "ROUND_END";
     this.state.countdownRemaining = 0;
     this.state.roundTimeRemaining = 0;
+    void this.refreshRoomMetadata();
 
     this.roundEndTimer = setTimeout(() => {
       this.roundEndTimer = null;
@@ -483,6 +516,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
         });
       }
       void this.unlock();
+      void this.refreshRoomMetadata();
       this.syncLobbyFlow();
     }, MULTIPLAYER_ROUND_END_SECONDS * 1000);
   }
@@ -960,6 +994,20 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
 
   private sendError(client: RoomClient, text: string): void {
     client.send("lobby_event", { type: "error", text });
+  }
+
+  private async refreshRoomMetadata(): Promise<void> {
+    const metadata: OrbitalRoomMetadata = {
+      roomName: this.state.roomName,
+      listing: this.listing,
+      visibility: this.visibility,
+      phase: this.state.phase as MultiplayerRoomPhase,
+      currentPlayers: this.clients.length,
+      maxPlayers: this.state.maxPlayers,
+      teamSize: this.state.teamSize,
+    };
+
+    await this.setMetadata(metadata);
   }
 }
 

--- a/server/src/colyseus/roomDirectory.ts
+++ b/server/src/colyseus/roomDirectory.ts
@@ -1,0 +1,117 @@
+import {
+  canJoinMultiplayerRoom,
+  getMaxPlayersForTeamSize,
+  getRoomStatus,
+  isMatchTeamSizeValue,
+  MULTIPLAYER_BROWSER_ROOM_NAME,
+  MULTIPLAYER_DEFAULT_TEAM_SIZE,
+  type MultiplayerRoomDirectoryEntry,
+  type MultiplayerRoomListing,
+  type MultiplayerRoomPhase,
+  type MultiplayerRoomVisibility,
+} from "../../../shared/multiplayer";
+
+type UnknownRecord = Record<string, unknown>;
+
+export function buildPublicRoomDirectory(rooms: unknown[]): MultiplayerRoomDirectoryEntry[] {
+  return rooms
+    .map((room) => toDirectoryEntry(room))
+    .filter((room): room is MultiplayerRoomDirectoryEntry => room !== null)
+    .sort(compareDirectoryEntries);
+}
+
+function toDirectoryEntry(raw: unknown): MultiplayerRoomDirectoryEntry | null {
+  const room = asRecord(raw);
+  if (!room) {
+    return null;
+  }
+
+  const metadata = asRecord(room.metadata);
+  if (!metadata) {
+    return null;
+  }
+
+  if (room.name !== MULTIPLAYER_BROWSER_ROOM_NAME) {
+    return null;
+  }
+
+  const listing = metadata.listing;
+  if (listing !== "browser") {
+    return null;
+  }
+
+  const visibility = metadata.visibility === "private" ? "private" : "public";
+  if (visibility !== "public") {
+    return null;
+  }
+
+  const teamSize = getTeamSize(metadata.teamSize);
+  const maxPlayers = getPositiveInt(metadata.maxPlayers) ?? getMaxPlayersForTeamSize(teamSize);
+  const currentPlayers = getPositiveInt(metadata.currentPlayers) ?? getPositiveInt(room.clients) ?? 0;
+  const phase = toPhase(metadata.phase);
+  const locked = Boolean(room.locked);
+  const joinable = canJoinMultiplayerRoom(phase) && !locked && currentPlayers < maxPlayers;
+
+  return {
+    roomId: String(room.roomId ?? ""),
+    roomName: String(metadata.roomName ?? "Orbital Lobby"),
+    phase,
+    status: getRoomStatus(phase, currentPlayers, maxPlayers, locked),
+    listing,
+    visibility,
+    currentPlayers,
+    maxPlayers,
+    teamSize,
+    joinable,
+  };
+}
+
+function getTeamSize(raw: unknown) {
+  const value = Number(raw);
+  return isMatchTeamSizeValue(value) ? value : MULTIPLAYER_DEFAULT_TEAM_SIZE;
+}
+
+function toPhase(raw: unknown): MultiplayerRoomPhase {
+  switch (raw) {
+    case "COUNTDOWN":
+    case "PLAYING":
+    case "ROUND_END":
+      return raw;
+    default:
+      return "LOBBY";
+  }
+}
+
+function getPositiveInt(raw: unknown): number | null {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return Math.floor(value);
+}
+
+function asRecord(raw: unknown): UnknownRecord | null {
+  return raw && typeof raw === "object" ? raw as UnknownRecord : null;
+}
+
+function compareDirectoryEntries(a: MultiplayerRoomDirectoryEntry, b: MultiplayerRoomDirectoryEntry): number {
+  if (a.joinable !== b.joinable) {
+    return a.joinable ? -1 : 1;
+  }
+
+  if (a.currentPlayers !== b.currentPlayers) {
+    return b.currentPlayers - a.currentPlayers;
+  }
+
+  return a.roomName.localeCompare(b.roomName);
+}
+
+export interface OrbitalRoomMetadata {
+  roomName: string;
+  listing: MultiplayerRoomListing;
+  visibility: MultiplayerRoomVisibility;
+  phase: MultiplayerRoomPhase;
+  currentPlayers: number;
+  maxPlayers: number;
+  teamSize: number;
+}

--- a/server/src/colyseus/state.ts
+++ b/server/src/colyseus/state.ts
@@ -34,6 +34,9 @@ export class ActorState extends Schema {
 }
 
 export class OrbitalLobbyState extends Schema {
+  public roomName = "Orbital Lobby";
+  public visibility = "public";
+  public listing = "quick";
   public phase = "LOBBY";
   public matchComplete = false;
   public countdownRemaining = 0;
@@ -41,6 +44,7 @@ export class OrbitalLobbyState extends Schema {
   public scoreTeam0 = 0;
   public scoreTeam1 = 0;
   public teamSize = 5;
+  public maxPlayers = 10;
   public roundNumber = 0;
   public members = new MapSchema<LobbyMemberState>();
   public actors = new MapSchema<ActorState>();
@@ -80,6 +84,9 @@ defineTypes(ActorState, {
 });
 
 defineTypes(OrbitalLobbyState, {
+  roomName: "string",
+  visibility: "string",
+  listing: "string",
   phase: "string",
   matchComplete: "boolean",
   countdownRemaining: "number",
@@ -87,6 +94,7 @@ defineTypes(OrbitalLobbyState, {
   scoreTeam0: "number",
   scoreTeam1: "number",
   teamSize: "number",
+  maxPlayers: "number",
   roundNumber: "number",
   members: { map: LobbyMemberState },
   actors: { map: ActorState },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,11 +1,12 @@
-import { Server } from "@colyseus/core";
+import { matchMaker, Server } from "@colyseus/core";
 import { WebSocketTransport } from "@colyseus/ws-transport";
 import cors from "cors";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import type { ErrorRequestHandler, Request, Response } from "express";
-import { MULTIPLAYER_ROOM_NAME } from "../../shared/multiplayer";
+import { MULTIPLAYER_BROWSER_ROOM_NAME, MULTIPLAYER_ROOM_NAME } from "../../shared/multiplayer";
 import { OrbitalLobbyRoom } from "./colyseus/OrbitalLobbyRoom";
+import { buildPublicRoomDirectory } from "./colyseus/roomDirectory";
 
 const PORT = Number(process.env.PORT || 2567);
 const NODE_ENV = process.env.NODE_ENV ?? "development";
@@ -79,6 +80,17 @@ async function main(): Promise<void> {
       app.get("/wake", probeLimiter, (_req: Request, res: Response) => {
         res.json(probePayload());
       });
+      app.get("/rooms", probeLimiter, async (_req: Request, res: Response, next) => {
+        try {
+          const rooms = await matchMaker.query({ name: MULTIPLAYER_BROWSER_ROOM_NAME });
+          res.json({
+            ok: true,
+            rooms: buildPublicRoomDirectory(rooms as unknown[]),
+          });
+        } catch (error) {
+          next(error);
+        }
+      });
 
       const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
         if (!IS_PROD) console.error(err);
@@ -94,6 +106,7 @@ async function main(): Promise<void> {
   // Do not mount @colyseus/monitor in production without auth; it exposes
   // room state, client list, and admin actions to anyone with the URL.
   gameServer.define(MULTIPLAYER_ROOM_NAME, OrbitalLobbyRoom);
+  gameServer.define(MULTIPLAYER_BROWSER_ROOM_NAME, OrbitalLobbyRoom);
   await gameServer.listen(PORT);
 
   console.log(`Colyseus listening on port ${PORT}`);

--- a/shared/multiplayer.ts
+++ b/shared/multiplayer.ts
@@ -2,16 +2,36 @@ import { MATCH_TEAM_SIZES, type MatchTeamSize } from "./match";
 import type { HitZone } from "./player-logic";
 
 export const MULTIPLAYER_ROOM_NAME = "orbital_lobby";
+export const MULTIPLAYER_BROWSER_ROOM_NAME = "orbital_browser_lobby";
 export const MULTIPLAYER_COUNTDOWN_SECONDS = 5;
 export const MULTIPLAYER_ROUND_SECONDS = 120;
 export const MULTIPLAYER_ROUND_END_SECONDS = 4;
 export const MULTIPLAYER_DEFAULT_TEAM_SIZE: MatchTeamSize = 5;
+export const MULTIPLAYER_INVITE_PARAM = "roomId";
+export const MULTIPLAYER_ROOM_NAME_MAX_LENGTH = 24;
 
 export type MultiplayerRoomPhase = "LOBBY" | "COUNTDOWN" | "PLAYING" | "ROUND_END";
 export type LobbyTeam = 0 | 1;
+export type MultiplayerRoomListing = "quick" | "browser";
+export type MultiplayerRoomVisibility = "public" | "private";
+export type MultiplayerRoomStatus = "Lobby Open" | "Full" | "Countdown" | "Live" | "Round End";
+
+export interface MultiplayerCreateRoomTarget {
+  kind: "create";
+  roomName: string;
+  listing: MultiplayerRoomListing;
+  visibility: MultiplayerRoomVisibility;
+  teamSize: MatchTeamSize;
+}
+
+export type MultiplayerJoinTarget =
+  | { kind: "quick" }
+  | { kind: "roomId"; roomId: string }
+  | MultiplayerCreateRoomTarget;
 
 export interface MultiplayerJoinOptions {
   name: string;
+  target?: MultiplayerJoinTarget;
 }
 
 export interface LobbyMemberSnapshot {
@@ -47,10 +67,13 @@ export interface OnlineActorSnapshot {
 
 export interface MultiplayerRoomSnapshot {
   roomId: string;
+  roomName: string;
   sessionId: string;
   selfTeam: LobbyTeam;
   phase: MultiplayerRoomPhase;
   matchComplete: boolean;
+  visibility: MultiplayerRoomVisibility;
+  listing: MultiplayerRoomListing;
   countdownRemaining: number;
   roundTimeRemaining: number;
   score: {
@@ -59,8 +82,22 @@ export interface MultiplayerRoomSnapshot {
   };
   roundNumber: number;
   teamSize: MatchTeamSize;
+  maxPlayers: number;
   members: LobbyMemberSnapshot[];
   actors: OnlineActorSnapshot[];
+}
+
+export interface MultiplayerRoomDirectoryEntry {
+  roomId: string;
+  roomName: string;
+  phase: MultiplayerRoomPhase;
+  status: MultiplayerRoomStatus;
+  listing: MultiplayerRoomListing;
+  visibility: MultiplayerRoomVisibility;
+  currentPlayers: number;
+  maxPlayers: number;
+  teamSize: MatchTeamSize;
+  joinable: boolean;
 }
 
 export interface PlayerUpdateMessage {
@@ -218,4 +255,57 @@ export function buildBotName(botIndex: number, team: LobbyTeam): string {
 
 export function canJoinMultiplayerRoom(phase: MultiplayerRoomPhase): boolean {
   return phase === "LOBBY";
+}
+
+export function getMaxPlayersForTeamSize(teamSize: MatchTeamSize): number {
+  return teamSize * 2;
+}
+
+export function getTeamSizeForMaxPlayers(maxPlayers: number): MatchTeamSize | null {
+  if (maxPlayers % 2 !== 0) {
+    return null;
+  }
+
+  const teamSize = maxPlayers / 2;
+  return isMatchTeamSizeValue(teamSize) ? teamSize : null;
+}
+
+export function getRoomStatus(
+  phase: MultiplayerRoomPhase,
+  currentPlayers: number,
+  maxPlayers: number,
+  locked = false,
+): MultiplayerRoomStatus {
+  switch (phase) {
+    case "COUNTDOWN":
+      return "Countdown";
+    case "PLAYING":
+      return "Live";
+    case "ROUND_END":
+      return "Round End";
+    case "LOBBY":
+    default:
+      return locked || currentPlayers >= maxPlayers ? "Full" : "Lobby Open";
+  }
+}
+
+export function sanitizeRoomName(raw: string | null | undefined): string {
+  const value = String(raw ?? "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .slice(0, MULTIPLAYER_ROOM_NAME_MAX_LENGTH);
+
+  return value || "Orbital Lobby";
+}
+
+export function getInviteRoomIdFromSearch(search: string): string | null {
+  const params = new URLSearchParams(search);
+  const roomId = params.get(MULTIPLAYER_INVITE_PARAM)?.trim();
+  return roomId ? roomId : null;
+}
+
+export function buildInviteUrl(roomId: string, origin: string, pathname = "/"): string {
+  const url = new URL(pathname, origin);
+  url.searchParams.set(MULTIPLAYER_INVITE_PARAM, roomId);
+  return url.toString();
 }

--- a/tests/roomDirectory.test.ts
+++ b/tests/roomDirectory.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { buildPublicRoomDirectory } from "../server/src/colyseus/roomDirectory";
+import {
+  buildInviteUrl,
+  getInviteRoomIdFromSearch,
+  getMaxPlayersForTeamSize,
+  getRoomStatus,
+  getTeamSizeForMaxPlayers,
+  MULTIPLAYER_BROWSER_ROOM_NAME,
+} from "../shared/multiplayer";
+
+describe("buildPublicRoomDirectory", () => {
+  it("includes only public browser rooms and preserves joinable lobby rooms", () => {
+    const rooms = buildPublicRoomDirectory([
+      {
+        roomId: "browser-open",
+        name: MULTIPLAYER_BROWSER_ROOM_NAME,
+        locked: false,
+        clients: 3,
+        metadata: {
+          listing: "browser",
+          visibility: "public",
+          roomName: "Dock Ring",
+          phase: "LOBBY",
+          currentPlayers: 3,
+          maxPlayers: 10,
+          teamSize: 5,
+        },
+      },
+      {
+        roomId: "browser-live",
+        name: MULTIPLAYER_BROWSER_ROOM_NAME,
+        locked: true,
+        clients: 10,
+        metadata: {
+          listing: "browser",
+          visibility: "public",
+          roomName: "Hot Zone",
+          phase: "PLAYING",
+          currentPlayers: 10,
+          maxPlayers: 10,
+          teamSize: 5,
+        },
+      },
+      {
+        roomId: "private-room",
+        name: MULTIPLAYER_BROWSER_ROOM_NAME,
+        locked: false,
+        clients: 1,
+        metadata: {
+          listing: "browser",
+          visibility: "private",
+          roomName: "Quiet Hangar",
+          phase: "LOBBY",
+          currentPlayers: 1,
+          maxPlayers: 4,
+          teamSize: 2,
+        },
+      },
+      {
+        roomId: "quick-room",
+        name: "orbital_lobby",
+        locked: false,
+        clients: 2,
+        metadata: {
+          listing: "quick",
+          visibility: "public",
+          roomName: "Quick Match",
+          phase: "LOBBY",
+          currentPlayers: 2,
+          maxPlayers: 10,
+          teamSize: 5,
+        },
+      },
+    ]);
+
+    expect(rooms).toHaveLength(2);
+    expect(rooms[0]).toMatchObject({
+      roomId: "browser-open",
+      roomName: "Dock Ring",
+      joinable: true,
+      status: "Lobby Open",
+    });
+    expect(rooms[1]).toMatchObject({
+      roomId: "browser-live",
+      roomName: "Hot Zone",
+      joinable: false,
+      status: "Live",
+    });
+  });
+});
+
+describe("multiplayer invite and cap helpers", () => {
+  it("maps team sizes to total caps and back", () => {
+    expect(getMaxPlayersForTeamSize(5)).toBe(10);
+    expect(getTeamSizeForMaxPlayers(10)).toBe(5);
+    expect(getTeamSizeForMaxPlayers(7)).toBeNull();
+  });
+
+  it("builds and parses direct invite URLs", () => {
+    const url = buildInviteUrl("abc123", "https://orbital-breach.vercel.app", "/");
+    expect(url).toBe("https://orbital-breach.vercel.app/?roomId=abc123");
+    expect(getInviteRoomIdFromSearch("?roomId=abc123")).toBe("abc123");
+    expect(getInviteRoomIdFromSearch("")).toBeNull();
+  });
+
+  it("derives room status from phase and availability", () => {
+    expect(getRoomStatus("LOBBY", 2, 10, false)).toBe("Lobby Open");
+    expect(getRoomStatus("LOBBY", 10, 10, true)).toBe("Full");
+    expect(getRoomStatus("COUNTDOWN", 10, 10, true)).toBe("Countdown");
+    expect(getRoomStatus("PLAYING", 10, 10, true)).toBe("Live");
+    expect(getRoomStatus("ROUND_END", 10, 10, true)).toBe("Round End");
+  });
+});


### PR DESCRIPTION
## Summary
- add a separate browser-based room pool alongside the existing quick-join lobby so default auto-join behavior remains intact
- expose public room directory data from the Colyseus server and add client flows for browsing, creating, and joining public/private rooms by invite
- add in-lobby invite sharing with direct URL, native share fallback, and QR generation, plus targeted room-directory tests

## Validation
- `npm run build` (`client/`)
- `npm run build` (`server/`)
- `npx vitest run`
- live smoke against the built server covering public room listing, join-by-id, private room hiding, and unchanged quick-join behavior