### PR TITLE
Add debrief stats tracking and awards

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -36,6 +36,7 @@ import type { PlaySelection } from "../ui/menu";
 import { DebriefScreen, type DebriefData, type DebriefPlayer } from "../ui/debrief";
 import { showConfirmDialog } from "../ui/confirmDialog";
 import { getScoreboardCursorTransition } from "./scoreboardCursor";
+import { MatchStatsTracker, type ObservedMatchPlayer } from "./matchStatsTracker";
 import {
   PORTAL_ARRIVAL_SPAWN,
   checkPortalCollisions,
@@ -86,6 +87,7 @@ export class App {
   private lastTime = 0;
   private match: LocalMatch;
   private menu: MainMenu;
+  private readonly matchStats = new MatchStatsTracker();
   private welcome!: WelcomeScreen;
   private debrief = new DebriefScreen();
   private multiplayer = new MultiplayerLobby();
@@ -144,6 +146,7 @@ export class App {
           );
           break;
         case "score":
+          this.matchStats.recordBreach(event.scorerId);
           this.killFeed.addScore(event.scorerName, event.scorerTeam);
           break;
         case "roundWin":
@@ -201,6 +204,7 @@ export class App {
           this.syncLocalOnlineActor(snapshot);
           this.arena.setPortalDoorsOpen(snapshot.phase === "PLAYING");
           this.onlineMatch.applySnapshot(snapshot.actors, snapshot.sessionId);
+          this.matchStats.observePlayers(this.getOnlineMatchStatsActors(snapshot), { accumulateTravel: false });
         }
         return;
       }
@@ -231,6 +235,9 @@ export class App {
         this.syncLocalOnlineActor(snapshot);
         this.arena.setPortalDoorsOpen(snapshot.phase === "PLAYING");
         this.onlineMatch.applySnapshot(snapshot.actors, snapshot.sessionId);
+        this.matchStats.observePlayers(this.getOnlineMatchStatsActors(snapshot), {
+          accumulateTravel: snapshot.phase === "PLAYING",
+        });
       }
     };
 
@@ -262,6 +269,7 @@ export class App {
       }
 
       if (event.reason === "breach" && event.winningTeam !== null) {
+        this.matchStats.recordBreach(event.scorerId);
         this.killFeed.addScore(event.scorerName, event.winningTeam);
       }
 
@@ -481,6 +489,9 @@ export class App {
       (hit) => this.match.handleProjectileHit(hit, this.player, this.cam),
     );
     this.tickGunTuning();
+    this.matchStats.observePlayers(this.match.getMatchStatsActors(this.player), {
+      accumulateTravel: this.round.isPlaying(),
+    });
 
     checkPortalCollisions(this.player.getPosition(), this.player.phys.vel.y);
     updateVibeJamPortals(this.sceneMgr.getCamera().position, dt);
@@ -684,6 +695,15 @@ export class App {
     }
 
     this.clearCelebrationState();
+    if (
+      snapshot.roundNumber === 1
+      && snapshot.score.team0 === 0
+      && snapshot.score.team1 === 0
+    ) {
+      this.matchStats.reset();
+    }
+
+
     this.onlineGameActive = true;
     this.onlineRoundActive = snapshot.phase === "PLAYING";
     this.onlineBreachReported = false;
@@ -726,6 +746,7 @@ export class App {
     this.arena.setPortalDoorsOpen(snapshot.phase === "PLAYING");
 
     this.onlineMatch.applySnapshot(snapshot.actors, snapshot.sessionId);
+    this.matchStats.observePlayers(this.getOnlineMatchStatsActors(snapshot), { accumulateTravel: false });
 
     if (this.mobile) {
       const menuOpen = this.sessionMenu.isOpen();
@@ -961,28 +982,8 @@ export class App {
     winningTeam: 0 | 1,
     finalScore: { team0: number; team1: number },
   ): void {
-    const rosters = this.match.getHudRosters(this.player);
     const playerTeam = this.player.team;
-    const enemyTeam = (1 - playerTeam) as 0 | 1;
-
-    const ownPlayers: DebriefPlayer[] = rosters.ownTeam.map((p) => ({
-      id: p.id,
-      name: p.name,
-      team: playerTeam,
-      breaches: p.kills,
-      frozen: p.deaths,
-      isBot: p.isBot,
-      isSelf: p.id === "local-player",
-    }));
-    const enemyPlayers: DebriefPlayer[] = rosters.enemyTeam.map((p) => ({
-      id: p.id,
-      name: p.name,
-      team: enemyTeam,
-      breaches: p.kills,
-      frozen: p.deaths,
-      isBot: p.isBot,
-      isSelf: false,
-    }));
+    this.matchStats.observePlayers(this.match.getMatchStatsActors(this.player), { accumulateTravel: false });
 
     const teamSize = this.lastSoloSelection?.teamSize ?? 1;
     const sizeLabelMap: Record<number, string> = {
@@ -992,7 +993,8 @@ export class App {
     const debriefData: DebriefData = {
       winningTeam,
       score: finalScore,
-      players: [...ownPlayers, ...enemyPlayers],
+      players: this.matchStats.buildPlayers(),
+      awards: this.matchStats.buildAwards(),
       playerTeam,
       secondaryActionLabel: "Main Menu",
       primaryActionLabel: "Play Again",
@@ -1173,6 +1175,7 @@ export class App {
     this.matchOver = false;
     this.onlineBreachReported = false;
     this.helpVisible = false;
+    this.matchStats.reset();
     this.tutorial.beginRun();
     this.killFeed.setLocalPlayerName(selection.name);
     this.thirdPerson = this.sessionMenu.getSettings().defaultCameraMode === "third";
@@ -1220,6 +1223,7 @@ export class App {
     this.onlineRoundActive = false;
     this.onlineBreachReported = false;
     this.onlineMatchConcluding = false;
+    this.matchStats.reset();
     this.pendingOnlineDebrief = null;
     if (this.matchEndHandle) { clearTimeout(this.matchEndHandle); this.matchEndHandle = null; }
     this.previousOnlinePhase = null;
@@ -1271,6 +1275,7 @@ export class App {
     this.closeSessionMenu();
     this.debrief.hide();
     this.clearCelebrationState();
+    this.matchStats.reset();
     this.appMode = "menu";
     this.onlineGameActive = false;
     this.onlineRoundActive = false;
@@ -1347,32 +1352,15 @@ export class App {
       1: "1v1 Duel", 2: "2v2 Duos", 5: "5v5 Squads", 10: "10v10 Rush", 20: "20v20 War",
     };
 
-    const players: DebriefPlayer[] = (snapshot?.actors ?? []).map((actor) => ({
-      id: actor.id,
-      name: actor.name,
-      team: actor.team,
-      breaches: actor.kills,
-      frozen: actor.deaths,
-      isBot: actor.isBot,
-      isSelf: actor.id === sessionId,
-    }));
-
-    if (players.length === 0) {
-      players.push({
-        id: sessionId,
-        name: this.onlinePlayerName,
-        team: playerTeam,
-        breaches: this.player.kills,
-        frozen: this.player.deaths,
-        isBot: false,
-        isSelf: true,
-      });
+    if (snapshot) {
+      this.matchStats.observePlayers(this.getOnlineMatchStatsActors(snapshot), { accumulateTravel: false });
     }
 
     return {
       winningTeam,
       score: finalScore,
-      players,
+      players: this.getTrackedOnlineDebriefPlayers(sessionId, playerTeam),
+      awards: this.matchStats.buildAwards(),
       playerTeam,
       secondaryActionLabel: "Main Menu",
       primaryActionLabel: "Return To Lobby",
@@ -1380,11 +1368,48 @@ export class App {
     };
   }
 
+  private getOnlineMatchStatsActors(snapshot: MultiplayerRoomSnapshot): ObservedMatchPlayer[] {
+    return snapshot.actors.map((actor) => ({
+      id: actor.id,
+      name: actor.name,
+      team: actor.team,
+      isBot: actor.isBot,
+      isSelf: actor.id === snapshot.sessionId,
+      freezes: actor.kills,
+      frozen: actor.deaths,
+      position: {
+        x: actor.posX,
+        y: actor.posY,
+        z: actor.posZ,
+      },
+    }));
+  }
+
+  private getTrackedOnlineDebriefPlayers(sessionId: string, playerTeam: 0 | 1): DebriefPlayer[] {
+    const trackedPlayers = this.matchStats.buildPlayers();
+    if (trackedPlayers.length > 0) {
+      return trackedPlayers;
+    }
+
+    return [{
+      id: sessionId,
+      name: this.onlinePlayerName,
+      team: playerTeam,
+      breaches: 0,
+      freezes: this.player.kills,
+      frozen: this.player.deaths,
+      travelDistance: 0,
+      isBot: false,
+      isSelf: true,
+    }];
+  }
+
   private returnToOnlineLobbyFromDebrief(): void {
     this.clearCelebrationState();
     this.onlineMatchConcluding = false;
     this.onlineGameActive = false;
     this.onlineRoundActive = false;
+    this.matchStats.reset();
     this.input.setUiBlocked(false);
     this.onlineMatch.dispose();
     this.projectiles.clear();

--- a/client/src/game/matchStatsTracker.ts
+++ b/client/src/game/matchStatsTracker.ts
@@ -1,0 +1,208 @@
+import type { DebriefAward, DebriefPlayer } from "../ui/debrief";
+
+export interface ObservedMatchPlayer {
+  id: string;
+  name: string;
+  team: 0 | 1;
+  isBot: boolean;
+  isSelf: boolean;
+  freezes: number;
+  frozen: number;
+  position: {
+    x: number;
+    y: number;
+    z: number;
+  };
+}
+
+interface TrackedMatchPlayer extends DebriefPlayer {
+  lastPosition: {
+    x: number;
+    y: number;
+    z: number;
+  };
+}
+
+const METERS_PER_WORLD_UNIT = 1;
+
+export class MatchStatsTracker {
+  private readonly players = new Map<string, TrackedMatchPlayer>();
+
+  public reset(): void {
+    this.players.clear();
+  }
+
+  public recordBreach(playerId: string | null | undefined): void {
+    if (!playerId) return;
+    const player = this.players.get(playerId);
+    if (!player) return;
+    player.breaches += 1;
+  }
+
+  public observePlayers(
+    players: ObservedMatchPlayer[],
+    options: { accumulateTravel: boolean },
+  ): void {
+    for (const incoming of players) {
+      const tracked = this.ensurePlayer(incoming);
+
+      tracked.name = incoming.name;
+      tracked.team = incoming.team;
+      tracked.isBot = incoming.isBot;
+      tracked.isSelf = incoming.isSelf;
+      tracked.freezes = Math.max(tracked.freezes, incoming.freezes);
+      tracked.frozen = Math.max(tracked.frozen, incoming.frozen);
+
+      if (options.accumulateTravel) {
+        tracked.travelDistance += distanceBetween(tracked.lastPosition, incoming.position);
+      }
+
+      tracked.lastPosition = { ...incoming.position };
+    }
+  }
+
+  public buildPlayers(): DebriefPlayer[] {
+    return Array.from(this.players.values()).map((player) => ({
+      id: player.id,
+      name: player.name,
+      team: player.team,
+      breaches: player.breaches,
+      freezes: player.freezes,
+      frozen: player.frozen,
+      travelDistance: player.travelDistance,
+      isBot: player.isBot,
+      isSelf: player.isSelf,
+    }));
+  }
+
+  public buildAwards(): DebriefAward[] {
+    return buildDebriefAwards(this.buildPlayers());
+  }
+
+  private ensurePlayer(player: ObservedMatchPlayer): TrackedMatchPlayer {
+    const existing = this.players.get(player.id);
+    if (existing) {
+      return existing;
+    }
+
+    const tracked: TrackedMatchPlayer = {
+      id: player.id,
+      name: player.name,
+      team: player.team,
+      breaches: 0,
+      freezes: Math.max(0, player.freezes),
+      frozen: Math.max(0, player.frozen),
+      travelDistance: 0,
+      isBot: player.isBot,
+      isSelf: player.isSelf,
+      lastPosition: { ...player.position },
+    };
+    this.players.set(player.id, tracked);
+    return tracked;
+  }
+}
+
+export function buildDebriefAwards(players: DebriefPlayer[]): DebriefAward[] {
+  const awards: DebriefAward[] = [];
+  const humans = players.filter((player) => !player.isBot);
+
+  const breachLeader = pickBestPlayer(
+    players,
+    (candidate, currentBest) =>
+      candidate.breaches > currentBest.breaches
+      || (
+        candidate.breaches === currentBest.breaches
+        && candidate.freezes > currentBest.freezes
+      ),
+  );
+  if (breachLeader && breachLeader.breaches > 0) {
+    awards.push({
+      key: "Portal Ace",
+      value: breachLeader.name,
+      note: `${breachLeader.breaches} breaches scored`,
+    });
+  }
+
+  const freezeLeader = pickBestPlayer(
+    players,
+    (candidate, currentBest) =>
+      candidate.freezes > currentBest.freezes
+      || (
+        candidate.freezes === currentBest.freezes
+        && candidate.breaches > currentBest.breaches
+      ),
+  );
+  if (freezeLeader && freezeLeader.freezes > 0) {
+    awards.push({
+      key: "Deep Freeze",
+      value: freezeLeader.name,
+      note: `${freezeLeader.freezes} freezes landed`,
+    });
+  }
+
+  const ironPilot = pickBestPlayer(
+    humans.filter((player) => player.frozen === 0),
+    (candidate, currentBest) =>
+      playerImpactScore(candidate) > playerImpactScore(currentBest),
+  );
+  if (ironPilot) {
+    awards.push({
+      key: "Iron Pilot",
+      value: ironPilot.name,
+      note: "no freezes taken",
+    });
+  }
+
+  const moonWalker = pickBestPlayer(
+    players,
+    (candidate, currentBest) => candidate.travelDistance > currentBest.travelDistance,
+  );
+  if (moonWalker && moonWalker.travelDistance > 0) {
+    awards.push({
+      key: "Moon Walker",
+      value: moonWalker.name,
+      note: `${formatTravelDistance(moonWalker.travelDistance)} travelled`,
+    });
+  }
+
+  if (awards.length === 0) {
+    awards.push({
+      key: "Round Complete",
+      value: "-",
+      note: "match concluded",
+    });
+  }
+
+  return awards;
+}
+
+function pickBestPlayer(
+  players: DebriefPlayer[],
+  isBetter: (candidate: DebriefPlayer, currentBest: DebriefPlayer) => boolean,
+): DebriefPlayer | null {
+  let best: DebriefPlayer | null = null;
+  for (const player of players) {
+    if (!best || isBetter(player, best)) {
+      best = player;
+    }
+  }
+  return best;
+}
+
+function playerImpactScore(player: DebriefPlayer): number {
+  return player.breaches * 5 + player.freezes * 3 + player.travelDistance * 0.05;
+}
+
+function distanceBetween(
+  a: { x: number; y: number; z: number },
+  b: { x: number; y: number; z: number },
+): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const dz = b.z - a.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz) * METERS_PER_WORLD_UNIT;
+}
+
+function formatTravelDistance(distance: number): string {
+  return `${distance.toFixed(distance >= 100 ? 0 : 1)}m`;
+}

--- a/client/src/match/localMatch.ts
+++ b/client/src/match/localMatch.ts
@@ -61,6 +61,17 @@ export interface SpawnProjectileEvent {
   team: 0 | 1;
 }
 
+export interface LocalMatchStatsActor {
+  id: string;
+  name: string;
+  team: 0 | 1;
+  isBot: boolean;
+  isSelf: boolean;
+  freezes: number;
+  frozen: number;
+  position: Vec3;
+}
+
 export type LocalMatchEvent =
   | {
     type: "hitConfirm";
@@ -75,6 +86,7 @@ export type LocalMatchEvent =
   }
   | {
     type: "score";
+    scorerId: string;
     scorerName: string;
     scorerTeam: 0 | 1;
   }
@@ -193,6 +205,31 @@ export class LocalMatch {
 
   public getScore(): { team0: number; team1: number } {
     return { ...this.score };
+  }
+
+  public getMatchStatsActors(player: LocalPlayer): LocalMatchStatsActor[] {
+    return [
+      {
+        id: LOCAL_PLAYER_ID,
+        name: this.config.humanName,
+        team: this.config.humanTeam,
+        isBot: false,
+        isSelf: true,
+        freezes: player.kills,
+        frozen: player.deaths,
+        position: toVec3(player.getPosition()),
+      },
+      ...this.bots.map((bot) => ({
+        id: bot.id,
+        name: bot.name,
+        team: bot.team,
+        isBot: true,
+        isSelf: false,
+        freezes: bot.kills,
+        frozen: bot.deaths,
+        position: toVec3(bot.phys.pos),
+      })),
+    ];
   }
 
   public addOutboundVibeJamPortal(params: PortalParams): void {
@@ -422,7 +459,7 @@ export class LocalMatch {
         bot.phase = "BREACH";
       }
 
-      this.awardRoundPoint(actor.team, actor.name, "breach");
+      this.awardRoundPoint(actor.team, actor.id, actor.name, "breach");
       return;
     }
   }
@@ -443,7 +480,12 @@ export class LocalMatch {
     this.maybeEmitMatchEnd();
   }
 
-  private awardRoundPoint(team: 0 | 1, scorerName: string, reason: "breach" | "fullFreeze"): void {
+  private awardRoundPoint(
+    team: 0 | 1,
+    scorerId: string,
+    scorerName: string,
+    reason: "breach" | "fullFreeze",
+  ): void {
     if (this.roundResolved) return;
     this.roundResolved = true;
     if (team === 0) this.score.team0 += 1;
@@ -451,6 +493,7 @@ export class LocalMatch {
 
     this.emitEvent({
       type: "score",
+      scorerId,
       scorerName,
       scorerTeam: team,
     });

--- a/client/src/ui/debrief.ts
+++ b/client/src/ui/debrief.ts
@@ -126,7 +126,7 @@ const CSS = `
     color: #57637a; margin-top: 8px; text-transform: uppercase;
   }
 
-  /* ── Main grid ── */
+  /* Main grid */
   .ob-debrief-grid {
     display: grid;
     grid-template-columns: 2fr 1fr;
@@ -152,7 +152,7 @@ const CSS = `
   }
   .ob-debrief-panel-head h3 .ob-dph-idx { color: var(--ob-debrief-accent); }
 
-  /* ── Stats table ── */
+  /* Stats table */
   .ob-stats-table {
     width: 100%; border-collapse: collapse;
     font-family: "JetBrains Mono", monospace; font-size: 11px;
@@ -183,7 +183,7 @@ const CSS = `
   .ob-stats-table .ob-self td { color: #e8ecf4; }
   .ob-stats-table .ob-self td.ob-pname { font-weight: 500; }
 
-  /* ── Awards ── */
+  /* Awards */
   .ob-awards { display: grid; gap: 10px; }
   .ob-award {
     border: 1px solid rgba(210, 220, 240, 0.08);
@@ -203,7 +203,7 @@ const CSS = `
     color: var(--ob-debrief-accent); margin-top: 2px;
   }
 
-  /* ── Action buttons ── */
+  /* Action buttons */
   .ob-debrief-actions { display: flex; gap: 12px; margin-top: 10px; }
   .ob-debrief-btn {
     flex: 1; position: relative;
@@ -219,13 +219,13 @@ const CSS = `
   .ob-debrief-btn--primary { border-color: var(--ob-debrief-accent-border); }
   .ob-debrief-btn--primary:hover { border-color: var(--ob-debrief-accent); color: var(--ob-debrief-accent-text); }
 
-  /* ── Tablet: collapse grid to 1-col ── */
+  /* Tablet: collapse grid to 1-col */
   @media (max-width: 900px) {
     .ob-debrief-grid { grid-template-columns: 1fr; }
     .ob-debrief-head { grid-template-columns: 1fr; gap: 12px; text-align: center; }
   }
 
-  /* ── Mobile portrait ── */
+  /* Mobile portrait */
   @media (max-width: 640px) and (orientation: portrait) {
     .ob-debrief-root {
       padding: 12px 10px;
@@ -271,7 +271,7 @@ const CSS = `
     #debrief-play-again { order: -1; }
   }
 
-  /* ── Mobile landscape ── */
+  /* Mobile landscape */
   @media (max-height: 500px) and (max-width: 900px) {
     .ob-debrief-root {
       padding: 8px 10px;
@@ -307,16 +307,6 @@ function injectStyle(): void {
   const style = document.createElement("style");
   style.textContent = CSS;
   document.head.appendChild(style);
-}
-
-function rating(breaches: number, frozen: number): string {
-  const r = (breaches * 3) / (frozen + 1);
-  if (r >= 3.5) return "A+";
-  if (r >= 2.2) return "A";
-  if (r >= 1.2) return "B+";
-  if (r >= 0.6) return "B";
-  if (r >= 0.2) return "C+";
-  return "C";
 }
 
 function escapeHtml(s: string): string {
@@ -487,14 +477,5 @@ export class DebriefScreen {
     return (awards ?? [{ key: "Round Complete", value: "-", note: "match concluded" }])
       .map((entry) => award(entry.key, entry.value, entry.note))
       .join("");
-    /*
-      parts.push(award("Top Rating", topKd.name, `${rating(topKd.breaches, topKd.frozen)} · ${topKd.breaches} breaches / ${topKd.frozen} frozen`));
-    }
-    if (parts.length === 0) {
-      parts.push(award("Round Complete", "—", "match concluded"));
-    }
-
-    return parts.join("");
-    */
   }
 }

--- a/client/src/ui/debrief.ts
+++ b/client/src/ui/debrief.ts
@@ -5,15 +5,24 @@ export interface DebriefPlayer {
   name: string;
   team: 0 | 1;
   breaches: number;
+  freezes: number;
   frozen: number;
+  travelDistance: number;
   isBot: boolean;
   isSelf: boolean;
+}
+
+export interface DebriefAward {
+  key: string;
+  value: string;
+  note: string;
 }
 
 export interface DebriefData {
   winningTeam: 0 | 1 | null;
   score: { team0: number; team1: number };
   players: DebriefPlayer[];
+  awards?: DebriefAward[];
   playerTeam: 0 | 1;
   matchLabel: string;
   primaryActionLabel?: string;
@@ -332,6 +341,7 @@ export function sortDebriefPlayers(players: DebriefPlayer[], playerTeam: 0 | 1):
     if (a.team !== b.team) return a.team - b.team;
     if (a.isSelf !== b.isSelf) return a.isSelf ? -1 : 1;
     if (a.breaches !== b.breaches) return b.breaches - a.breaches;
+    if (a.freezes !== b.freezes) return b.freezes - a.freezes;
     return a.name.localeCompare(b.name);
   });
 }
@@ -398,21 +408,24 @@ export class DebriefScreen {
       : winningTeam === null ? "DRAW"
       : "DEFEAT";
 
+    const winnerText = winningTeam === null
+      ? `Winner - Draw / ${matchLabel}`
+      : `Winner - ${winningTeam === 0 ? "Team Cyan" : "Team Magenta"} / ${matchLabel}`;
+
     const sortedPlayers = sortDebriefPlayers(players, playerTeam);
 
-    const tableRows = sortedPlayers.map((p, i) => {
+    const tableRows = sortedPlayers.map((p) => {
       const teamCls = p.team === 0 ? "ob-t-cyan" : "ob-t-magenta";
       const selfCls = p.isSelf ? " ob-self" : "";
-      const r = rating(p.breaches, p.frozen);
       return `<tr class="${teamCls}${selfCls}">
         <td class="ob-pname">${escapeHtml(p.name)}${p.isBot ? " <small style='opacity:.4;font-size:9px;font-family:var(--ob-mono,monospace)'>[BOT]</small>" : ""}</td>
         <td>${p.breaches}</td>
+        <td>${p.freezes}</td>
         <td>${p.frozen}</td>
-        <td>${r}</td>
       </tr>`;
     }).join("");
 
-    const awards = this.buildAwards(players);
+    const awards = this.buildAwards(data.awards);
     const secondaryAction = showSecondaryAction
       ? `<button class="ob-debrief-btn" id="debrief-main-menu">${escapeHtml(mainMenuLabel)}</button>`
       : "";
@@ -429,7 +442,7 @@ export class DebriefScreen {
           </div>
           <div class="ob-debrief-verdict">
             ${verdictText}
-            <span class="ob-dv-sub">${escapeHtml(matchLabel)}</span>
+            <span class="ob-dv-sub">${escapeHtml(winnerText)}</span>
           </div>
           <div class="ob-debrief-team-score ob-debrief-team-score--magenta ${team1StateClass}">
             <div class="ob-ds-name">Team Magenta</div>
@@ -445,7 +458,7 @@ export class DebriefScreen {
             </div>
             <table class="ob-stats-table">
               <thead>
-                <tr><th>Pilot</th><th>Breaches</th><th>Frozen</th><th>Rating</th></tr>
+                <tr><th>Pilot</th><th>Breaches</th><th>Freezes</th><th>Frozen</th></tr>
               </thead>
               <tbody>${tableRows}</tbody>
             </table>
@@ -463,22 +476,7 @@ export class DebriefScreen {
     `;
   }
 
-  private buildAwards(players: DebriefPlayer[]): string {
-    const humans = players.filter((p) => !p.isBot);
-    const all = players;
-
-    const mostBreaches = all.reduce<DebriefPlayer | null>(
-      (best, p) => (!best || p.breaches > best.breaches ? p : best), null,
-    );
-    const ironPilot = humans.find((p) => p.frozen === 0);
-    const topKd = all.reduce<DebriefPlayer | null>(
-      (best, p) => {
-        const scoreA = p.breaches * 3 / (p.frozen + 1);
-        const scoreB = best ? best.breaches * 3 / (best.frozen + 1) : -1;
-        return scoreA > scoreB ? p : best;
-      }, null,
-    );
-
+  private buildAwards(awards: DebriefAward[] | undefined): string {
     const award = (key: string, val: string, note: string) =>
       `<div class="ob-award">
         <span class="ob-award-key">${key}</span>
@@ -486,14 +484,10 @@ export class DebriefScreen {
         <span class="ob-award-note">${escapeHtml(note)}</span>
       </div>`;
 
-    const parts: string[] = [];
-    if (mostBreaches && mostBreaches.breaches > 0) {
-      parts.push(award("Most Breaches", mostBreaches.name, `${mostBreaches.breaches} portal traversals`));
-    }
-    if (ironPilot) {
-      parts.push(award("Iron Pilot", ironPilot.name, "never frozen this match"));
-    }
-    if (topKd) {
+    return (awards ?? [{ key: "Round Complete", value: "-", note: "match concluded" }])
+      .map((entry) => award(entry.key, entry.value, entry.note))
+      .join("");
+    /*
       parts.push(award("Top Rating", topKd.name, `${rating(topKd.breaches, topKd.frozen)} · ${topKd.breaches} breaches / ${topKd.frozen} frozen`));
     }
     if (parts.length === 0) {
@@ -501,5 +495,6 @@ export class DebriefScreen {
     }
 
     return parts.join("");
+    */
   }
 }

--- a/server/src/colyseus/OrbitalLobbyRoom.ts
+++ b/server/src/colyseus/OrbitalLobbyRoom.ts
@@ -350,7 +350,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
       ? message.scorerTeam
       : actor.team;
 
-    this.awardOnlineRoundPoint(scorerTeam, String(message.scorerName || actor.name), "breach");
+    this.awardOnlineRoundPoint(scorerTeam, actor.id, String(message.scorerName || actor.name), "breach");
   }
 
   // ── Round flow ──────────────────────────────────────────────────────────────
@@ -496,13 +496,18 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     if (team0.length === 0 || team1.length === 0) return;
 
     if (team0.every((a) => a.frozen)) {
-      this.awardOnlineRoundPoint(1, "Magenta Team", "fullFreeze");
+      this.awardOnlineRoundPoint(1, null, "Magenta Team", "fullFreeze");
     } else if (team1.every((a) => a.frozen)) {
-      this.awardOnlineRoundPoint(0, "Cyan Team", "fullFreeze");
+      this.awardOnlineRoundPoint(0, null, "Cyan Team", "fullFreeze");
     }
   }
 
-  private awardOnlineRoundPoint(team: 0 | 1, scorerName: string, reason: "breach" | "fullFreeze"): void {
+  private awardOnlineRoundPoint(
+    team: 0 | 1,
+    scorerId: string | null,
+    scorerName: string,
+    reason: "breach" | "fullFreeze",
+  ): void {
     if (this.roundResolved) return;
     this.roundResolved = true;
 
@@ -525,6 +530,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
       winningTeam: team,
       matchWinner,
       reason,
+      scorerId: scorerId ?? undefined,
       scorerName,
     };
     if (matchWinner !== null) {
@@ -668,7 +674,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
         }
 
         if (!this.roundResolved && this.botIsInEnemyBreachRoom(actor)) {
-          this.awardOnlineRoundPoint(actor.team, actor.name, "breach");
+          this.awardOnlineRoundPoint(actor.team, actor.id, actor.name, "breach");
         }
 
         const fireTimer = this.botFireTimers.get(actor.id) ?? p.fireDelay;

--- a/shared/multiplayer.ts
+++ b/shared/multiplayer.ts
@@ -118,6 +118,7 @@ export interface RoundResultEventMessage {
   winningTeam: 0 | 1 | null;
   matchWinner: 0 | 1 | null;
   reason: "breach" | "fullFreeze" | "timeout";
+  scorerId?: string;
   scorerName: string;
   finalScore?: {
     team0: number;

--- a/tests/localMatch.test.ts
+++ b/tests/localMatch.test.ts
@@ -151,12 +151,13 @@ describe("LocalMatch", () => {
   });
 
   it("emits a score event for breach wins", () => {
-    (match as unknown as { awardRoundPoint: (team: 0 | 1, scorerName: string, reason: "breach" | "fullFreeze") => void })
-      .awardRoundPoint(0, "Pilot", "breach");
+    (match as unknown as { awardRoundPoint: (team: 0 | 1, scorerId: string, scorerName: string, reason: "breach" | "fullFreeze") => void })
+      .awardRoundPoint(0, "local-player", "Pilot", "breach");
 
     expect(events).toEqual([
       {
         type: "score",
+        scorerId: "local-player",
         scorerName: "Pilot",
         scorerTeam: 0,
       },
@@ -187,6 +188,7 @@ describe("LocalMatch", () => {
     expect(events).toEqual([
       {
         type: "score",
+        scorerId: "local-player",
         scorerName: "Pilot",
         scorerTeam: 0,
       },
@@ -216,6 +218,7 @@ describe("LocalMatch", () => {
     expect(events).toEqual([
       {
         type: "score",
+        scorerId: "local-player",
         scorerName: "Pilot",
         scorerTeam: 0,
       },

--- a/tests/matchStatsTracker.test.ts
+++ b/tests/matchStatsTracker.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MatchStatsTracker,
+  buildDebriefAwards,
+} from "../client/src/game/matchStatsTracker";
+
+describe("MatchStatsTracker", () => {
+  it("tracks breaches, freeze totals, and travel distance from observed players", () => {
+    const tracker = new MatchStatsTracker();
+
+    tracker.observePlayers([
+      {
+        id: "self",
+        name: "Pilot",
+        team: 0,
+        isBot: false,
+        isSelf: true,
+        freezes: 0,
+        frozen: 0,
+        position: { x: 0, y: 0, z: 0 },
+      },
+    ], { accumulateTravel: false });
+
+    tracker.recordBreach("self");
+    tracker.observePlayers([
+      {
+        id: "self",
+        name: "Pilot",
+        team: 0,
+        isBot: false,
+        isSelf: true,
+        freezes: 2,
+        frozen: 0,
+        position: { x: 3, y: 4, z: 0 },
+      },
+    ], { accumulateTravel: true });
+
+    const [player] = tracker.buildPlayers();
+    expect(player.breaches).toBe(1);
+    expect(player.freezes).toBe(2);
+    expect(player.frozen).toBe(0);
+    expect(player.travelDistance).toBeCloseTo(5, 5);
+  });
+
+  it("resets all tracked stats between matches", () => {
+    const tracker = new MatchStatsTracker();
+    tracker.observePlayers([
+      {
+        id: "self",
+        name: "Pilot",
+        team: 0,
+        isBot: false,
+        isSelf: true,
+        freezes: 1,
+        frozen: 1,
+        position: { x: 1, y: 0, z: 0 },
+      },
+    ], { accumulateTravel: false });
+    tracker.recordBreach("self");
+
+    tracker.reset();
+
+    expect(tracker.buildPlayers()).toEqual([]);
+    expect(tracker.buildAwards()).toEqual([
+      { key: "Round Complete", value: "-", note: "match concluded" },
+    ]);
+  });
+});
+
+describe("buildDebriefAwards", () => {
+  it("assigns iron, moon walker, portal ace, and freeze awards from tracked players", () => {
+    const awards = buildDebriefAwards([
+      {
+        id: "self",
+        name: "Pilot",
+        team: 0,
+        breaches: 2,
+        freezes: 3,
+        frozen: 0,
+        travelDistance: 32,
+        isBot: false,
+        isSelf: true,
+      },
+      {
+        id: "ally",
+        name: "Wing",
+        team: 0,
+        breaches: 4,
+        freezes: 1,
+        frozen: 2,
+        travelDistance: 58,
+        isBot: false,
+        isSelf: false,
+      },
+    ]);
+
+    expect(awards).toEqual([
+      { key: "Portal Ace", value: "Wing", note: "4 breaches scored" },
+      { key: "Deep Freeze", value: "Pilot", note: "3 freezes landed" },
+      { key: "Iron Pilot", value: "Pilot", note: "no freezes taken" },
+      { key: "Moon Walker", value: "Wing", note: "58.0m travelled" },
+    ]);
+  });
+});

--- a/tests/teamPresentation.test.ts
+++ b/tests/teamPresentation.test.ts
@@ -58,9 +58,9 @@ describe("player-relative team UI helpers", () => {
 
   it("sorts debrief players with the local team first and self at the top", () => {
     const players: DebriefPlayer[] = [
-      { id: "cyan-1", name: "Cyan Wing", team: 0, breaches: 5, frozen: 1, isBot: false, isSelf: false },
-      { id: "self", name: "Magenta Self", team: 1, breaches: 1, frozen: 0, isBot: false, isSelf: true },
-      { id: "magenta-2", name: "Magenta Ally", team: 1, breaches: 4, frozen: 2, isBot: false, isSelf: false },
+      { id: "cyan-1", name: "Cyan Wing", team: 0, breaches: 5, freezes: 2, frozen: 1, travelDistance: 42, isBot: false, isSelf: false },
+      { id: "self", name: "Magenta Self", team: 1, breaches: 1, freezes: 3, frozen: 0, travelDistance: 58, isBot: false, isSelf: true },
+      { id: "magenta-2", name: "Magenta Ally", team: 1, breaches: 4, freezes: 1, frozen: 2, travelDistance: 31, isBot: false, isSelf: false },
     ];
 
     const sorted = sortDebriefPlayers(players, 1);


### PR DESCRIPTION
## Summary
- add a browser-side match stats tracker for breaches, freezes, freeze-taken counts, and travel distance
- feed tracker data into solo and online debrief generation and render explicit awards/winner details
- extend breach result plumbing and tests so debrief data resets cleanly per match and validates in build/test

## Validation
- `npm run build --prefix client`
- `npm run build --prefix server`
- `npx vitest run`