### PR TITLE
fix: restore cursors on all menu screens

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -1703,6 +1703,7 @@ export class App {
   }
 
   private syncDesktopOverlayCursor(gameplayActive: boolean): void {
+    if (!gameplayActive) return;
     if (shouldShowDesktopOverlayCursor({
       gameplayActive,
       mobile: this.mobile,


### PR DESCRIPTION
## Root cause

`syncDesktopOverlayCursor` runs every animation frame. On menu screens (`gameplayActive=false`), `shouldShowDesktopOverlayCursor` always returns `false` → `cursor.hide()` fires each frame, overriding the explicit `cursor.show()` calls from `returnToMenuFromSolo`, `returnToMenuFromOnline`, and `showDebrief`.

The native cursor was also invisible because `globalCursor.ts` injects `* { cursor: none !important }` globally on init — hiding native cursor permanently. So with the custom div also hidden, no cursor appeared on any menu screen.

## Fix

One guard in `syncDesktopOverlayCursor`: return early when `!gameplayActive`. Overlay cursor management only applies during matches; menu/lobby/debrief transitions already call `cursor.show()`/`cursor.hide()` explicitly.

## Test

- TS: clean (client + server)
- Tests: 203/203 pass (2 pre-existing unhandled rejections in `onlineRoomLeave.test.ts`, unrelated)
- Build: ✅ 1.54s

🤖 Generated with [Claude Code](https://claude.com/claude-code)