### PR TITLE
Fix online disconnect cleanup

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -272,6 +272,11 @@ export class App {
       this.killFeed.addKill(event.killerName, event.killerTeam, event.victimName, event.victimTeam);
     };
 
+    this.net.onPlayerLeaveEvent = (event) => {
+      if (this.isUserExitingOnline || this.appMode !== "online") return;
+      this.killFeed.addLeave(event.playerName, event.playerTeam);
+    };
+
     this.net.onRoundResultEvent = (event) => {
       if (this.isUserExitingOnline || this.appMode !== "online") return;
       if (!this.onlineGameActive) return;

--- a/client/src/net/client.ts
+++ b/client/src/net/client.ts
@@ -16,6 +16,7 @@ import {
   type MultiplayerJoinOptions,
   type MultiplayerRoomSnapshot,
   type OnlineActorSnapshot,
+  type PlayerLeaveEventMessage,
   type PlayerUpdateMessage,
   type RoundResultEventMessage,
   type SetReadyMessage,
@@ -54,6 +55,7 @@ export class NetClient {
   public onLobbyEvent: ((event: LobbyEventMessage) => void) | null = null;
   public onLeave: (() => void) | null = null;
   public onFreezeEvent: ((event: FreezeEventMessage) => void) | null = null;
+  public onPlayerLeaveEvent: ((event: PlayerLeaveEventMessage) => void) | null = null;
   public onRoundResultEvent: ((event: RoundResultEventMessage) => void) | null = null;
   public onShotEvent: ((event: ShotEventMessage) => void) | null = null;
 
@@ -77,6 +79,9 @@ export class NetClient {
     });
     room.onMessage("freeze_event", (event: FreezeEventMessage) => {
       this.onFreezeEvent?.(event);
+    });
+    room.onMessage("player_leave_event", (event: PlayerLeaveEventMessage) => {
+      this.onPlayerLeaveEvent?.(event);
     });
     room.onMessage("round_result_event", (event: RoundResultEventMessage) => {
       this.onRoundResultEvent?.(event);

--- a/client/src/ui/kill-feed.ts
+++ b/client/src/ui/kill-feed.ts
@@ -78,4 +78,45 @@ export class KillFeed {
     setTimeout(() => { entry.style.opacity = "0"; }, 4500);
     setTimeout(() => { entry.remove(); }, 5000);
   }
+
+  public addLeave(playerName: string, playerTeam: 0 | 1): void {
+    const color = playerTeam === 0 ? "#00ffff" : "#ff00ff";
+    const entry = document.createElement("div");
+    const displayName = this.localPlayerName && playerName === this.localPlayerName ? "YOU" : playerName;
+    entry.innerHTML =
+      `<span style="color:${color};text-shadow:0 0 6px ${color};font-weight:bold">${escapeHtml(displayName)}</span>`
+      + `<span style="color:#c8c8c8;margin-left:6px">Player left</span>`;
+
+    Object.assign(entry.style, {
+      background: "rgba(88,92,99,0.78)",
+      border: "1px solid rgba(180,185,194,0.45)",
+      borderRadius: "4px",
+      padding: "3px 10px",
+      transition: "opacity 0.5s ease",
+      opacity: "1",
+    });
+
+    this.container.prepend(entry);
+    setTimeout(() => { entry.style.opacity = "0"; }, 4500);
+    setTimeout(() => { entry.remove(); }, 5000);
+  }
+}
+
+function escapeHtml(raw: string): string {
+  return raw.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return ch;
+    }
+  });
 }

--- a/server/src/colyseus/OrbitalLobbyRoom.ts
+++ b/server/src/colyseus/OrbitalLobbyRoom.ts
@@ -138,7 +138,11 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
   }
 
   public onJoin(client: RoomClient, options?: { name?: string }): void {
-    const joinTeam = this.getJoinTeamForHuman();
+    const playerName = sanitizePlayerName(options?.name);
+    const reclaimedTeam = this.removeStaleHumanPresenceForName(playerName, client.sessionId);
+    const joinTeam = reclaimedTeam !== null && this.hasSeatForHuman(reclaimedTeam)
+      ? reclaimedTeam
+      : this.getJoinTeamForHuman();
     if (joinTeam === null) {
       throw new Error("That room is full right now.");
     }
@@ -147,7 +151,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     const member = new LobbyMemberState();
     member.id = client.sessionId;
     member.sessionId = client.sessionId;
-    member.name = sanitizePlayerName(options?.name);
+    member.name = playerName;
     member.team = joinTeam;
     member.ready = false;
     member.connected = true;
@@ -165,10 +169,16 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     const member = this.state.members.get(client.sessionId);
     if (member) {
       const leavingName = member.name;
+      const leavingTeam = member.team;
       this.state.members.delete(client.sessionId);
       this.broadcast("lobby_event", {
         type: "info",
         text: `${leavingName} left the room.`,
+      });
+      this.broadcast("player_leave_event", {
+        playerId: client.sessionId,
+        playerName: leavingName,
+        playerTeam: leavingTeam,
       });
     }
 
@@ -184,6 +194,8 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
       this.state.countdownRemaining = 0;
       this.state.roundTimeRemaining = 0;
       this.clearActors();
+    } else {
+      this.checkTeamDisconnectWin();
     }
 
     this.syncLobbyFlow();
@@ -542,11 +554,29 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     }
   }
 
+  private checkTeamDisconnectWin(): void {
+    if (this.roundResolved || this.state.phase !== "PLAYING") return;
+
+    const actors = Array.from(this.state.actors.values());
+    const team0Active = actors.some((actor) => actor.team === 0);
+    const team1Active = actors.some((actor) => actor.team === 1);
+
+    if (team0Active === team1Active) return;
+
+    const winningTeam = team0Active ? 0 : 1;
+    this.awardOnlineRoundPoint(
+      winningTeam,
+      null,
+      winningTeam === 0 ? "Cyan Team" : "Magenta Team",
+      "disconnect",
+    );
+  }
+
   private awardOnlineRoundPoint(
     team: 0 | 1,
     scorerId: string | null,
     scorerName: string,
-    reason: "breach" | "fullFreeze",
+    reason: "breach" | "fullFreeze" | "disconnect",
   ): void {
     if (this.roundResolved) return;
     this.roundResolved = true;
@@ -671,6 +701,22 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     this.botAI.delete(id);
     this.botFireTimers.delete(id);
     this.lastPlayerUpdate.delete(id);
+  }
+
+  private removeStaleHumanPresenceForName(name: string, sessionId: string): LobbyTeam | null {
+    let reclaimedTeam: LobbyTeam | null = null;
+
+    for (const member of Array.from(this.state.members.values())) {
+      if (member.isBot || member.id === sessionId || member.name !== name) {
+        continue;
+      }
+
+      reclaimedTeam = member.team;
+      this.state.members.delete(member.id);
+      this.removePresence(member.id);
+    }
+
+    return reclaimedTeam;
   }
 
   private tickBots(dt: number): void {
@@ -879,6 +925,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
     }
 
     this.state.members.delete(removableBot.id);
+    this.removePresence(removableBot.id);
     return true;
   }
 

--- a/shared/multiplayer.ts
+++ b/shared/multiplayer.ts
@@ -150,11 +150,17 @@ export interface FreezeEventMessage {
   victimTeam: 0 | 1;
 }
 
+export interface PlayerLeaveEventMessage {
+  playerId: string;
+  playerName: string;
+  playerTeam: 0 | 1;
+}
+
 export interface RoundResultEventMessage {
   outcome: "tie" | "win";
   winningTeam: 0 | 1 | null;
   matchWinner: 0 | 1 | null;
-  reason: "breach" | "fullFreeze" | "timeout";
+  reason: "breach" | "fullFreeze" | "disconnect" | "timeout";
   scorerId?: string;
   scorerName: string;
   finalScore?: {

--- a/tests/onlineMatch.test.ts
+++ b/tests/onlineMatch.test.ts
@@ -3,6 +3,7 @@ import * as THREE from "three";
 import type { OnlineActorSnapshot } from "../shared/multiplayer";
 
 const avatarUpdate = vi.fn();
+const avatarDispose = vi.fn();
 
 vi.mock("../client/src/match/simulatedPlayerAvatar", () => ({
   SimulatedPlayerAvatar: class {
@@ -10,7 +11,9 @@ vi.mock("../client/src/match/simulatedPlayerAvatar", () => ({
     public constructor(_scene: THREE.Scene, team: 0 | 1) {
       this.team = team;
     }
-    public dispose(): void {}
+    public dispose(): void {
+      avatarDispose(this.team);
+    }
     public triggerArmRecoil(): void {}
     public update(...args: unknown[]): void {
       avatarUpdate(this.team, ...args);
@@ -23,6 +26,7 @@ import { OnlineMatch } from "../client/src/match/onlineMatch";
 describe("OnlineMatch", () => {
   beforeEach(() => {
     avatarUpdate.mockClear();
+    avatarDispose.mockClear();
   });
 
   it("routes celebration only to remote actors on the winning team", () => {
@@ -48,6 +52,28 @@ describe("OnlineMatch", () => {
 
     expect(team0Flags).toEqual([false]);
     expect(team1Flags).toEqual([true]);
+
+    match.dispose();
+  });
+
+  it("disposes remote actors that disappear from the authoritative snapshot", () => {
+    const match = new OnlineMatch(new THREE.Scene());
+    match.applySnapshot(
+      [
+        createActor("remote-cyan", 0),
+        createActor("remote-magenta", 1),
+      ],
+      "local-player",
+    );
+
+    match.applySnapshot([createActor("remote-magenta", 1)], "local-player");
+
+    expect(avatarDispose).toHaveBeenCalledTimes(1);
+    expect(avatarDispose).toHaveBeenCalledWith(0);
+
+    avatarUpdate.mockClear();
+    match.update(1 / 60);
+    expect(avatarUpdate.mock.calls.map(([team]) => team)).toEqual([1]);
 
     match.dispose();
   });

--- a/tests/onlineRoomLeave.test.ts
+++ b/tests/onlineRoomLeave.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { OrbitalLobbyRoom } from "../server/src/colyseus/OrbitalLobbyRoom";
 import { ActorState, LobbyMemberState, OrbitalLobbyState } from "../server/src/colyseus/state";
 
@@ -43,6 +43,10 @@ function addActor(
 }
 
 describe("OrbitalLobbyRoom onLeave", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("removes the departing human from roster and live actors without touching bots", () => {
     const room = createRoom();
     room.state.phase = "PLAYING";
@@ -63,6 +67,32 @@ describe("OrbitalLobbyRoom onLeave", () => {
     expect(room.state.members.has("bot-0")).toBe(true);
     expect(room.state.actors.has("bot-0")).toBe(true);
     expect(room.state.phase).toBe("PLAYING");
+    expect(room.broadcast).toHaveBeenCalledWith("player_leave_event", {
+      playerId: "human-1",
+      playerName: "Alpha",
+      playerTeam: 0,
+    });
+  });
+
+  it("awards a technical round win when one team fully disconnects during play", () => {
+    vi.useFakeTimers();
+    const room = createRoom();
+    room.state.phase = "PLAYING";
+
+    addMember(room, "human-1", { name: "Alpha", team: 0 });
+    addMember(room, "human-2", { name: "Bravo", team: 1 });
+    addActor(room, "human-1", { name: "Alpha", team: 0 });
+    addActor(room, "human-2", { name: "Bravo", team: 1 });
+
+    room.onLeave({ sessionId: "human-1" } as never);
+
+    expect(room.state.scoreTeam1).toBe(1);
+    expect(room.broadcast).toHaveBeenCalledWith("round_result_event", expect.objectContaining({
+      outcome: "win",
+      winningTeam: 1,
+      reason: "disconnect",
+      scorerName: "Magenta Team",
+    }));
   });
 
   it("clears bots, actors, and round state when the room loses its last human", () => {
@@ -97,6 +127,21 @@ describe("OrbitalLobbyRoom onLeave", () => {
 });
 
 describe("OrbitalLobbyRoom onJoin", () => {
+  it("reclaims a stale same-name human slot and actor before seating a rejoin", () => {
+    const room = createRoom();
+    room.state.phase = "LOBBY";
+
+    addMember(room, "old-session", { name: "Alpha", team: 0 });
+    addActor(room, "old-session", { name: "Alpha", team: 0 });
+
+    room.onJoin({ sessionId: "new-session" } as never, { name: "Alpha" });
+
+    expect(room.state.members.has("old-session")).toBe(false);
+    expect(room.state.actors.has("old-session")).toBe(false);
+    expect(room.state.members.has("new-session")).toBe(true);
+    expect(room.state.members.get("new-session")?.team).toBe(0);
+  });
+
   it("reclaims a bot seat when a human joins a bot-filled lobby", () => {
     const room = createRoom();
     room.state.phase = "LOBBY";
@@ -114,5 +159,22 @@ describe("OrbitalLobbyRoom onJoin", () => {
       currentPlayers: 2,
       maxPlayers: 2,
     }));
+  });
+
+  it("removes a reclaimed bot actor when seating a human during countdown", () => {
+    const room = createRoom();
+    room.state.phase = "COUNTDOWN";
+
+    addMember(room, "bot-0", { name: "CY-BOT-01", team: 0, isBot: true });
+    addMember(room, "bot-1", { name: "MG-BOT-01", team: 1, isBot: true });
+    addActor(room, "bot-0", { name: "CY-BOT-01", team: 0, isBot: true });
+    addActor(room, "bot-1", { name: "MG-BOT-01", team: 1, isBot: true });
+
+    room.onJoin({ sessionId: "human-1" } as never, { name: "Alpha" });
+
+    expect(room.state.members.has("human-1")).toBe(true);
+    expect(room.state.members.has("bot-0")).toBe(false);
+    expect(room.state.actors.has("bot-0")).toBe(false);
+    expect(room.state.actors.has("bot-1")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- reclaim stale same-name online player slots before seating rejoins
- remove departed actors and bot actor leftovers from authoritative server state
- add typed leave events, neutral kill feed feedback, and disconnect technical wins
- cover stale rejoin, disconnect win, bot seat cleanup, and client actor reconciliation with tests

## Validation
- npx vitest run
- npm run build --prefix server
- npm run build --prefix client

Closes #86