### PR TITLE
Tune Vite client chunk size warning threshold

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  build: {
+    // Orbital Breach ships as a single-entry Three.js game, so the main
+    // production bundle is expected to exceed Vite's generic 500 kB warning.
+    chunkSizeWarningLimit: 1200,
+  },
   server: {
     proxy: {
       "/matchmake": {


### PR DESCRIPTION
## Summary
- raise the Vite client `chunkSizeWarningLimit` to 1200 kB for the single-entry Three.js game bundle
- document in config why the default 500 kB warning is too low for this startup-heavy client

## Validation
- `npm run build --prefix client`
- served the built client with `npm run preview --prefix client -- --host 127.0.0.1 --port 4173` and verified the preview responded with the built `Orbital Breach` HTML
- `npm test` is not available in this checkout because the repository root has no `package.json`