### PR TITLE
fix(ui): hide desktop debrief scrollbar

### DIFF
--- a/client/src/ui/debrief.ts
+++ b/client/src/ui/debrief.ts
@@ -69,6 +69,14 @@ const CSS = `
     gap: 22px;
   }
 
+  @media (hover: hover) and (pointer: fine) {
+    .ob-debrief-wrap {
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+    }
+    .ob-debrief-wrap::-webkit-scrollbar { display: none; }
+  }
+
   /* ── Score head ── */
   .ob-debrief-head {
     display: grid;


### PR DESCRIPTION
## Summary
- hide the native desktop scrollbar for the debrief scroll container only
- keep `overflow: auto` so mouse-wheel and trackpad scrolling continue to work
- scope the scrollbar suppression to fine-pointer desktop-class devices so mobile keeps its existing behavior

## Validation
- `npm run build --prefix client`
- `npx --yes vitest run`
- manual browser verification on local Vite dev server via headless Playwright:
  - desktop debrief wrapper had `scrollbar-width: none`, zero scrollbar gutter, and `scrollTop` advanced from `0` to `900` after a wheel event
  - mobile emulation kept `scrollbar-width: auto` and the debrief wrapper remained scrollable (`scrollTop` advanced from `0` to `910`)

## Ticket
- DOT-14