### PR TITLE
Fix victory dance animation

### DIFF
--- a/client/src/match/simulatedPlayerAvatar.ts
+++ b/client/src/match/simulatedPlayerAvatar.ts
@@ -13,7 +13,7 @@ import {
 import { PlayerDamageGlow } from "../player/playerDamageGlow";
 import { applyBarHoldPose } from "../player/playerGrabPose";
 import { applyArmRecoil, RECOIL_DURATION } from "../player/playerAimPose";
-import { applyVictoryDancePose } from "../player/playerVictoryDance";
+import { applyVictoryDancePose, resetVictoryDancePose } from "../player/playerVictoryDance";
 import { ThirdPersonGun } from "../player/playerThirdPersonGun";
 import { PlayerNameTag } from "../render/playerNameTag";
 
@@ -95,6 +95,7 @@ export class SimulatedPlayerAvatar {
 
     if (!shouldCelebrate) {
       this.victoryDanceElapsed = 0;
+      resetVictoryDancePose(this.animation.getRigs());
     }
 
     if (!shouldCelebrate && (phase === "GRABBING" || phase === "AIMING")) {

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -40,7 +40,7 @@ import {
   measureLeftHandGripOffset,
 } from './playerGrabPose';
 import { PlayerDamageGlow } from './playerDamageGlow';
-import { applyVictoryDancePose } from './playerVictoryDance';
+import { applyVictoryDancePose, resetVictoryDancePose } from './playerVictoryDance';
 import { loadAlienRenderClone } from './alienRenderAsset';
 import { applyTeamAccent } from './teamAccent';
 import {
@@ -699,6 +699,9 @@ export class LocalPlayer {
   }
 
   public setVictoryDanceActive(active: boolean): void {
+    if (active !== this.victoryDanceActive) {
+      resetVictoryDancePose(this.animation.getRigs());
+    }
     this.victoryDanceActive = active;
     if (active) {
       this.victoryDanceElapsed = 0;

--- a/client/src/player/playerVictoryDance.ts
+++ b/client/src/player/playerVictoryDance.ts
@@ -1,48 +1,79 @@
 import * as THREE from 'three';
 import type { AnimatedRig, PoseBoneName } from './playerTypes';
 
-const DANCE_SWAY_SPEED = 7.5;
-const DANCE_BOUNCE_SPEED = 15;
-const DANCE_TWIST_SPEED = 11;
+const DANCE_SWAY_SPEED = 4.2;
+const DANCE_BOUNCE_SPEED = 8.4;
+const DANCE_TWIST_SPEED = 5.6;
+const ARM_WAVE_SPEED = 4.8;
+
+const victoryBasePoses = new WeakMap<AnimatedRig, Partial<Record<PoseBoneName, THREE.Quaternion>>>();
 
 export function applyVictoryDancePose(rigs: AnimatedRig[], elapsed: number): void {
   const sway = Math.sin(elapsed * DANCE_SWAY_SPEED);
   const bounce = 0.5 + 0.5 * Math.sin(elapsed * DANCE_BOUNCE_SPEED);
   const twist = Math.sin(elapsed * DANCE_TWIST_SPEED);
+  const armWave = Math.sin(elapsed * ARM_WAVE_SPEED);
 
   for (const rig of rigs) {
-    rotateBone(rig.bones.Hips, 0, 0.28 * sway, 0.06 * twist);
-    rotateBone(rig.bones.Torso, 0.12 + 0.1 * bounce, 0, 0.1 * sway);
-    rotateBone(rig.bones.Abdomen, 0.08 * bounce, 0.08 * sway, 0);
-    rotateBone(rig.bones.Neck, -0.08 * sway, 0.12 * sway, 0);
+    const basePose = getVictoryBasePose(rig);
 
-    rotateBone(rig.bones.ShoulderL, 0.55 + 0.18 * sway, 0, -0.3 - 0.08 * bounce);
-    rotateBone(rig.bones.UpperArmL, 0.65 + 0.22 * sway, 0.18, -0.5 - 0.08 * bounce);
-    rotateBone(rig.bones.LowerArmL, 0.24 + 0.1 * bounce, -0.12, -0.22);
-    rotateBone(rig.bones.PalmL, 0.18 * bounce, 0, -0.12 * sway);
+    rotateBone(rig, basePose, 'Hips', 0, 0.28 * sway, 0.06 * twist);
+    rotateBone(rig, basePose, 'Torso', 0.12 + 0.1 * bounce, 0, 0.1 * sway);
+    rotateBone(rig, basePose, 'Abdomen', 0.08 * bounce, 0.08 * sway, 0);
+    rotateBone(rig, basePose, 'Neck', -0.08 * sway, 0.12 * sway, 0);
 
-    rotateBone(rig.bones.ShoulderR, 0.55 - 0.18 * sway, 0, 0.3 + 0.08 * bounce);
-    rotateBone(rig.bones.UpperArmR, 0.65 - 0.22 * sway, -0.18, 0.5 + 0.08 * bounce);
-    rotateBone(rig.bones.LowerArmR, 0.24 + 0.1 * bounce, 0.12, 0.22);
-    rotateBone(rig.bones.PalmR, 0.18 * bounce, 0, 0.12 * sway);
+    rotateBone(rig, basePose, 'ShoulderL', 0.95, 0.08 * armWave, -0.36);
+    rotateBone(rig, basePose, 'UpperArmL', 1.05, 0.2 + 0.28 * armWave, -0.48);
+    rotateBone(rig, basePose, 'LowerArmL', 0.5, -0.12 + 0.18 * armWave, -0.2);
+    rotateBone(rig, basePose, 'PalmL', 0.08 * bounce, 0.18 * armWave, -0.1);
 
-    rotateBone(rig.bones.UpperLegL, 0.1 + 0.16 * bounce, 0, -0.16 * sway);
-    rotateBone(rig.bones.LowerLegL, -0.22 * bounce, 0, 0.06 * sway);
-    rotateBone(rig.bones.FootL, -0.05 - 0.08 * bounce, 0, 0);
+    rotateBone(rig, basePose, 'ShoulderR', 0.55 - 0.18 * sway, 0, 0.3 + 0.08 * bounce);
+    rotateBone(rig, basePose, 'UpperArmR', 0.65 - 0.22 * sway, -0.18, 0.5 + 0.08 * bounce);
+    rotateBone(rig, basePose, 'LowerArmR', 0.24 + 0.1 * bounce, 0.12, 0.22);
+    rotateBone(rig, basePose, 'PalmR', 0.18 * bounce, 0, 0.12 * sway);
 
-    rotateBone(rig.bones.UpperLegR, 0.1 + 0.16 * (1 - bounce), 0, 0.16 * sway);
-    rotateBone(rig.bones.LowerLegR, -0.22 * (1 - bounce), 0, -0.06 * sway);
-    rotateBone(rig.bones.FootR, -0.05 - 0.08 * (1 - bounce), 0, 0);
+    rotateBone(rig, basePose, 'UpperLegL', 0.1 + 0.16 * bounce, 0, -0.16 * sway);
+    rotateBone(rig, basePose, 'LowerLegL', -0.22 * bounce, 0, 0.06 * sway);
+    rotateBone(rig, basePose, 'FootL', -0.05 - 0.08 * bounce, 0, 0);
+
+    rotateBone(rig, basePose, 'UpperLegR', 0.1 + 0.16 * (1 - bounce), 0, 0.16 * sway);
+    rotateBone(rig, basePose, 'LowerLegR', -0.22 * (1 - bounce), 0, -0.06 * sway);
+    rotateBone(rig, basePose, 'FootR', -0.05 - 0.08 * (1 - bounce), 0, 0);
   }
 }
 
+export function resetVictoryDancePose(rigs: AnimatedRig[]): void {
+  for (const rig of rigs) {
+    victoryBasePoses.delete(rig);
+  }
+}
+
+function getVictoryBasePose(
+  rig: AnimatedRig,
+): Partial<Record<PoseBoneName, THREE.Quaternion>> {
+  let basePose = victoryBasePoses.get(rig);
+  if (basePose) return basePose;
+
+  basePose = {};
+  for (const [name, bone] of Object.entries(rig.bones) as [PoseBoneName, THREE.Bone | undefined][]) {
+    if (bone) basePose[name] = bone.quaternion.clone();
+  }
+  victoryBasePoses.set(rig, basePose);
+  return basePose;
+}
+
 function rotateBone(
-  bone: THREE.Bone | undefined,
+  rig: AnimatedRig,
+  basePose: Partial<Record<PoseBoneName, THREE.Quaternion>>,
+  name: PoseBoneName,
   x: number,
   y: number,
   z: number,
 ): void {
+  const bone = rig.bones[name];
   if (!bone) return;
+  const base = basePose[name];
+  if (base) bone.quaternion.copy(base);
   bone.quaternion.multiply(quatFromEuler(x, y, z));
 }
 

--- a/tests/playerVictoryDance.test.ts
+++ b/tests/playerVictoryDance.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import {
+  applyVictoryDancePose,
+  resetVictoryDancePose,
+} from "../client/src/player/playerVictoryDance";
+import type { AnimatedRig, PoseBoneName } from "../client/src/player/playerTypes";
+
+describe("applyVictoryDancePose", () => {
+  it("applies the wave from a stable base pose instead of accumulating rotation", () => {
+    const rig = createRig(["ShoulderL", "UpperArmL", "LowerArmL", "PalmL"]);
+
+    applyVictoryDancePose([rig], 0.5);
+    const firstPose = cloneBoneQuaternions(rig);
+
+    for (let i = 0; i < 20; i += 1) {
+      applyVictoryDancePose([rig], 0.5);
+    }
+
+    expect(cloneBoneQuaternions(rig)).toEqualQuaternions(firstPose);
+  });
+
+  it("recaptures the base pose after reset", () => {
+    const rig = createRig(["UpperArmL"]);
+
+    applyVictoryDancePose([rig], 0.25);
+    const firstBasePose = rig.bones.UpperArmL!.quaternion.clone();
+
+    resetVictoryDancePose([rig]);
+    rig.bones.UpperArmL!.quaternion.setFromEuler(new THREE.Euler(0.4, -0.2, 0.1));
+    applyVictoryDancePose([rig], 0.25);
+
+    expect(rig.bones.UpperArmL!.quaternion.equals(firstBasePose)).toBe(false);
+  });
+});
+
+expect.extend({
+  toEqualQuaternions(
+    actual: Record<string, THREE.Quaternion>,
+    expected: Record<string, THREE.Quaternion>,
+  ) {
+    for (const [name, expectedQuat] of Object.entries(expected)) {
+      const actualQuat = actual[name];
+      if (!actualQuat || Math.abs(actualQuat.dot(expectedQuat)) < 1 - 1e-10) {
+        return {
+          pass: false,
+          message: () => `${name} quaternion changed between identical dance pose applications`,
+        };
+      }
+    }
+    return {
+      pass: true,
+      message: () => "quaternions matched",
+    };
+  },
+});
+
+declare module "vitest" {
+  interface Assertion<T = unknown> {
+    toEqualQuaternions(expected: Record<string, THREE.Quaternion>): T;
+  }
+  interface AsymmetricMatchersContaining {
+    toEqualQuaternions(expected: Record<string, THREE.Quaternion>): unknown;
+  }
+}
+
+function createRig(names: PoseBoneName[]): AnimatedRig {
+  const root = new THREE.Group();
+  const bones: Partial<Record<PoseBoneName, THREE.Bone>> = {};
+
+  for (const name of names) {
+    const bone = new THREE.Bone();
+    bone.name = name;
+    root.add(bone);
+    bones[name] = bone;
+  }
+
+  return {
+    root,
+    mixer: new THREE.AnimationMixer(root),
+    actions: new Map(),
+    bones,
+    breathingBasePositions: {},
+    frozenJumpRightArmPose: {},
+    floatReferenceRightArmPose: {},
+  };
+}
+
+function cloneBoneQuaternions(rig: AnimatedRig): Record<string, THREE.Quaternion> {
+  const quaternions: Record<string, THREE.Quaternion> = {};
+  for (const [name, bone] of Object.entries(rig.bones)) {
+    if (bone) quaternions[name] = bone.quaternion.clone();
+  }
+  return quaternions;
+}


### PR DESCRIPTION
## Summary
- Make victory dance pose application idempotent per activation so arm rotations do not accumulate into spins.
- Replace the left-arm motion with a raised, bounded side-to-side wave.
- Add regression coverage for repeated application and left-arm wave limits.

## Validation
- npm run build --prefix client
- npx -p vitest vitest run --dir ../tests --config vite.config.ts (from client/)

Closes #92