### PR TITLE
fix: show crosshair cursor on gameplay overlays

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -28,6 +28,7 @@ import { FloatArmTuneOverlay } from "./floatArmTuneOverlay";
 import { ProjectileSystem } from "./projectileSystem";
 import { RoundController } from "./roundController";
 import { GunTuneOverlay } from "./gunTuneOverlay";
+import { shouldShowDesktopOverlayCursor } from "./overlayCursor";
 import { buildShotFromCamera } from "./weaponFire";
 import { NetClient } from "../net/client";
 import { MultiplayerLobby } from "../ui/multiplayerLobby";
@@ -1551,14 +1552,12 @@ export class App {
   }
 
   private syncDesktopOverlayCursor(gameplayActive: boolean): void {
-    if (this.mobile || !gameplayActive) {
-      return;
-    }
-
-    // Gameplay owns the cursor lifecycle. While in-world overlays are open,
-    // surface the custom cursor; otherwise keep it hidden like normal combat.
-    const overlayVisible = this.sessionMenu.isOpen() || this.input.isTabHeld();
-    if (overlayVisible) {
+    if (shouldShowDesktopOverlayCursor({
+      gameplayActive,
+      mobile: this.mobile,
+      sessionMenuOpen: this.sessionMenu.isOpen(),
+      tabHeld: this.input.isTabHeld(),
+    })) {
       this.cursor.show();
     } else {
       this.cursor.hide();

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -433,6 +433,7 @@ export class App {
     }
 
     this.syncCombatPresentation(gameplayActive);
+    this.syncDesktopOverlayCursor(gameplayActive);
     this.sceneMgr.render();
     requestAnimationFrame((nextTimestamp) => this.loop(nextTimestamp));
   }
@@ -1547,5 +1548,20 @@ export class App {
     }
 
     this.combatPresentationActive = gameplayActive;
+  }
+
+  private syncDesktopOverlayCursor(gameplayActive: boolean): void {
+    if (this.mobile || !gameplayActive) {
+      return;
+    }
+
+    // Gameplay owns the cursor lifecycle. While in-world overlays are open,
+    // surface the custom cursor; otherwise keep it hidden like normal combat.
+    const overlayVisible = this.sessionMenu.isOpen() || this.input.isTabHeld();
+    if (overlayVisible) {
+      this.cursor.show();
+    } else {
+      this.cursor.hide();
+    }
   }
 }

--- a/client/src/game/overlayCursor.ts
+++ b/client/src/game/overlayCursor.ts
@@ -1,0 +1,16 @@
+export interface DesktopOverlayCursorState {
+  gameplayActive: boolean;
+  mobile: boolean;
+  sessionMenuOpen: boolean;
+  tabHeld: boolean;
+}
+
+export function shouldShowDesktopOverlayCursor(
+  state: DesktopOverlayCursorState,
+): boolean {
+  if (state.mobile || !state.gameplayActive) {
+    return false;
+  }
+
+  return state.sessionMenuOpen || state.tabHeld;
+}

--- a/tests/overlayCursor.test.ts
+++ b/tests/overlayCursor.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowDesktopOverlayCursor } from "../client/src/game/overlayCursor";
+
+describe("shouldShowDesktopOverlayCursor", () => {
+  it("stays hidden outside active gameplay", () => {
+    expect(shouldShowDesktopOverlayCursor({
+      gameplayActive: false,
+      mobile: false,
+      sessionMenuOpen: true,
+      tabHeld: true,
+    })).toBe(false);
+  });
+
+  it("stays hidden on mobile even when gameplay overlays are open", () => {
+    expect(shouldShowDesktopOverlayCursor({
+      gameplayActive: true,
+      mobile: true,
+      sessionMenuOpen: true,
+      tabHeld: true,
+    })).toBe(false);
+  });
+
+  it("shows the custom cursor for the session menu during desktop gameplay", () => {
+    expect(shouldShowDesktopOverlayCursor({
+      gameplayActive: true,
+      mobile: false,
+      sessionMenuOpen: true,
+      tabHeld: false,
+    })).toBe(true);
+  });
+
+  it("shows the custom cursor for the combat roster during desktop gameplay", () => {
+    expect(shouldShowDesktopOverlayCursor({
+      gameplayActive: true,
+      mobile: false,
+      sessionMenuOpen: false,
+      tabHeld: true,
+    })).toBe(true);
+  });
+
+  it("returns to hidden gameplay behavior once overlays close", () => {
+    expect(shouldShowDesktopOverlayCursor({
+      gameplayActive: true,
+      mobile: false,
+      sessionMenuOpen: false,
+      tabHeld: false,
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- drive the desktop global cursor from active gameplay overlay state each frame
- show the custom crosshair cursor for the ESC session menu and TAB combat roster in solo and online play
- restore the hidden gameplay cursor when those overlays close
- extract the overlay cursor rule into a pure helper and cover it with regression tests

## Validation
- Playwright repro: verified solo ESC/TAB now show `.gc-cursor`, and TAB release restores `gc-hidden`
- Playwright repro: verified online ESC/TAB now show `.gc-cursor`, and TAB release restores `gc-hidden`
- verified overlay DOM still computes `cursor: none`, so the default browser cursor does not appear
- `npm run build` (client)
- `npm run build` (server)
- `npx vitest run tests/overlayCursor.test.ts`
- `npx vitest run` (root fallback because `npm test` fails in this repo copy with no root `package.json`)