### PR TITLE
Fix itch index cursor visibility

### DIFF
--- a/itch/index.html
+++ b/itch/index.html
@@ -18,7 +18,7 @@
       position: fixed; inset: 0; z-index: 20;
       background: #04060e;
       overflow: hidden;
-      cursor: none;
+      cursor: auto;
       touch-action: none;
       animation: wc-fade-in .6s ease both;
     }
@@ -57,7 +57,7 @@
       font-size: clamp(11px, 1.5vw, 15px);
       letter-spacing: clamp(4px, 1vw, 9px);
       text-transform: uppercase;
-      cursor: none;
+      cursor: pointer;
       overflow: hidden;
       touch-action: manipulation;
       backdrop-filter: blur(14px);

--- a/tests/itchIndexCursor.test.ts
+++ b/tests/itchIndexCursor.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const itchIndex = readFileSync(path.resolve(__dirname, "../itch/index.html"), "utf8");
+
+function cssRuleFor(selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = itchIndex.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`));
+  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  return match[1];
+}
+
+describe("itch index cursor styles", () => {
+  it("keeps the desktop cursor visible on the embed entry page", () => {
+    expect(cssRuleFor(".wc-root")).not.toContain("cursor: none");
+    expect(cssRuleFor(".wc-root")).toContain("cursor: auto");
+  });
+
+  it("uses normal pointer affordance for the breach button", () => {
+    expect(cssRuleFor(".wc-btn")).not.toContain("cursor: none");
+    expect(cssRuleFor(".wc-btn")).toContain("cursor: pointer");
+  });
+});


### PR DESCRIPTION
## Summary
- keep the desktop cursor visible on the static itch embed entry page
- use a normal pointer cursor for the Breach button
- add a regression test for the itch page cursor CSS

## Validation
- npm run build --prefix client
- npx vitest run tests/itchIndexCursor.test.ts (with NODE_PATH pointed at npx temp deps because this checkout has no root vitest install)
- npx vitest run (same NODE_PATH workaround): 38 files / 218 tests passed

Closes #90