### PR TITLE
Fix instructions wording and layout

### DIFF
--- a/client/src/ui/instructionsContent.ts
+++ b/client/src/ui/instructionsContent.ts
@@ -20,7 +20,7 @@ export interface InstructionsContent {
 const OBJECTIVE: InstructionTextBlock[] = [
   {
     title: "Objective",
-    body: "Freeze the enemy squad, open their breach portal, and cross it before they recover their formation.",
+    body: "Win each round by breaching the enemy room or freezing every enemy pilot.",
   },
   {
     title: "Teams",
@@ -38,19 +38,23 @@ const ROUND_FLOW: InstructionTextBlock[] = [
     body: "Drift through debris, use rails to redirect, and fire the freeze pistol at enemy pilots.",
   },
   {
-    title: "Open The Portal",
-    body: "Freeze all enemies on the opposing team to open their breach portal route.",
+    title: "FREEZE TO SCORE",
+    body: "Freeze all enemy players to score a round instantly.",
   },
   {
     title: "Breach To Score",
-    body: "Cross the enemy breach portal to score a round for your team.",
+    body: "Cross into the enemy breach room to score a round for your team.",
   },
 ];
 
 const WINNING_SCENARIOS: InstructionTextBlock[] = [
   {
-    title: "Round Win",
-    body: "A round is won when a player crosses the enemy breach portal after the enemy team has been fully frozen.",
+    title: "Breach Win",
+    body: "A round is won when a player breaches the enemy room.",
+  },
+  {
+    title: "Freeze Win",
+    body: "A round is also won when every enemy player is frozen.",
   },
   {
     title: "Match Win",
@@ -79,10 +83,8 @@ const DESKTOP_CONTROLS: InstructionControl[] = [
 
 export function getInstructionsContent(isMobile: boolean): InstructionsContent {
   return {
-    title: isMobile ? "Mobile Instructions" : "Desktop Instructions",
-    subtitle: isMobile
-      ? "Round flow, objective, and scoring rules for touch pilots."
-      : "Controls, objective, round flow, and scoring rules for desktop pilots.",
+    title: "INSTRUCTIONS",
+    subtitle: "Controls, objective, round flow, and scoring rules.",
     objective: OBJECTIVE,
     roundFlow: ROUND_FLOW,
     winningScenarios: WINNING_SCENARIOS,

--- a/client/src/ui/sessionMenu.ts
+++ b/client/src/ui/sessionMenu.ts
@@ -962,12 +962,12 @@ export class SessionMenu {
   }
 }
 
-function buildInstructionsHtml(content: InstructionsContent): string {
+export function buildInstructionsHtml(content: InstructionsContent): string {
   const controlsHtml = content.controls.length > 0
     ? `
       <section class="ob-session-settings-card">
-        <div class="ob-session-settings-title">Desktop Controls</div>
-        <div class="ob-session-note">Keyboard and mouse bindings from the README quick reference.</div>
+        <div class="ob-session-settings-title">Controls</div>
+        <div class="ob-session-note">Keyboard and mouse bindings from the quick reference.</div>
         <div class="ob-session-control-list">
           ${content.controls.map((control) => `
             <div class="ob-session-control-row">
@@ -981,6 +981,8 @@ function buildInstructionsHtml(content: InstructionsContent): string {
     : "";
 
   return `
+    ${controlsHtml}
+
     <section class="ob-session-settings-card">
       <div class="ob-session-settings-title">Objective</div>
       <div class="ob-session-note">Cyan and Magenta fight to breach the opposing room.</div>
@@ -1004,8 +1006,6 @@ function buildInstructionsHtml(content: InstructionsContent): string {
         ${content.winningScenarios.map((item) => buildInstructionItem(item, true)).join("")}
       </div>
     </section>
-
-    ${controlsHtml}
   `;
 }
 

--- a/tests/instructionsContent.test.ts
+++ b/tests/instructionsContent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { getInstructionsContent } from "../client/src/ui/instructionsContent";
+import { buildInstructionsHtml } from "../client/src/ui/sessionMenu";
 
 describe("getInstructionsContent", () => {
   it("includes README-derived desktop controls", () => {
@@ -24,22 +25,56 @@ describe("getInstructionsContent", () => {
     const content = getInstructionsContent(true);
 
     expect(content.controls).toEqual([]);
-    expect(content.title).toBe("Mobile Instructions");
+    expect(content.title).toBe("INSTRUCTIONS");
   });
 
-  it("explains scoring, match wins, and timeout ties in both variants", () => {
+  it("uses a unified title in both variants", () => {
+    for (const isMobile of [false, true]) {
+      const content = getInstructionsContent(isMobile);
+
+      expect(content.title).toBe("INSTRUCTIONS");
+      expect(content.title).not.toContain("Desktop");
+      expect(content.title).not.toContain("Mobile");
+    }
+  });
+
+  it("explains independent round wins, match wins, and timeout ties in both variants", () => {
     for (const isMobile of [false, true]) {
       const content = getInstructionsContent(isMobile);
       const text = [
+        ...content.objective,
         ...content.roundFlow,
         ...content.winningScenarios,
-      ].map((item) => item.body).join(" ");
+      ].map((item) => `${item.title} ${item.body}`).join(" ");
 
-      expect(text).toContain("Freeze all enemies on the opposing team");
-      expect(text).toContain("Cross the enemy breach portal");
+      expect(text).toContain("breaching the enemy room or freezing every enemy pilot");
+      expect(text).toContain("FREEZE TO SCORE");
+      expect(text).toContain("Freeze all enemy players to score a round instantly");
+      expect(text).toContain("A round is won when a player breaches the enemy room");
+      expect(text).toContain("A round is also won when every enemy player is frozen");
       expect(text).toContain("first team to 5 round wins");
       expect(text).toContain("120-second round timer expires");
       expect(text).toContain("tie and no point is awarded");
+      expect(text).not.toContain("open their breach portal");
+      expect(text).not.toContain("after the enemy team has been fully frozen");
     }
+  });
+
+  it("renders controls before mechanics when desktop controls are available", () => {
+    const html = buildInstructionsHtml(getInstructionsContent(false));
+
+    expect(html.indexOf("Controls")).toBeGreaterThanOrEqual(0);
+    expect(html.indexOf("Controls")).toBeLessThan(html.indexOf("Objective"));
+    expect(html.indexOf("Controls")).toBeLessThan(html.indexOf("Round Flow"));
+    expect(html.indexOf("Controls")).toBeLessThan(html.indexOf("Winning"));
+    expect(html).not.toContain("Desktop Controls");
+  });
+
+  it("keeps mobile instructions readable without an empty controls section", () => {
+    const html = buildInstructionsHtml(getInstructionsContent(true));
+
+    expect(html).not.toContain("ob-session-control-list");
+    expect(html.indexOf("Objective")).toBeGreaterThanOrEqual(0);
+    expect(html.indexOf("Round Flow")).toBeGreaterThan(html.indexOf("Objective"));
   });
 });


### PR DESCRIPTION
## Summary
- clarify instructions page round wins as independent breach or freeze scoring conditions
- replace misleading portal-opening flow copy with FREEZE TO SCORE wording
- use unified INSTRUCTIONS title and render desktop controls before mechanics
- add coverage for title, copy, desktop ordering, and mobile no-controls rendering

## Validation
- npm run build --prefix client
- npm exec --yes --package vitest -- powershell -NoProfile -Command '$npxBin = ($env:PATH -split '';'' | Where-Object { $_ -match ''_npx.*node_modules\\.bin'' } | Select-Object -First 1); $env:NODE_PATH = (Split-Path $npxBin -Parent); vitest run tests/instructionsContent.test.ts'
- npm exec --yes --package vitest -- powershell -NoProfile -Command '$npxBin = ($env:PATH -split '';'' | Where-Object { $_ -match ''_npx.*node_modules\\.bin'' } | Select-Object -First 1); $env:NODE_PATH = (Split-Path $npxBin -Parent); vitest run'

## Notes
- `npm test` is currently blocked in this checkout because there is no root `package.json`; the full Vitest suite passes via temporary `npm exec --package vitest` resolution.

Closes #83