### PR TITLE
Fix fullscreen settings sync

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -24,7 +24,7 @@ import { SceneManager } from "../render/scene";
 import { isEmbedMode } from "../embed";
 import { KillFeed } from "../ui/kill-feed";
 import { initGlobalCursor, type GlobalCursor } from "../ui/globalCursor";
-import { enterFullscreen, exitFullscreen, isFullscreen } from "../ui/fullscreen";
+import { isFullscreen, leaveFullscreen, requestFullscreen } from "../ui/fullscreen";
 import { MainMenu } from "../ui/menu";
 import { MobileControls } from "../ui/mobileControls";
 import { RoomBrowser } from "../ui/roomBrowser";
@@ -189,7 +189,7 @@ export class App {
       this.applySessionSettings(settings);
       if (fullscreenPreferenceChanged) {
         this.fullscreenPreference = settings.fullscreenEnabled;
-        this.applyFullscreenPreference(settings.fullscreenEnabled);
+        void this.applyFullscreenPreference(settings.fullscreenEnabled);
       }
     };
 
@@ -1200,11 +1200,13 @@ export class App {
     this.sound.setMusicEnabled(settings.soundtrackEnabled);
   }
 
-  private applyFullscreenPreference(enabled: boolean): void {
-    if (enabled) {
-      if (!isFullscreen()) enterFullscreen();
-    } else if (isFullscreen()) {
-      exitFullscreen();
+  private async applyFullscreenPreference(enabled: boolean): Promise<void> {
+    const applied = enabled
+      ? (isFullscreen() || await requestFullscreen())
+      : (!isFullscreen() || await leaveFullscreen());
+
+    if (!applied) {
+      this.sessionMenu.syncFullscreenFromBrowser();
     }
   }
 

--- a/client/src/ui/fullscreen.ts
+++ b/client/src/ui/fullscreen.ts
@@ -8,17 +8,41 @@ type FullscreenElement = HTMLElement & {
 };
 
 export function enterFullscreen(): void {
-  if (typeof document === "undefined") return;
+  void requestFullscreen();
+}
+
+export async function requestFullscreen(): Promise<boolean> {
+  if (!isFullscreenSupported()) return false;
   const el = document.documentElement as FullscreenElement;
-  const requestFullscreen = el.requestFullscreen ?? el.webkitRequestFullscreen;
-  void requestFullscreen?.call(el);
+  const request = el.requestFullscreen ?? el.webkitRequestFullscreen;
+  if (!request) return false;
+
+  try {
+    await request.call(el);
+    return isFullscreen();
+  } catch {
+    return false;
+  }
 }
 
 export function exitFullscreen(): void {
-  if (typeof document === "undefined") return;
+  void leaveFullscreen();
+}
+
+export async function leaveFullscreen(): Promise<boolean> {
+  if (typeof document === "undefined") return false;
+  if (!isFullscreen()) return true;
+
   const fullscreenDocument = document as FullscreenDocument;
   const exit = fullscreenDocument.exitFullscreen ?? fullscreenDocument.webkitExitFullscreen;
-  void exit?.call(fullscreenDocument);
+  if (!exit) return false;
+
+  try {
+    await exit.call(fullscreenDocument);
+    return !isFullscreen();
+  } catch {
+    return false;
+  }
 }
 
 export function isFullscreen(): boolean {
@@ -39,6 +63,12 @@ export function onFullscreenChange(cb: () => void): () => void {
 
 export function isFullscreenSupported(): boolean {
   if (typeof document === "undefined") return false;
+  const fullscreenDocument = document as FullscreenDocument & {
+    fullscreenEnabled?: boolean;
+    webkitFullscreenEnabled?: boolean;
+  };
+  const enabled = fullscreenDocument.fullscreenEnabled ?? fullscreenDocument.webkitFullscreenEnabled;
+  if (enabled === false) return false;
   const el = document.documentElement as FullscreenElement | undefined;
   return Boolean(el?.requestFullscreen ?? el?.webkitRequestFullscreen);
 }

--- a/client/src/ui/multiplayerLobby.ts
+++ b/client/src/ui/multiplayerLobby.ts
@@ -1267,7 +1267,7 @@ function describeQueueState(state: MultiplayerRoomSnapshot, humans: number): str
     return "Both squads are full and the ready check passed.";
   }
   if (state.phase === "PLAYING") {
-    return "Match is deployed. Menu access and settings stay available between points.";
+    return "Match is live. Menu access and settings stay available between points.";
   }
   if (state.phase === "ROUND_END") {
     return "Point resolved. The next round will auto-cycle while the room stays checked in.";

--- a/client/src/ui/sessionMenu.ts
+++ b/client/src/ui/sessionMenu.ts
@@ -5,7 +5,7 @@ import {
   ITCH_IO_URL,
   NOAM_SOUNDCLOUD_URL,
 } from "./creditsContent";
-import { isFullscreenSupported } from "./fullscreen";
+import { isFullscreen, isFullscreenSupported, onFullscreenChange } from "./fullscreen";
 import { getInstructionsContent, type InstructionsContent } from "./instructionsContent";
 import { GITHUB_ICON_SVG, ITCH_ICON_SVG } from "./linkIcons";
 import { isTouchDevice } from "../platform";
@@ -608,6 +608,7 @@ export class SessionMenu {
   private readonly sfxInput: HTMLInputElement;
   private readonly sfxValue: HTMLSpanElement;
   private readonly cameraSelect: HTMLSelectElement;
+  private readonly disposeFullscreenListener: () => void;
   private settings = loadSettings();
   private currentConfig: SessionMenuConfig | null = null;
 
@@ -647,7 +648,7 @@ export class SessionMenu {
           <div id="session-menu-settings-view" class="ob-session-view">
             <section class="ob-session-settings-card">
               <div class="ob-session-settings-title">Flight Settings</div>
-              <div class="ob-session-note">Changes apply immediately. Soundtrack toggle mutes music while preserving the level setting.</div>
+              <div class="ob-session-note">Changes apply immediately.</div>
 
               <div class="ob-session-field">
                 <div class="ob-session-field-head">
@@ -663,7 +664,7 @@ export class SessionMenu {
                   <span id="session-menu-soundtrack-value" class="ob-session-value"></span>
                 </div>
                 <label class="ob-session-toggle">
-                  <span class="ob-session-toggle-copy">Keep the soundtrack channel armed once the music pass lands.</span>
+                  <span class="ob-session-toggle-copy">Play music during menus and matches.</span>
                   <input id="session-menu-soundtrack" class="ob-session-checkbox" type="checkbox" />
                 </label>
               </div>
@@ -674,7 +675,7 @@ export class SessionMenu {
                   <span id="session-menu-fullscreen-value" class="ob-session-value"></span>
                 </div>
                 <label class="ob-session-toggle">
-                  <span class="ob-session-toggle-copy">Enter fullscreen on breach and when toggled from this panel.</span>
+                  <span class="ob-session-toggle-copy">Use fullscreen when this browser allows it.</span>
                   <input id="session-menu-fullscreen" class="ob-session-checkbox" type="checkbox" />
                 </label>
               </div>
@@ -716,7 +717,7 @@ export class SessionMenu {
 
             <section class="ob-session-settings-card">
               <div class="ob-session-settings-title">Credits</div>
-              <div class="ob-session-note">Review model, audio, and project-link credits without leaving the build.</div>
+              <div class="ob-session-note">View music, sound, asset, and project credits.</div>
               <div class="ob-session-card-actions">
                 <button id="session-menu-open-credits" type="button" class="ob-session-inline-button">Open Credits</button>
               </div>
@@ -770,7 +771,7 @@ export class SessionMenu {
 
             <section class="ob-session-settings-card">
               <div class="ob-session-settings-title">Asset Credits</div>
-              <div class="ob-session-note">3D model assets used by the current browser build.</div>
+              <div class="ob-session-note">3D assets featured in Orbital Breach.</div>
               <div class="ob-session-credit-list">
                 ${ASSET_CREDITS.map((credit) => `
                   <article class="ob-session-credit-item">
@@ -857,6 +858,9 @@ export class SessionMenu {
       this.renderSettings();
       this.onSettingsChange?.(this.getSettings());
     });
+    this.disposeFullscreenListener = onFullscreenChange(() => {
+      this.syncFullscreenFromBrowser();
+    });
 
     this.renderSettings();
   }
@@ -907,6 +911,25 @@ export class SessionMenu {
     this.launcher.style.display = visible ? "inline-flex" : "none";
   }
 
+  public syncFullscreenFromBrowser(notify = true): void {
+    const fullscreenEnabled = isFullscreenSupported() && isFullscreen();
+    if (this.settings.fullscreenEnabled === fullscreenEnabled) {
+      this.renderSettings();
+      return;
+    }
+
+    this.settings.fullscreenEnabled = fullscreenEnabled;
+    this.persistSettings();
+    this.renderSettings();
+    if (notify) this.onSettingsChange?.(this.getSettings());
+  }
+
+  public dispose(): void {
+    this.disposeFullscreenListener();
+    this.root.remove();
+    this.launcher.remove();
+  }
+
   private persistSettings(): void {
     localStorage.setItem(STORAGE_KEYS.mouseSensitivity, String(this.settings.mouseSensitivity));
     localStorage.setItem(STORAGE_KEYS.musicVolume, String(this.settings.musicVolume));
@@ -949,7 +972,7 @@ export class SessionMenu {
 
     if (view === "credits") {
       this.title.textContent = "Credits";
-      this.subtitle.textContent = "Asset, audio, and external-link acknowledgements for Orbital Breach.";
+      this.subtitle.textContent = "Music, sound, asset, and project credits for Orbital Breach.";
       return;
     }
 
@@ -967,7 +990,7 @@ function buildInstructionsHtml(content: InstructionsContent): string {
     ? `
       <section class="ob-session-settings-card">
         <div class="ob-session-settings-title">Desktop Controls</div>
-        <div class="ob-session-note">Keyboard and mouse bindings from the README quick reference.</div>
+        <div class="ob-session-note">Keyboard and mouse controls for desktop play.</div>
         <div class="ob-session-control-list">
           ${content.controls.map((control) => `
             <div class="ob-session-control-row">
@@ -1036,7 +1059,9 @@ function loadSettings(): SessionSettings {
   // Always default music to ON — never persist "off" state across sessions.
   // Stale "0" values from prior sessions would silently gate all audio on mobile.
   localStorage.removeItem(STORAGE_KEYS.soundtrackEnabled);
-  const fullscreenEnabled = localStorage.getItem(STORAGE_KEYS.fullscreenEnabled);
+  const fullscreenEnabled = isFullscreenSupported()
+    ? localStorage.getItem(STORAGE_KEYS.fullscreenEnabled)
+    : "false";
   const musicVolume = Number(localStorage.getItem(STORAGE_KEYS.musicVolume) ?? DEFAULT_SETTINGS.musicVolume);
   const sfxVolume = Number(localStorage.getItem(STORAGE_KEYS.sfxVolume) ?? DEFAULT_SETTINGS.sfxVolume);
   const savedCameraMode = localStorage.getItem(STORAGE_KEYS.defaultCameraMode);

--- a/tests/fullscreen.test.ts
+++ b/tests/fullscreen.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { isFullscreen, isFullscreenSupported } from "../client/src/ui/fullscreen";
+import {
+  isFullscreen,
+  isFullscreenSupported,
+  leaveFullscreen,
+  requestFullscreen,
+} from "../client/src/ui/fullscreen";
 
 const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
 
@@ -48,6 +53,61 @@ describe("fullscreen utilities", () => {
       },
     });
     expect(isFullscreenSupported()).toBe(true);
+  });
+
+  it("respects browser fullscreenEnabled guards", () => {
+    installDocument({
+      documentElement: {
+        requestFullscreen: () => {},
+      },
+      fullscreenEnabled: false,
+    });
+
+    expect(isFullscreenSupported()).toBe(false);
+  });
+
+  it("reports whether a fullscreen request actually entered fullscreen", async () => {
+    const documentMock: Record<string, unknown> = {
+      documentElement: {
+        requestFullscreen: () => {
+          documentMock.fullscreenElement = documentMock.documentElement;
+          return Promise.resolve();
+        },
+      },
+      fullscreenElement: null,
+    };
+    installDocument(documentMock);
+
+    await expect(requestFullscreen()).resolves.toBe(true);
+    expect(isFullscreen()).toBe(true);
+  });
+
+  it("reports rejected fullscreen requests without throwing", async () => {
+    installDocument({
+      documentElement: {
+        requestFullscreen: () => Promise.reject(new Error("denied")),
+      },
+      fullscreenElement: null,
+    });
+
+    await expect(requestFullscreen()).resolves.toBe(false);
+    expect(isFullscreen()).toBe(false);
+  });
+
+  it("reports whether exiting fullscreen succeeded", async () => {
+    const fullscreenElement = {};
+    const documentMock: Record<string, unknown> = {
+      documentElement: {},
+      fullscreenElement,
+      exitFullscreen: () => {
+        documentMock.fullscreenElement = null;
+        return Promise.resolve();
+      },
+    };
+    installDocument(documentMock);
+
+    await expect(leaveFullscreen()).resolves.toBe(true);
+    expect(isFullscreen()).toBe(false);
   });
 
   it("returns false when the fullscreen APIs are unavailable", () => {


### PR DESCRIPTION
## Summary
- sync the settings fullscreen toggle from browser fullscreen state changes and failed fullscreen requests
- guard unsupported fullscreen contexts with an unavailable setting state
- rewrite developer-facing settings/lobby copy into player-facing menu text
- add fullscreen utility tests for browser guards, request failure, and exit success

## Validation
- npm run build --prefix client
- npm test (blocked: no root package.json in this checkout)
- NODE_PATH=server/node_modules;client/node_modules npx --yes vitest run --config vitest.config.ts

Closes #82