### PR TITLE
[codex] Add Vercel Web Analytics landing attribution

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@colyseus/sdk": "^0.17.40",
         "@types/three": "^0.179.0",
+        "@vercel/analytics": "^2.0.1",
         "colyseus.js": "^0.16.22",
         "three": "^0.179.1",
         "typescript": "^5.9.3",
@@ -1042,6 +1043,48 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.69",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@colyseus/sdk": "^0.17.40",
         "@types/three": "^0.179.0",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "colyseus.js": "^0.16.22",
         "three": "^0.179.1",
         "typescript": "^5.9.3",
@@ -720,9 +721,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -735,9 +733,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -752,9 +747,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -767,9 +759,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -784,9 +773,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,9 +785,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -816,9 +799,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -831,9 +811,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -848,9 +825,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -863,9 +837,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -880,9 +851,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -896,9 +864,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -911,9 +876,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1063,6 +1025,44 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@colyseus/sdk": "^0.17.40",
     "@types/three": "^0.179.0",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "colyseus.js": "^0.16.22",
     "three": "^0.179.1",
     "typescript": "^5.9.3",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@colyseus/sdk": "^0.17.40",
     "@types/three": "^0.179.0",
+    "@vercel/analytics": "^2.0.1",
     "colyseus.js": "^0.16.22",
     "three": "^0.179.1",
     "typescript": "^5.9.3",

--- a/client/src/analytics/analytics.ts
+++ b/client/src/analytics/analytics.ts
@@ -1,0 +1,106 @@
+import { track as vercelTrack } from "@vercel/analytics";
+
+type AnalyticsValue = string | number | boolean | null | undefined;
+type AnalyticsProperties = Record<string, AnalyticsValue>;
+type DeviceType = "desktop" | "mobile" | "tablet";
+type Orientation = "landscape" | "portrait";
+
+declare global {
+  interface Window {
+    __orbitalBreachLandingVisitTracked?: boolean;
+  }
+}
+
+function readQueryParam(searchParams: URLSearchParams, key: string): string | null {
+  const value = searchParams.get(key);
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getDocumentReferrerHost(): string | null {
+  if (typeof document === "undefined" || document.referrer.length === 0) return null;
+
+  try {
+    return new URL(document.referrer).host || null;
+  } catch {
+    return null;
+  }
+}
+
+function getViewportSize(): { width: number; height: number } {
+  const viewport = window.visualViewport;
+  if (viewport) {
+    return {
+      width: Math.round(viewport.width),
+      height: Math.round(viewport.height),
+    };
+  }
+
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+}
+
+function getOrientation(width: number, height: number): Orientation {
+  return width >= height ? "landscape" : "portrait";
+}
+
+function getDeviceType(width: number): DeviceType {
+  const userAgent = navigator.userAgent.toLowerCase();
+  const isTabletUa = /ipad|tablet|playbook|silk|(android(?!.*mobile))/i.test(userAgent);
+  if (isTabletUa) return "tablet";
+
+  const isMobileUa = /mobi|android|iphone|ipod/i.test(userAgent);
+  if (isMobileUa) return "mobile";
+
+  if (navigator.maxTouchPoints > 0) {
+    if (width < 768) return "mobile";
+    if (width < 1024) return "tablet";
+  }
+
+  return "desktop";
+}
+
+function getLandingVisitProperties(): AnalyticsProperties {
+  const searchParams = new URLSearchParams(window.location.search);
+  const { width, height } = getViewportSize();
+
+  return {
+    path: window.location.pathname,
+    ref: readQueryParam(searchParams, "ref"),
+    utm_source: readQueryParam(searchParams, "utm_source"),
+    utm_medium: readQueryParam(searchParams, "utm_medium"),
+    utm_campaign: readQueryParam(searchParams, "utm_campaign"),
+    utm_content: readQueryParam(searchParams, "utm_content"),
+    documentReferrerHost: getDocumentReferrerHost(),
+    deviceType: getDeviceType(width),
+    orientation: getOrientation(width, height),
+    viewportWidth: width,
+    viewportHeight: height,
+  };
+}
+
+export function track(eventName: string, properties?: AnalyticsProperties): void {
+  if (typeof window === "undefined") return;
+
+  if (import.meta.env.DEV) {
+    console.info(`[analytics] ${eventName}`, properties ?? {});
+  }
+
+  try {
+    vercelTrack(eventName, properties);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn(`[analytics] failed to track ${eventName}`, error);
+    }
+  }
+}
+
+export function trackLandingVisitOnce(): void {
+  if (typeof window === "undefined" || window.__orbitalBreachLandingVisitTracked) return;
+
+  window.__orbitalBreachLandingVisitTracked = true;
+  track("landing_visit", getLandingVisitProperties());
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,5 +1,9 @@
+import { inject } from "@vercel/analytics";
+import { trackLandingVisitOnce } from "./analytics/analytics";
 import { App } from "./app";
 import { wakeBackend } from "./net/wakeBackend";
 
+inject({ mode: import.meta.env.DEV ? "development" : "production" });
+trackLandingVisitOnce();
 wakeBackend();
 new App().start();

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,9 +1,11 @@
 import { inject } from "@vercel/analytics";
+import { injectSpeedInsights } from "@vercel/speed-insights";
 import { trackLandingVisitOnce } from "./analytics/analytics";
 import { App } from "./app";
 import { wakeBackend } from "./net/wakeBackend";
 
 inject({ mode: import.meta.env.DEV ? "development" : "production" });
+injectSpeedInsights();
 trackLandingVisitOnce();
 wakeBackend();
 new App().start();

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function installBrowserGlobals(options?: {
+  pathname?: string;
+  search?: string;
+  referrer?: string;
+  width?: number;
+  height?: number;
+  userAgent?: string;
+  maxTouchPoints?: number;
+}): void {
+  const pathname = options?.pathname ?? "/";
+  const search = options?.search ?? "";
+  const referrer = options?.referrer ?? "";
+  const width = options?.width ?? 1280;
+  const height = options?.height ?? 720;
+  const userAgent = options?.userAgent ?? "Mozilla/5.0";
+  const maxTouchPoints = options?.maxTouchPoints ?? 0;
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      innerWidth: width,
+      innerHeight: height,
+      location: {
+        pathname,
+        search,
+      },
+      visualViewport: {
+        width,
+        height,
+      },
+    },
+  });
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      referrer,
+    },
+  });
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      maxTouchPoints,
+      userAgent,
+    },
+  });
+}
+
+describe("analytics", () => {
+  const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleInfoSpy.mockClear();
+  });
+
+  it("tracks landing_visit once per page load with landing source fields", async () => {
+    installBrowserGlobals({
+      search: "?ref=vibejam&utm_source=jam&utm_medium=social&utm_campaign=launch&utm_content=hero",
+      referrer: "https://example.com/some/path?x=1",
+      width: 390,
+      height: 844,
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+      maxTouchPoints: 5,
+    });
+
+    const { trackLandingVisitOnce } = await import("../client/src/analytics/analytics");
+
+    trackLandingVisitOnce();
+    trackLandingVisitOnce();
+
+    expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+    expect(consoleInfoSpy).toHaveBeenCalledWith("[analytics] landing_visit", {
+      path: "/",
+      ref: "vibejam",
+      utm_source: "jam",
+      utm_medium: "social",
+      utm_campaign: "launch",
+      utm_content: "hero",
+      documentReferrerHost: "example.com",
+      deviceType: "mobile",
+      orientation: "portrait",
+      viewportWidth: 390,
+      viewportHeight: 844,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- install `@vercel/analytics` in the client and inject it once from `client/src/main.ts`
- add a small `client/src/analytics/analytics.ts` wrapper that is browser-safe and logs custom events in development
- emit a one-shot `landing_visit` event per page load with path, landing source params, referrer host, device type, orientation, and viewport dimensions
- add a focused test covering one-shot landing attribution and the `/?ref=vibejam` payload contract

## Why
The landing page needed privacy-safe frontend analytics and explicit landing source attribution without collecting full referrer URLs or player-identifying data.

## Impact
Landing source and campaign params are now captured on first load, dev mode shows the event payload in the console, and production builds include the Vercel analytics bootstrap.

## Validation
- `npm run build --prefix client`
- `npx vitest run --pool=threads --maxWorkers=1`
- `npm run build --prefix server` currently fails on the existing TypeScript 6 deprecation in `server/tsconfig.json` (`moduleResolution=node10`), unrelated to this change