### PR TITLE
fix: mobile scroll, spawn-room protection, and link icons

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -565,7 +565,7 @@ export class App {
     const localCentre = this.player.getPosition().clone();
     localCentre.y += HITBOX_OFFSET_Y;
     const localTarget = {
-      active: this.player.phase !== "RESPAWNING" && !this.player.damage.frozen,
+      active: this.player.phase !== "RESPAWNING" && this.player.phase !== "BREACH" && !this.player.damage.frozen,
       id: localActorId,
       pos: localCentre,
       radius: HITBOX_RADIUS,

--- a/client/src/match/localMatch.ts
+++ b/client/src/match/localMatch.ts
@@ -270,7 +270,7 @@ export class LocalMatch {
     humanCentre.y += HITBOX_OFFSET_Y;
     return [
       {
-        active: player.phase !== "RESPAWNING" && !player.damage.frozen,
+        active: player.phase !== "RESPAWNING" && player.phase !== "BREACH" && !player.damage.frozen,
         id: LOCAL_PLAYER_ID,
         pos: humanCentre,
         radius: HITBOX_RADIUS,
@@ -280,7 +280,7 @@ export class LocalMatch {
         const botCentre = bot.phys.pos.clone();
         botCentre.y += HITBOX_OFFSET_Y;
         return {
-          active: bot.phase !== "RESPAWNING" && !bot.damage.frozen,
+          active: bot.phase !== "RESPAWNING" && bot.phase !== "BREACH" && !bot.damage.frozen,
           id: bot.id,
           pos: botCentre,
           radius: HITBOX_RADIUS,
@@ -650,7 +650,7 @@ export class LocalMatch {
     bot.rot.yaw = command.lookYaw;
     bot.rot.pitch = command.lookPitch;
 
-    if (command.fire && !bot.damage.rightArm && command.fireDirection) {
+    if (command.fire && bot.phase !== "BREACH" && !bot.damage.rightArm && command.fireDirection) {
       const forward = toThree(command.fireDirection).normalize();
       shots.push({
         direction: forward.clone(),

--- a/client/src/match/onlineMatch.ts
+++ b/client/src/match/onlineMatch.ts
@@ -169,7 +169,7 @@ export class OnlineMatch {
         track.renderPos.z,
       ),
       team: track.snapshot.team,
-      active: !track.snapshot.frozen && track.snapshot.phase !== "RESPAWNING",
+      active: !track.snapshot.frozen && track.snapshot.phase !== "RESPAWNING" && track.snapshot.phase !== "BREACH",
       radius: HITBOX_RADIUS,
     }));
   }

--- a/client/src/ui/linkIcons.ts
+++ b/client/src/ui/linkIcons.ts
@@ -1,0 +1,3 @@
+export const GITHUB_ICON_SVG = `<svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="9" cy="8" r="5"/><path d="M5 4.5 3.5 3M13 4.5 14.5 3"/><path d="M7 13v2M11 13v2M7 15c0-.8.9-1.5 2-1.5s2 .7 2 1.5"/></svg>`;
+
+export const ITCH_ICON_SVG = `<svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1.5 4.5C1.5 3 4.5 2 9 2s7.5 1 7.5 2.5"/><rect x="2" y="4.5" width="14" height="11" rx="1"/><path d="M6 9h2.5M7.25 7.75v2.5M11.5 9.5l1.5.5-1.5.5"/></svg>`;

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -1,6 +1,7 @@
 import { isTouchDevice } from "../../platform";
 import type { MatchTeamSize } from "../../../../shared/match";
 import { GITHUB_REPO_URL, ITCH_IO_URL } from "../creditsContent";
+import { GITHUB_ICON_SVG, ITCH_ICON_SVG } from "../linkIcons";
 import { injectDesignTokens } from "../designTokens";
 import { SESSION_MENU_GEAR_ICON } from "../sessionMenu";
 
@@ -353,6 +354,15 @@ const CSS = `
     justify-content: center;
     width: 100%;
   }
+  .ob-link-chip-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+  }
+  .ob-link-chip-icon svg { width: 18px; height: 18px; }
   .ob-link-chip {
     display: inline-flex;
     align-items: center;
@@ -451,10 +461,10 @@ const CSS = `
   @media (max-width: 640px) {
     .ob-match-grid   { grid-template-columns: repeat(3, 1fr); }
     .ob-launch-row   { flex-direction: column; align-items: center; }
-    .ob-settings-row { margin-top: 0; }
+    .ob-settings-row { margin-top: 0; flex-wrap: wrap; }
     .ob-link-row     { gap: 8px; }
     .ob-callsign-box { min-width: 0; width: 90vw; }
-    .menu-root       { cursor: auto; overflow-y: auto; align-items: start; }
+    .menu-root       { cursor: auto; overflow-y: auto; overflow-x: hidden; align-items: start; }
 
     .ob-topbar  { padding-left: 16px; padding-right: 16px; padding-top: calc(14px + env(safe-area-inset-top, 0px)); }
     .ob-bottombar { padding-left: 16px; padding-right: 16px;
@@ -579,7 +589,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
       </button>`;
   }
 
-  function externalLink(label: string, href: string): string {
+  function externalLink(label: string, href: string, icon: string): string {
     return `
       <a
         class="ob-link-chip"
@@ -587,6 +597,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
         target="_blank"
         rel="noreferrer noopener"
       >
+        <span class="ob-link-chip-icon">${icon}</span>
         <span>${label}</span>
         <span class="ob-link-chip-arrow">&nearr;</span>
       </a>`;
@@ -723,8 +734,8 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
           ${btn("btn-open-credits", "utility", "Credits")}
         </div>
         <div class="ob-link-row" aria-label="External project links">
-          ${externalLink("GitHub", GITHUB_REPO_URL)}
-          ${externalLink("itch.io", ITCH_IO_URL)}
+          ${externalLink("GITHUB REPO", GITHUB_REPO_URL, GITHUB_ICON_SVG)}
+          ${externalLink("DOTANV.ITCH.IO", ITCH_IO_URL, ITCH_ICON_SVG)}
         </div>
       </div>
 

--- a/client/src/ui/sessionMenu.ts
+++ b/client/src/ui/sessionMenu.ts
@@ -5,6 +5,7 @@ import {
   ITCH_IO_URL,
   NOAM_SOUNDCLOUD_URL,
 } from "./creditsContent";
+import { GITHUB_ICON_SVG, ITCH_ICON_SVG } from "./linkIcons";
 
 export interface SessionSettings {
   mouseSensitivity: number;
@@ -637,11 +638,13 @@ export class SessionMenu {
               <div class="ob-session-note">External pages open in a new tab.</div>
               <div class="ob-session-link-grid">
                 <a class="ob-session-link" href="${GITHUB_REPO_URL}" target="_blank" rel="noreferrer noopener">
-                  <span>GitHub Repository</span>
+                  ${GITHUB_ICON_SVG}
+                  <span>GITHUB REPO</span>
                   <span>&nearr;</span>
                 </a>
                 <a class="ob-session-link" href="${ITCH_IO_URL}" target="_blank" rel="noreferrer noopener">
-                  <span>itch.io Page</span>
+                  ${ITCH_ICON_SVG}
+                  <span>DOTANV.ITCH.IO</span>
                   <span>&nearr;</span>
                 </a>
               </div>


### PR DESCRIPTION
## Summary

- **Fix 1 — mobile horizontal scroll:** `ob-settings-row` (3 buttons) had no `flex-wrap`, overflowing the 345px portrait viewport. Added `flex-wrap: wrap` so buttons stack. Added `overflow-x: hidden` to `.menu-root` as a hard backstop against any future overflow.

- **Fix 2 — spawn room protection:** Players and bots in `BREACH` phase (own team's gravity room) were valid projectile targets and bots could fire from there. Added `phase !== "BREACH"` guards to: `localMatch.getProjectileTargets` (human + bot active), bot fire condition in `tickBot`, `gameApp` online local player target, and `onlineMatch.getProjectileTargets` remote tracks.

- **Fix 3 — link icons:** New `linkIcons.ts` exports 18px stroke SVGs for GitHub (octocat-inspired circle + fork) and itch.io (arch + d-pad hint). `externalLink()` in menuView accepts and renders the icon; labels updated to ALL CAPS. Same icons applied to credits view in sessionMenu.

## Test plan

- [ ] Portrait mobile: main menu no longer scrolls horizontally
- [ ] Settings row buttons wrap on narrow screens
- [ ] Player in own breach room: cannot be hit by projectiles
- [ ] Bots in own breach room: do not fire
- [ ] Main menu: GitHub and itch chips show inline icon + ALL CAPS label
- [ ] Credits view: same icons + labels visible
- [ ] TS clean, 203/203 tests pass, build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)