### PR TITLE
Add responsive instructions page

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Debrief awards are generated from match stats:
 | Browser game deployment | Done |
 | Solo and online multiplayer | Done |
 | Mobile touch controls | Done |
+| In-game instructions page | Done |
 | Itch.io landing page | Done |
 | Fullscreen mode with settings toggle | Done; iPhone Safari disables the toggle because non-video fullscreen is unsupported |
 

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -427,6 +427,9 @@ export class App {
         defaultTeamSize: selection.teamSize,
       });
     };
+    this.menu.onOpenInstructions = () => {
+      this.openSessionMenu("instructions");
+    };
     this.menu.onOpenSettings = () => {
       this.openSessionMenu();
     };
@@ -1076,7 +1079,7 @@ export class App {
     this.menu.show();
   }
 
-  private openSessionMenu(view: "settings" | "credits" = "settings"): void {
+  private openSessionMenu(view: "settings" | "instructions" | "credits" = "settings"): void {
     if (this.sessionMenu.isOpen() || this.debrief.isVisible() || this.onlineMatchConcluding) return;
 
     const inMenu = this.appMode === "menu";

--- a/client/src/ui/instructionsContent.ts
+++ b/client/src/ui/instructionsContent.ts
@@ -1,0 +1,91 @@
+export interface InstructionTextBlock {
+  title: string;
+  body: string;
+}
+
+export interface InstructionControl {
+  input: string;
+  action: string;
+}
+
+export interface InstructionsContent {
+  title: string;
+  subtitle: string;
+  objective: InstructionTextBlock[];
+  roundFlow: InstructionTextBlock[];
+  winningScenarios: InstructionTextBlock[];
+  controls: InstructionControl[];
+}
+
+const OBJECTIVE: InstructionTextBlock[] = [
+  {
+    title: "Objective",
+    body: "Freeze the enemy squad, open their breach portal, and cross it before they recover their formation.",
+  },
+  {
+    title: "Teams",
+    body: "Team Cyan and Team Magenta spawn in opposite breach rooms and fight across the zero-G arena.",
+  },
+];
+
+const ROUND_FLOW: InstructionTextBlock[] = [
+  {
+    title: "Start In Gravity",
+    body: "Each round begins in a breach room. Move, jump, grab a rail, and charge a launch into the arena.",
+  },
+  {
+    title: "Fight In Zero-G",
+    body: "Drift through debris, use rails to redirect, and fire the freeze pistol at enemy pilots.",
+  },
+  {
+    title: "Open The Portal",
+    body: "Freeze all enemies on the opposing team to open their breach portal route.",
+  },
+  {
+    title: "Breach To Score",
+    body: "Cross the enemy breach portal to score a round for your team.",
+  },
+];
+
+const WINNING_SCENARIOS: InstructionTextBlock[] = [
+  {
+    title: "Round Win",
+    body: "A round is won when a player crosses the enemy breach portal after the enemy team has been fully frozen.",
+  },
+  {
+    title: "Match Win",
+    body: "The first team to 5 round wins wins the match.",
+  },
+  {
+    title: "Timeout",
+    body: "If the 120-second round timer expires, the round is a tie and no point is awarded.",
+  },
+];
+
+const DESKTOP_CONTROLS: InstructionControl[] = [
+  { input: "Mouse", action: "Look around" },
+  { input: "WASD", action: "Walk inside breach rooms" },
+  { input: "E", action: "Grab or release a rail" },
+  { input: "Space", action: "Jump in breach rooms" },
+  { input: "Hold Space while grabbing", action: "Charge launch" },
+  { input: "Mouse movement while charging", action: "Aim launch power" },
+  { input: "Left mouse button", action: "Fire freeze pistol" },
+  { input: "V", action: "Toggle first-person / third-person view" },
+  { input: "B", action: "Hold selfie / look-back view" },
+  { input: "Tab", action: "Hold combat roster / scoreboard" },
+  { input: "Esc", action: "Session menu / release cursor" },
+  { input: "H", action: "Help overlay" },
+];
+
+export function getInstructionsContent(isMobile: boolean): InstructionsContent {
+  return {
+    title: isMobile ? "Mobile Instructions" : "Desktop Instructions",
+    subtitle: isMobile
+      ? "Round flow, objective, and scoring rules for touch pilots."
+      : "Controls, objective, round flow, and scoring rules for desktop pilots.",
+    objective: OBJECTIVE,
+    roundFlow: ROUND_FLOW,
+    winningScenarios: WINNING_SCENARIOS,
+    controls: isMobile ? [] : DESKTOP_CONTROLS,
+  };
+}

--- a/client/src/ui/menu.ts
+++ b/client/src/ui/menu.ts
@@ -19,6 +19,7 @@ export class MainMenu {
   public onPlaySolo: ((selection: PlaySelection) => void) | null = null;
   public onPlayOnline: ((selection: PlaySelection) => void) | null = null;
   public onBrowseOnline: ((selection: PlaySelection) => void) | null = null;
+  public onOpenInstructions: (() => void) | null = null;
   public onOpenSettings: (() => void) | null = null;
   public onOpenCredits: (() => void) | null = null;
   public onPlayTutorial: ((selection: PlaySelection) => void) | null = null;
@@ -63,6 +64,9 @@ export class MainMenu {
     elements.browseRoomsButton.addEventListener('click', () => {
       if (!this.checkNameBeforePlay(elements)) return;
       this.onBrowseOnline?.(this.saveSelection());
+    });
+    elements.openInstructionsButton.addEventListener('click', () => {
+      this.onOpenInstructions?.();
     });
     elements.openSettingsButton.addEventListener('click', () => {
       this.onOpenSettings?.();

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -539,6 +539,7 @@ export interface MenuElements {
   playSoloButton: HTMLButtonElement;
   playOnlineButton: HTMLButtonElement;
   browseRoomsButton: HTMLButtonElement;
+  openInstructionsButton: HTMLButtonElement;
   openSettingsButton: HTMLButtonElement;
   openCreditsButton: HTMLButtonElement;
   playTutorialButton: HTMLButtonElement;
@@ -730,6 +731,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
         </div>
         <div class="ob-settings-row">
           ${btn("btn-browse-rooms", "utility", "Rooms & Invites")}
+          ${btn("btn-open-instructions", "utility", "Instructions")}
           ${btn("btn-open-settings", "utility", "Settings", SESSION_MENU_GEAR_ICON)}
           ${btn("btn-open-credits", "utility", "Credits")}
         </div>
@@ -779,6 +781,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
     playSoloButton:    container.querySelector<HTMLButtonElement>("#btn-play-solo")!,
     playOnlineButton:  container.querySelector<HTMLButtonElement>("#btn-play-online")!,
     browseRoomsButton: container.querySelector<HTMLButtonElement>("#btn-browse-rooms")!,
+    openInstructionsButton: container.querySelector<HTMLButtonElement>("#btn-open-instructions")!,
     openSettingsButton:container.querySelector<HTMLButtonElement>("#btn-open-settings")!,
     openCreditsButton: container.querySelector<HTMLButtonElement>("#btn-open-credits")!,
     playTutorialButton:container.querySelector<HTMLButtonElement>("#btn-play-tutorial")!,

--- a/client/src/ui/sessionMenu.ts
+++ b/client/src/ui/sessionMenu.ts
@@ -6,7 +6,9 @@ import {
   NOAM_SOUNDCLOUD_URL,
 } from "./creditsContent";
 import { isFullscreenSupported } from "./fullscreen";
+import { getInstructionsContent, type InstructionsContent } from "./instructionsContent";
 import { GITHUB_ICON_SVG, ITCH_ICON_SVG } from "./linkIcons";
+import { isTouchDevice } from "../platform";
 
 export interface SessionSettings {
   mouseSensitivity: number;
@@ -24,7 +26,7 @@ export interface SessionMenuConfig {
   title: string;
 }
 
-type SessionMenuView = "settings" | "credits";
+type SessionMenuView = "settings" | "instructions" | "credits";
 
 export const SESSION_MENU_GEAR_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
 
@@ -318,6 +320,80 @@ const CSS = `
     display: none !important;
   }
 
+  .ob-session-instructions-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    margin-top: 16px;
+  }
+
+  .ob-session-instruction-item,
+  .ob-session-control-row {
+    min-width: 0;
+    border: 1px solid rgba(210, 220, 240, 0.08);
+    background:
+      radial-gradient(circle at top left, rgba(127, 252, 255, 0.07), transparent 42%),
+      radial-gradient(circle at bottom right, rgba(255, 125, 248, 0.07), transparent 44%),
+      rgba(255, 255, 255, 0.02);
+  }
+
+  .ob-session-instruction-item {
+    padding: 14px 16px;
+  }
+
+  .ob-session-instruction-item--wide {
+    grid-column: 1 / -1;
+  }
+
+  .ob-session-instruction-title,
+  .ob-session-control-key {
+    font-family: "JetBrains Mono", monospace;
+    color: #7ffcff;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .ob-session-instruction-item:nth-child(even) .ob-session-instruction-title,
+  .ob-session-control-row:nth-child(even) .ob-session-control-key {
+    color: #ff9df8;
+  }
+
+  .ob-session-instruction-body {
+    margin-top: 8px;
+    color: #d7e7ee;
+    font-size: 16px;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+  }
+
+  .ob-session-control-list {
+    display: grid;
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.25fr);
+    gap: 8px;
+    margin-top: 16px;
+  }
+
+  .ob-session-control-row {
+    display: contents;
+  }
+
+  .ob-session-control-key,
+  .ob-session-control-action {
+    min-width: 0;
+    padding: 11px 12px;
+    border: 1px solid rgba(210, 220, 240, 0.08);
+    background: rgba(255, 255, 255, 0.02);
+    overflow-wrap: anywhere;
+  }
+
+  .ob-session-control-action {
+    color: #cfe3ed;
+    font-size: 15px;
+    line-height: 1.35;
+  }
+
   .ob-session-card-actions {
     display: flex;
     gap: 12px;
@@ -437,6 +513,11 @@ const CSS = `
       grid-template-columns: 1fr;
     }
 
+    .ob-session-instructions-grid,
+    .ob-session-control-list {
+      grid-template-columns: 1fr;
+    }
+
     .ob-session-launcher {
       top: 10px;
       right: 10px;
@@ -510,8 +591,11 @@ export class SessionMenu {
   private readonly resumeButton: HTMLButtonElement;
   private readonly mainMenuButton: HTMLButtonElement;
   private readonly settingsView: HTMLDivElement;
+  private readonly instructionsView: HTMLDivElement;
   private readonly creditsView: HTMLDivElement;
+  private readonly openInstructionsButton: HTMLButtonElement;
   private readonly openCreditsButton: HTMLButtonElement;
+  private readonly backToSettingsFromInstructionsButton: HTMLButtonElement;
   private readonly backToSettingsButton: HTMLButtonElement;
   private readonly sensitivityInput: HTMLInputElement;
   private readonly sensitivityValue: HTMLSpanElement;
@@ -534,6 +618,7 @@ export class SessionMenu {
 
   public constructor() {
     injectStyle();
+    const instructionsContent = getInstructionsContent(isTouchDevice());
 
     this.launcher = document.createElement("button");
     this.launcher.type = "button";
@@ -622,12 +707,28 @@ export class SessionMenu {
             </section>
 
             <section class="ob-session-settings-card">
+              <div class="ob-session-settings-title">Instructions</div>
+              <div class="ob-session-note">Review objective, round flow, and scoring before launch.</div>
+              <div class="ob-session-card-actions">
+                <button id="session-menu-open-instructions" type="button" class="ob-session-inline-button">Open Instructions</button>
+              </div>
+            </section>
+
+            <section class="ob-session-settings-card">
               <div class="ob-session-settings-title">Credits</div>
               <div class="ob-session-note">Review model, audio, and project-link credits without leaving the build.</div>
               <div class="ob-session-card-actions">
                 <button id="session-menu-open-credits" type="button" class="ob-session-inline-button">Open Credits</button>
               </div>
             </section>
+          </div>
+
+          <div id="session-menu-instructions-view" class="ob-session-view" hidden>
+            ${buildInstructionsHtml(instructionsContent)}
+
+            <div class="ob-session-card-actions">
+              <button id="session-menu-back-to-settings-from-instructions" type="button" class="ob-session-inline-button ob-session-inline-button--ghost">Back To Settings</button>
+            </div>
           </div>
 
           <div id="session-menu-credits-view" class="ob-session-view" hidden>
@@ -695,8 +796,11 @@ export class SessionMenu {
     this.resumeButton = this.query("#session-menu-resume");
     this.mainMenuButton = this.query("#session-menu-main");
     this.settingsView = this.query("#session-menu-settings-view");
+    this.instructionsView = this.query("#session-menu-instructions-view");
     this.creditsView = this.query("#session-menu-credits-view");
+    this.openInstructionsButton = this.query("#session-menu-open-instructions");
     this.openCreditsButton = this.query("#session-menu-open-credits");
+    this.backToSettingsFromInstructionsButton = this.query("#session-menu-back-to-settings-from-instructions");
     this.backToSettingsButton = this.query("#session-menu-back-to-settings");
     this.sensitivityInput = this.query("#session-menu-sensitivity");
     this.sensitivityValue = this.query("#session-menu-sensitivity-value");
@@ -712,7 +816,9 @@ export class SessionMenu {
 
     this.resumeButton.addEventListener("click", () => this.onResume?.());
     this.mainMenuButton.addEventListener("click", () => this.onMainMenu?.());
+    this.openInstructionsButton.addEventListener("click", () => this.showView("instructions"));
     this.openCreditsButton.addEventListener("click", () => this.showView("credits"));
+    this.backToSettingsFromInstructionsButton.addEventListener("click", () => this.showView("settings"));
     this.backToSettingsButton.addEventListener("click", () => this.showView("settings"));
 
     this.sensitivityInput.addEventListener("input", () => {
@@ -829,9 +935,17 @@ export class SessionMenu {
 
   private showView(view: SessionMenuView): void {
     this.settingsView.hidden = view !== "settings";
+    this.instructionsView.hidden = view !== "instructions";
     this.creditsView.hidden = view !== "credits";
 
     if (!this.currentConfig) return;
+
+    if (view === "instructions") {
+      const instructionsContent = getInstructionsContent(isTouchDevice());
+      this.title.textContent = instructionsContent.title;
+      this.subtitle.textContent = instructionsContent.subtitle;
+      return;
+    }
 
     if (view === "credits") {
       this.title.textContent = "Credits";
@@ -846,6 +960,62 @@ export class SessionMenu {
   private query<T extends HTMLElement>(selector: string): T {
     return this.root.querySelector<T>(selector) as T;
   }
+}
+
+function buildInstructionsHtml(content: InstructionsContent): string {
+  const controlsHtml = content.controls.length > 0
+    ? `
+      <section class="ob-session-settings-card">
+        <div class="ob-session-settings-title">Desktop Controls</div>
+        <div class="ob-session-note">Keyboard and mouse bindings from the README quick reference.</div>
+        <div class="ob-session-control-list">
+          ${content.controls.map((control) => `
+            <div class="ob-session-control-row">
+              <div class="ob-session-control-key">${escapeHtml(control.input)}</div>
+              <div class="ob-session-control-action">${escapeHtml(control.action)}</div>
+            </div>
+          `).join("")}
+        </div>
+      </section>
+    `
+    : "";
+
+  return `
+    <section class="ob-session-settings-card">
+      <div class="ob-session-settings-title">Objective</div>
+      <div class="ob-session-note">Cyan and Magenta fight to breach the opposing room.</div>
+      <div class="ob-session-instructions-grid">
+        ${content.objective.map((item) => buildInstructionItem(item)).join("")}
+      </div>
+    </section>
+
+    <section class="ob-session-settings-card">
+      <div class="ob-session-settings-title">Round Flow</div>
+      <div class="ob-session-note">From breach-room launch to zero-G freeze fight.</div>
+      <div class="ob-session-instructions-grid">
+        ${content.roundFlow.map((item) => buildInstructionItem(item)).join("")}
+      </div>
+    </section>
+
+    <section class="ob-session-settings-card">
+      <div class="ob-session-settings-title">Winning</div>
+      <div class="ob-session-note">How rounds score, how matches end, and what happens on timeout.</div>
+      <div class="ob-session-instructions-grid">
+        ${content.winningScenarios.map((item) => buildInstructionItem(item, true)).join("")}
+      </div>
+    </section>
+
+    ${controlsHtml}
+  `;
+}
+
+function buildInstructionItem(item: { title: string; body: string }, wide = false): string {
+  return `
+    <article class="ob-session-instruction-item${wide ? " ob-session-instruction-item--wide" : ""}">
+      <div class="ob-session-instruction-title">${escapeHtml(item.title)}</div>
+      <div class="ob-session-instruction-body">${escapeHtml(item.body)}</div>
+    </article>
+  `;
 }
 
 function escapeHtml(raw: string): string {

--- a/tests/instructionsContent.test.ts
+++ b/tests/instructionsContent.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { getInstructionsContent } from "../client/src/ui/instructionsContent";
+
+describe("getInstructionsContent", () => {
+  it("includes README-derived desktop controls", () => {
+    const content = getInstructionsContent(false);
+    const inputs = content.controls.map((control) => control.input);
+
+    expect(inputs).toEqual(
+      expect.arrayContaining([
+        "Mouse",
+        "WASD",
+        "E",
+        "Space",
+        "Left mouse button",
+        "Tab",
+        "Esc",
+      ]),
+    );
+  });
+
+  it("omits desktop key bindings for mobile instructions", () => {
+    const content = getInstructionsContent(true);
+
+    expect(content.controls).toEqual([]);
+    expect(content.title).toBe("Mobile Instructions");
+  });
+
+  it("explains scoring, match wins, and timeout ties in both variants", () => {
+    for (const isMobile of [false, true]) {
+      const content = getInstructionsContent(isMobile);
+      const text = [
+        ...content.roundFlow,
+        ...content.winningScenarios,
+      ].map((item) => item.body).join(" ");
+
+      expect(text).toContain("Freeze all enemies on the opposing team");
+      expect(text).toContain("Cross the enemy breach portal");
+      expect(text).toContain("first team to 5 round wins");
+      expect(text).toContain("120-second round timer expires");
+      expect(text).toContain("tie and no point is awarded");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add responsive desktop/mobile Instructions content for objective, round flow, scoring, match wins, and timeout ties.
- Expose Instructions from the main menu and from the session menu before Credits.
- Style the instructions view with cyan/magenta accents while preserving single-column mobile layouts and bounded grids.
- Add Vitest coverage for the pure instructions content helper and update README status.

## Validation

- `cd client && node_modules/.bin/tsc --noEmit`
- `cd server && node_modules/.bin/tsc --noEmit`
- `npm test`
- `npm run build --prefix client`
- `npm run build --prefix server`

## Notes

- This PR targets `staging` so it remains separate from #80 (`staging` -> `main`).
- Manual browser smoke was not run in this environment because browser automation tooling is unavailable here.