### PR TITLE
Fix desktop scoreboard cursor handling

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -35,6 +35,7 @@ import { MultiplayerLobby } from "../ui/multiplayerLobby";
 import type { PlaySelection } from "../ui/menu";
 import { DebriefScreen, type DebriefData, type DebriefPlayer } from "../ui/debrief";
 import { showConfirmDialog } from "../ui/confirmDialog";
+import { getScoreboardCursorTransition } from "./scoreboardCursor";
 import {
   PORTAL_ARRIVAL_SPAWN,
   checkPortalCollisions,
@@ -71,6 +72,7 @@ export class App {
   private combatPresentationActive = false;
   private portalArrivalPending = false;
   private portalUrlCleaned = false;
+  private restorePointerLockAfterScoreboard = false;
 
   private arena: Arena;
   private cam: CameraController;
@@ -107,6 +109,9 @@ export class App {
     this.sceneMgr = new SceneManager();
     this.sound = new SoundEngine(this.sceneMgr.getCamera(), this.sceneMgr.getScene());
     this.input = new InputManager();
+    this.input.onTabHoldChange = (held) => {
+      this.handleScoreboardTabHoldChange(held);
+    };
     this.cam = new CameraController(this.sceneMgr.getCamera());
     this.arena = new Arena(this.sceneMgr.getScene());
     this.player = new LocalPlayer(this.sceneMgr.getScene());
@@ -270,6 +275,7 @@ export class App {
             matchScore: event.finalScore,
           }),
         );
+        this.restorePointerLockAfterScoreboard = false;
         this.input.exitPointerLock();
         this.input.setUiBlocked(true);
         this.mobileControls?.hide();
@@ -739,6 +745,7 @@ export class App {
     this.onlineMatch.dispose();
     this.projectiles.clear();
     this.killFeed.setVisible(false);
+    this.restorePointerLockAfterScoreboard = false;
     this.input.exitPointerLock();
     this.mobileControls?.hide();
     this.input.setMobileControlsActive(false);
@@ -999,6 +1006,7 @@ export class App {
     this.hud.setVisible(false);
     this.hud.hideRoundEnd();
     this.killFeed.setVisible(false);
+    this.restorePointerLockAfterScoreboard = false;
     this.input.exitPointerLock();
     this.mobileControls?.hide();
     this.input.setMobileControlsActive(false);
@@ -1036,6 +1044,7 @@ export class App {
           : "Back To Lobby";
     const mainMenuLabel = inMenu ? null : "Return To Main Menu";
 
+    this.restorePointerLockAfterScoreboard = false;
     this.input.exitPointerLock();
     this.input.setUiBlocked(true);
     if (this.mobile) {
@@ -1209,6 +1218,7 @@ export class App {
     this.hud.setVisible(false);
     this.killFeed.setVisible(false);
     this.input.setUiBlocked(false);
+    this.restorePointerLockAfterScoreboard = false;
     this.input.exitPointerLock();
     this.mobileControls?.hide();
     this.input.setMobileControlsActive(false);
@@ -1270,6 +1280,7 @@ export class App {
     this.mobileControls?.hide();
     this.input.setMobileControlsActive(false);
     this.input.setUiBlocked(false);
+    this.restorePointerLockAfterScoreboard = false;
     this.input.exitPointerLock();
     this.sessionMenu.setLauncherVisible(false);
     this.gun.setVisible(false);
@@ -1300,6 +1311,7 @@ export class App {
     }
 
     this.sessionMenu.close();
+    this.restorePointerLockAfterScoreboard = false;
     this.input.exitPointerLock();
     this.input.setUiBlocked(true);
     this.mobileControls?.hide();
@@ -1532,6 +1544,30 @@ export class App {
         this.appMode === "solo"
         || (this.appMode === "online" && this.onlineGameActive)
       );
+  }
+
+  private handleScoreboardTabHoldChange(held: boolean): void {
+    const transition = getScoreboardCursorTransition(held, {
+      desktop: !this.mobile,
+      gameplayActive: this.isGameplaySceneActive(),
+      pointerLocked: this.input.isLocked(),
+      restorePointerLockAfterScoreboard: this.restorePointerLockAfterScoreboard,
+      sessionMenuOpen: this.sessionMenu.isOpen(),
+    });
+    this.restorePointerLockAfterScoreboard = transition.nextRestorePointerLockAfterScoreboard;
+
+    if (transition.showCursor) {
+      this.cursor.show();
+    }
+    if (transition.hideCursor) {
+      this.cursor.hide();
+    }
+    if (transition.exitPointerLock) {
+      this.input.exitPointerLock();
+    }
+    if (transition.requestPointerLock) {
+      this.input.lockPointer(this.sceneMgr.getRenderer().domElement);
+    }
   }
 
   private syncCombatPresentation(gameplayActive: boolean): void {

--- a/client/src/game/scoreboardCursor.ts
+++ b/client/src/game/scoreboardCursor.ts
@@ -1,0 +1,51 @@
+export interface ScoreboardCursorContext {
+  desktop: boolean;
+  gameplayActive: boolean;
+  pointerLocked: boolean;
+  restorePointerLockAfterScoreboard: boolean;
+  sessionMenuOpen: boolean;
+}
+
+export interface ScoreboardCursorTransition {
+  exitPointerLock: boolean;
+  hideCursor: boolean;
+  nextRestorePointerLockAfterScoreboard: boolean;
+  requestPointerLock: boolean;
+  showCursor: boolean;
+}
+
+const NOOP_TRANSITION: ScoreboardCursorTransition = {
+  exitPointerLock: false,
+  hideCursor: false,
+  nextRestorePointerLockAfterScoreboard: false,
+  requestPointerLock: false,
+  showCursor: false,
+};
+
+export function getScoreboardCursorTransition(
+  held: boolean,
+  context: ScoreboardCursorContext,
+): ScoreboardCursorTransition {
+  const eligible = context.desktop && context.gameplayActive && !context.sessionMenuOpen;
+  if (!eligible) {
+    return NOOP_TRANSITION;
+  }
+
+  if (held) {
+    return {
+      exitPointerLock: context.pointerLocked,
+      hideCursor: false,
+      nextRestorePointerLockAfterScoreboard: context.pointerLocked,
+      requestPointerLock: false,
+      showCursor: true,
+    };
+  }
+
+  return {
+    exitPointerLock: false,
+    hideCursor: true,
+    nextRestorePointerLockAfterScoreboard: false,
+    requestPointerLock: context.restorePointerLockAfterScoreboard,
+    showCursor: false,
+  };
+}

--- a/client/src/input.ts
+++ b/client/src/input.ts
@@ -17,6 +17,7 @@ export class InputManager {
   private gunTunePrintPressed = false;
   private menuTogglePressed = false;
   private helpPressed = false;
+  public onTabHoldChange: ((held: boolean) => void) | null = null;
 
   // Mobile touch input state
   private touchLookDx = 0;
@@ -30,7 +31,9 @@ export class InputManager {
 
   public constructor() {
     window.addEventListener('keydown', (e) => {
+      const tabWasHeld = this.keys.has('Tab');
       this.keys.add(e.code);
+      if (e.code === 'Tab' && !tabWasHeld) this.onTabHoldChange?.(true);
       if (e.code === 'KeyE' && !e.repeat) this.grabPressed = true;
       if (e.code === 'KeyV' && !e.repeat) this.thirdPersonTogglePressed = true;
       if (e.code === 'KeyP' && !e.repeat) this.gunTuneTogglePressed = true;
@@ -59,7 +62,9 @@ export class InputManager {
     });
 
     window.addEventListener('keyup', (e) => {
+      const tabWasHeld = e.code === 'Tab' && this.keys.has('Tab');
       this.keys.delete(e.code);
+      if (tabWasHeld) this.onTabHoldChange?.(false);
     });
 
     window.addEventListener('mousemove', (e) => {
@@ -344,6 +349,7 @@ export class InputManager {
   }
 
   private clearState(): void {
+    const tabWasHeld = this.keys.has('Tab');
     this.keys.clear();
     this.mouseDx = 0;
     this.mouseDy = 0;
@@ -359,6 +365,7 @@ export class InputManager {
     this.gunTunePrintPressed = false;
     this.menuTogglePressed = false;
     // mobileControlsActive is intentionally preserved across blur/visibility changes
+    if (tabWasHeld) this.onTabHoldChange?.(false);
   }
 }
 

--- a/tests/scoreboardCursor.test.ts
+++ b/tests/scoreboardCursor.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { getScoreboardCursorTransition } from "../client/src/game/scoreboardCursor";
+
+describe("getScoreboardCursorTransition", () => {
+  it("shows the cursor and exits pointer lock when Tab opens the desktop scoreboard", () => {
+    expect(
+      getScoreboardCursorTransition(true, {
+        desktop: true,
+        gameplayActive: true,
+        pointerLocked: true,
+        restorePointerLockAfterScoreboard: false,
+        sessionMenuOpen: false,
+      }),
+    ).toEqual({
+      exitPointerLock: true,
+      hideCursor: false,
+      nextRestorePointerLockAfterScoreboard: true,
+      requestPointerLock: false,
+      showCursor: true,
+    });
+  });
+
+  it("re-locks pointer and hides the cursor when Tab is released", () => {
+    expect(
+      getScoreboardCursorTransition(false, {
+        desktop: true,
+        gameplayActive: true,
+        pointerLocked: false,
+        restorePointerLockAfterScoreboard: true,
+        sessionMenuOpen: false,
+      }),
+    ).toEqual({
+      exitPointerLock: false,
+      hideCursor: true,
+      nextRestorePointerLockAfterScoreboard: false,
+      requestPointerLock: true,
+      showCursor: false,
+    });
+  });
+
+  it("ignores scoreboard cursor changes outside desktop gameplay", () => {
+    expect(
+      getScoreboardCursorTransition(true, {
+        desktop: false,
+        gameplayActive: true,
+        pointerLocked: true,
+        restorePointerLockAfterScoreboard: false,
+        sessionMenuOpen: false,
+      }),
+    ).toEqual({
+      exitPointerLock: false,
+      hideCursor: false,
+      nextRestorePointerLockAfterScoreboard: false,
+      requestPointerLock: false,
+      showCursor: false,
+    });
+  });
+
+  it("does not try to restore pointer lock while the session menu is open", () => {
+    expect(
+      getScoreboardCursorTransition(false, {
+        desktop: true,
+        gameplayActive: true,
+        pointerLocked: false,
+        restorePointerLockAfterScoreboard: true,
+        sessionMenuOpen: true,
+      }),
+    ).toEqual({
+      exitPointerLock: false,
+      hideCursor: false,
+      nextRestorePointerLockAfterScoreboard: false,
+      requestPointerLock: false,
+      showCursor: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- release pointer lock and show the desktop cursor while the scoreboard is held open with `Tab`
- restore pointer lock and hide the cursor when `Tab` is released
- add focused regression coverage for the scoreboard cursor transition helper

## Validation
- `npm run build` (client)
- `npm run build` (server)
- `npx vitest run`
- Playwright runtime check on `http://localhost:5173`:
  - before `Tab`: pointer lock active, cursor hidden, scoreboard hidden
  - during `Tab`: pointer lock released, cursor visible, scoreboard visible
  - after release: pointer lock active, cursor hidden, scoreboard hidden

## Notes
- `npm test` is not available from the repo root in this checkout because there is no root `package.json`; `npx vitest run` is the working suite entrypoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tab-hold cursor and pointer-lock management for the scoreboard—cursor becomes visible and pointer lock releases when holding Tab to view the scoreboard, with automatic restoration upon release.

* **Tests**
  * Added test coverage for scoreboard cursor transitions and pointer-lock behavior across desktop and menu contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->