### PR TITLE
Apply team colors to in-game hints

### DIFF
--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -9,6 +9,29 @@ const IS_MOBILE = isTouchDevice();
 
 export type GamePhase = 'LOBBY' | 'COUNTDOWN' | 'PLAYING' | 'ROUND_END';
 
+export interface TeamHintPalette {
+  textColor: string;
+  glowColor: string;
+  panelBg: string;
+  powerGradient: string;
+}
+
+export function getTeamHintPalette(team: 0 | 1): TeamHintPalette {
+  return team === 0
+    ? {
+        textColor: '#aaffff',
+        glowColor: '#00ffff',
+        panelBg: 'rgba(0,8,8,0.72)',
+        powerGradient: 'linear-gradient(90deg, rgba(116, 245, 255, 0.98), rgba(255, 223, 127, 0.92))',
+      }
+    : {
+        textColor: '#ffaaff',
+        glowColor: '#ff00ff',
+        panelBg: 'rgba(8,0,8,0.72)',
+        powerGradient: 'linear-gradient(90deg, rgba(255, 130, 239, 0.98), rgba(255, 214, 122, 0.92))',
+      };
+}
+
 export function buildRoundEndHtml(
   result:
     | "tie"
@@ -94,6 +117,9 @@ export class HUD {
   }
 
   public update(state: HudState): void {
+    this.view.root.classList.toggle("ob-hud-root--cyan", state.team === 0);
+    this.view.root.classList.toggle("ob-hud-root--magenta", state.team === 1);
+
     if (state.phase !== this.prevPhase) {
       if (this.prevPhase === 'ROUND_END' && state.phase === 'COUNTDOWN') {
         this.isFirstRound = false;
@@ -106,8 +132,8 @@ export class HUD {
     this.renderCountdown(state.phase, state.countdown);
     this.renderObjectiveTypewriter(state.phase, state.dt, state.team);
     this.renderCrosshair(state.dt);
-    this.renderGrabPrompt(state.playerPhase, state.nearBar, state.damage);
-    this.renderPowerBar(state.playerPhase, state.launchPower, state.maxLaunchPower);
+    this.renderGrabPrompt(state.playerPhase, state.nearBar, state.damage, state.team);
+    this.renderPowerBar(state.playerPhase, state.launchPower, state.maxLaunchPower, state.team);
     this.renderDamage(state.damage);
     this.renderTutorial(state.phase, state.tutorialPrompt, state.team);
     this.renderScoreboard(state.tabHeld, state.ownTeam, state.enemyTeam, state.showPing, state.team);
@@ -167,13 +193,11 @@ export class HUD {
   private renderObjectiveTypewriter(phase: GamePhase, dt: number, team: 0 | 1): void {
     const el = this.view.objective;
     if (this.isFirstRound && phase === 'COUNTDOWN') {
-      const textColor = team === 0 ? '#aaffff' : '#ffaaff';
-      const glowColor = team === 0 ? '#00ffff' : '#ff00ff';
-      const backdropBg = team === 0 ? 'rgba(0,8,8,0.72)' : 'rgba(8,0,8,0.72)';
+      const palette = getTeamHintPalette(team);
 
-      el.style.color = textColor;
-      el.style.textShadow = `0 0 12px ${glowColor}`;
-      el.style.background = backdropBg;
+      el.style.color = palette.textColor;
+      el.style.textShadow = `0 0 12px ${palette.glowColor}`;
+      el.style.background = palette.panelBg;
       el.style.padding = '4px 14px';
       el.style.borderRadius = '4px';
       el.style.display = 'block';
@@ -198,8 +222,10 @@ export class HUD {
     playerPhase: string,
     nearBar: boolean,
     damage: DamageState,
+    team: 0 | 1,
   ): void {
     const el = this.view.grab;
+    const palette = getTeamHintPalette(team);
     let promptText = '';
     let show = false;
 
@@ -208,8 +234,8 @@ export class HUD {
         show = true;
         promptText = 'Pull mouse down to charge power - release [SPACE] to launch';
         el.style.fontSize = '14px';
-        el.style.color = '#ffff88';
-        el.style.textShadow = '0 0 8px #ffaa00';
+        el.style.color = palette.textColor;
+        el.style.textShadow = `0 0 8px ${palette.glowColor}`;
       }
     } else if (playerPhase === 'GRABBING') {
       show = true;
@@ -217,8 +243,8 @@ export class HUD {
         ? 'Hold LAUNCH and drag down to charge'
         : 'Hold [SPACE] to aim';
       el.style.fontSize = IS_MOBILE ? '13px' : '15px';
-      el.style.color = '#aaffff';
-      el.style.textShadow = '0 0 8px #00ffff';
+      el.style.color = palette.textColor;
+      el.style.textShadow = `0 0 8px ${palette.glowColor}`;
     } else if (
       nearBar
       && (playerPhase === 'FLOATING' || playerPhase === 'BREACH')
@@ -229,8 +255,8 @@ export class HUD {
         show = true;
         promptText = '[E]  GRAB BAR';
         el.style.fontSize = '17px';
-        el.style.color = '#aaffff';
-        el.style.textShadow = '0 0 8px #00ffff';
+        el.style.color = palette.textColor;
+        el.style.textShadow = `0 0 8px ${palette.glowColor}`;
       }
     }
 
@@ -242,6 +268,7 @@ export class HUD {
     playerPhase: string,
     launchPower: number,
     maxLaunchPower: number,
+    team: 0 | 1,
   ): void {
     if (IS_MOBILE) {
       this.view.powerWrap.style.display = 'none';
@@ -261,8 +288,10 @@ export class HUD {
     this.view.powerLabel.textContent = capPct < 99.9
       ? `POWER  ${Math.round(pct)}% (CAP ${Math.round(capPct)}%)`
       : `POWER  ${Math.round(pct)}%`;
-    const hue = 120 - pct * 1.2;
-    this.view.powerBar.style.background = `hsl(${hue},90%,55%)`;
+    const palette = getTeamHintPalette(team);
+    this.view.powerBar.style.background = palette.powerGradient;
+    this.view.powerLabel.style.color = palette.textColor;
+    this.view.powerLabel.style.textShadow = `0 0 8px ${palette.glowColor}`;
   }
 
   private renderDamage(damage: DamageState): void {

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -66,6 +66,9 @@ const HUD_CSS = `
     --hud-cyan-soft: oklch(0.82 0.15 210 / 0.14);
     --hud-magenta: oklch(0.72 0.25 330);
     --hud-magenta-soft: oklch(0.72 0.25 330 / 0.22);
+    --hud-team: var(--hud-cyan);
+    --hud-team-soft: var(--hud-cyan-soft);
+    --hud-team-glow: oklch(0.82 0.15 210 / 0.38);
     --hud-text: #e8ecf4;
     --hud-muted: #9aa5b8;
     --hud-panel: rgba(7, 10, 18, 0.76);
@@ -83,6 +86,18 @@ const HUD_CSS = `
 
   .ob-hud-root * {
     box-sizing: border-box;
+  }
+
+  .ob-hud-root--cyan {
+    --hud-team: var(--hud-cyan);
+    --hud-team-soft: var(--hud-cyan-soft);
+    --hud-team-glow: oklch(0.82 0.15 210 / 0.38);
+  }
+
+  .ob-hud-root--magenta {
+    --hud-team: var(--hud-magenta);
+    --hud-team-soft: var(--hud-magenta-soft);
+    --hud-team-glow: oklch(0.72 0.25 330 / 0.42);
   }
 
   .ob-score-cluster {
@@ -247,12 +262,13 @@ const HUD_CSS = `
 
   .ob-power-label {
     margin-top: 7px;
-    color: #e3fbff;
+    color: var(--hud-team);
     font-family: "JetBrains Mono", monospace;
     font-size: 11px;
     letter-spacing: 0.12em;
     text-align: center;
     text-transform: uppercase;
+    text-shadow: 0 0 8px var(--hud-team-glow);
   }
 
   .ob-damage-panel {
@@ -323,7 +339,7 @@ const HUD_CSS = `
   }
 
   .ob-tutorial__eyebrow {
-    color: var(--hud-muted);
+    color: var(--hud-team);
     font-family: "JetBrains Mono", monospace;
     font-size: 10px;
     font-weight: 700;
@@ -333,6 +349,7 @@ const HUD_CSS = `
 
   .ob-tutorial__title {
     margin-top: 6px;
+    color: var(--hud-team);
     font-family: "Cormorant Garamond", serif;
     font-size: 22px;
     font-weight: 400;
@@ -341,9 +358,10 @@ const HUD_CSS = `
 
   .ob-tutorial__body {
     margin-top: 6px;
-    color: #d6edf5;
+    color: var(--hud-team);
     font-size: 13px;
     line-height: 1.55;
+    text-shadow: 0 0 10px var(--hud-team-glow);
   }
 
   .ob-round-end {

--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -328,6 +328,7 @@ const CSS = `
   }
   .ob-btn-primary::before  { background: radial-gradient(circle at var(--mx,50%) var(--my,50%), var(--ob-magenta-soft), transparent 60%); }
   .ob-btn-secondary::before{ background: radial-gradient(circle at var(--mx,50%) var(--my,50%), var(--ob-cyan-soft),    transparent 60%); }
+  .ob-btn-online::before   { background: radial-gradient(circle at var(--mx,50%) var(--my,50%), rgba(255, 210, 112, .2), rgba(255, 92, 208, .1) 42%, transparent 68%); }
   .ob-btn-utility::before  { background: radial-gradient(circle at var(--mx,50%) var(--my,50%), rgba(140,225,255,.12), transparent 62%); }
   .ob-btn:hover { border-color: rgba(255,255,255,.4); transform: translateY(-1px); }
   .ob-btn:hover::before { opacity: 1; }
@@ -335,6 +336,16 @@ const CSS = `
   .ob-btn:hover .ob-btn-icon { transform: rotate(18deg) scale(1.06); }
   .ob-btn-primary:hover  { color: oklch(0.88 0.12 60);  border-color: var(--ob-magenta); }
   .ob-btn-secondary:hover{ color: var(--ob-cyan); border-color: var(--ob-cyan); }
+  .ob-btn-online:hover {
+    color: #ffd670;
+    border-color: rgba(255, 214, 112, .82);
+    background:
+      linear-gradient(135deg, rgba(255, 92, 208, .14), rgba(255, 214, 112, .08)),
+      rgba(18, 12, 24, .72);
+    box-shadow:
+      0 0 0 1px rgba(255, 92, 208, .26) inset,
+      0 14px 34px rgba(255, 92, 208, .14);
+  }
   .ob-btn-utility:hover  { color: var(--ob-cyan); border-color: rgba(140,225,255,.42); }
   .ob-btn:focus-visible { outline: 2px solid var(--ob-cyan); outline-offset: 3px; }
   .ob-btn-corner {
@@ -582,8 +593,9 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
     const adornment = iconHtml
       ? `<span class="ob-btn-icon">${iconHtml}</span>`
       : `<span class="ob-btn-arrow">&rarr;</span>`;
+    const onlineClass = id === "btn-play-online" ? " ob-btn-online" : "";
     return `
-      <button class="ob-btn ob-btn-${mod}" id="${id}">
+      <button class="ob-btn ob-btn-${mod}${onlineClass}" id="${id}">
         <span class="ob-btn-corner ob-tl"></span><span class="ob-btn-corner ob-tr"></span>
         <span class="ob-btn-corner ob-bl"></span><span class="ob-btn-corner ob-br"></span>
         <span class="ob-btn-label">${label} ${adornment}</span>

--- a/tests/teamPresentation.test.ts
+++ b/tests/teamPresentation.test.ts
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import { applyTeamAccent } from "../client/src/player/teamAccent";
@@ -7,7 +8,7 @@ import {
   sortDebriefPlayers,
   type DebriefPlayer,
 } from "../client/src/ui/debrief";
-import { buildRoundEndHtml } from "../client/src/render/hud";
+import { buildRoundEndHtml, getTeamHintPalette } from "../client/src/render/hud";
 import { getTeamRelationLabel } from "../client/src/ui/multiplayerLobby";
 
 describe("applyTeamAccent", () => {
@@ -49,6 +50,28 @@ describe("applyTeamAccent", () => {
 });
 
 describe("player-relative team UI helpers", () => {
+  it("uses team-colored palettes for in-game hint text", () => {
+    const cyan = getTeamHintPalette(0);
+    const magenta = getTeamHintPalette(1);
+
+    expect(cyan.textColor).toBe("#aaffff");
+    expect(cyan.glowColor).toBe("#00ffff");
+    expect(cyan.panelBg).toContain("rgba(0,8,8");
+    expect(magenta.textColor).toBe("#ffaaff");
+    expect(magenta.glowColor).toBe("#ff00ff");
+    expect(magenta.panelBg).toContain("rgba(8,0,8");
+    expect(magenta.powerGradient).toContain("255, 130, 239");
+  });
+
+  it("gives Play Online a dedicated hover style instead of generic secondary cyan only", () => {
+    const menuView = readFileSync(new URL("../client/src/ui/menu/menuView.ts", import.meta.url), "utf8");
+
+    expect(menuView).toContain("ob-btn-online::before");
+    expect(menuView).toContain(".ob-btn-online:hover");
+    expect(menuView).toContain('id === "btn-play-online" ? " ob-btn-online"');
+    expect(menuView).toContain("#ffd670");
+  });
+
   it("marks friendly and hostile teams relative to the local player", () => {
     expect(getTeamRelationLabel(0, 0)).toBe("Friendly");
     expect(getTeamRelationLabel(0, 1)).toBe("Hostile");


### PR DESCRIPTION
## Summary
- apply the current player team palette to objective, grab/aim, power, and tutorial hint text
- add a dedicated magenta/gold hover treatment for the Play Online button
- cover team hint palette and Play Online class assignment in tests

## Validation
- npm run build --prefix client
- temp Vitest runner: `run tests/teamPresentation.test.ts` (6 tests)
- temp Vitest runner: `run` (37 files / 218 tests)
- `npm test` attempted but this repo copy has no root package.json

Closes #85