### PR TITLE
docs: refresh architecture and testing docs to match production state

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ Orbital Breach runs in the browser with no account or install. The game supports
 
 Two teams, **Team Cyan** and **Team Magenta**, spawn in opposite breach rooms around a zero-G arena. Each round begins from gravity, then players jump, grab rails, charge a launch, and drift through the arena.
 
-The freeze pistol disables enemies for the rest of the round. Limb hits matter: a damaged right arm blocks firing, damaged legs reduce launch power, and a full freeze strands the pilot. Once a team is frozen, the enemy portal route opens. A player scores by reaching the opposing breach room and crossing the portal volume.
+The freeze pistol disables enemies for the rest of the round. Limb hits matter: a damaged right arm blocks firing, damaged legs reduce launch power, and a full freeze strands the pilot. A round is won in one of two independent ways:
 
-Matches are first to 5 round wins. Rounds have a 120-second limit and the online server runs authoritative match state at 20 Hz.
+- **Breach** — a non-frozen player crosses into the enemy breach room through the open portal volume.
+- **Full freeze** — every member of the enemy team is frozen at the same time.
+
+Portal doors open at the start of every round, so the breach path is live from the first second — freezing the enemy team is not a prerequisite for breaching, it is its own win condition. Matches are first team to 5 round wins. Rounds have a 120-second hard cap and the online server runs authoritative match state at 20 Hz.
 
 ## Playlists
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,82 +1,250 @@
 # Orbital Breach Architecture
 
-This document describes the post-AI-bots branch structure.
+This document describes the production architecture of Orbital Breach as it ships
+on Vercel (frontend) and Render (Colyseus multiplayer server). It reflects the
+current `staging` / `main` state, including the room browser, private/invite
+rooms, Vibe Jam portal handoff, mobile controls, the itch.io embed, analytics,
+and stale-player cleanup.
+
+For per-feature gameplay rules and tuning, read `CLAUDE.md` and `shared/constants.ts`.
 
 ---
 
-## Client
+## High-level shape
 
-### `client/src/game`
+```
+Browser (Three.js + TypeScript, built by Vite, hosted on Vercel)
+   │
+   │  Colyseus client over WebSocket  (ws / wss)
+   ▼
+Colyseus server (Node.js + Express, hosted on Render)
+   │
+   ├── /matchmake     room join + create
+   ├── /ws            Colyseus transport
+   ├── /health        Render health probe
+   ├── /wake          warm-up endpoint for free-tier cold starts
+   └── /rooms         public room directory
+```
+
+The same client codebase runs solo (no socket) and online (Colyseus). Solo and
+online share match-flow logic in `shared/`. The browser game also embeds inside
+the itch.io page via an `<iframe>` and supports the Vibe Jam 2026 portal protocol.
+
+---
+
+## Win conditions (authoritative)
+
+Two independent win paths per round, both implemented in
+`client/src/match/localMatch.ts` (solo) and `server/src/colyseus/OrbitalLobbyRoom.ts`
+(online):
+
+1. **Breach** — a non-frozen player from team A enters team B's breach room while
+   team B's portal door is open. Portal doors open when the round phase becomes
+   `PLAYING`; they are not gated on freezing the enemy team.
+2. **Full freeze** — every member of one team is frozen at the same time.
+   `findFullFreezeWinner` in `shared/player-logic.ts` decides this.
+
+Match wins are first-to-`MATCH_POINT_TARGET` round wins
+(`MATCH_POINT_TARGET = 5`, `shared/constants.ts`). Rounds also have a hard cap
+of `ROUND_DURATION_SECONDS = 120` so a stalled round always ends. The server
+runs authoritative state at `TICK_RATE = 20` Hz.
+
+---
+
+## Client (`client/src`)
+
+### Entry + composition
 
 | File | Responsibility |
 |---|---|
-| `gameApp.ts` | Main loop, menu start flow, round resets, HUD sync, projectile updates |
-| `projectileSystem.ts` | Visual projectiles plus nearest-hit resolution against obstacles, portal barriers, and actors |
-| `projectileActorCollision.ts` | Pure segment-vs-sphere collision helper for actor hits |
-| `weaponFire.ts` | Build human shot origin and direction from the camera and gun model |
-| `roundController.ts` | Countdown and round-end timing |
+| `main.ts` | Boot: inject Vercel Analytics + Speed Insights, then `new App().start()` |
+| `app.ts` | Re-export of `game/gameApp.App` |
+| `game/gameApp.ts` | Application shell: app-mode transitions (menu → solo / online lobby → match → debrief), Vibe Jam portal flow, render loop, HUD sync, projectile updates, portal-door state |
+| `featureFlags.ts`, `config.ts`, `embed.ts`, `platform.ts` | Build-time / runtime flags, itch.io embed detection, mobile/desktop platform detection |
 
-### `client/src/match`
+### Game systems (`client/src/game`)
 
 | File | Responsibility |
 |---|---|
-| `localMatch.ts` | Local solo match authority for bot fill, bot state, scoring, and roster building |
-| `botBrain.ts` | Bot navigation and combat decisions |
-| `arenaQueryAdapter.ts` | Adapter from Three.js arena queries to transport-neutral shared helpers |
-| `rosterView.ts` | Pure HUD roster shaping for own team vs enemy team |
+| `roundController.ts` | LOBBY → COUNTDOWN → PLAYING → ROUND_END timing for solo |
+| `projectileSystem.ts` | Visual projectiles + nearest-hit resolution against obstacles, portal barriers, and actors |
+| `projectileActorCollision.ts` | Pure segment-vs-sphere collision helper |
+| `weaponFire.ts` | Pure helper: build shot origin and direction from the camera and gun model |
+| `bulletCollision.ts` | Pure swept AABB ray test (`bulletHitsBox`, `bulletHitPoint`) |
+| `cameraYawFromBreach.ts` | Pure yaw math for breach-room re-entry |
+| `matchStatsTracker.ts` | Per-match stat accumulation for the debrief screen |
+| `gunTuneOverlay.ts`, `floatArmTuneOverlay.ts`, `overlayCursor.ts`, `scoreboardCursor.ts` | Dev / runtime overlay helpers |
+| `portal/parsePortalParams.ts` | Pure parser for Vibe Jam URL params (`portal`, `ref`, `username`, etc.) |
+| `portal/portalPlacement.ts` | Pure placement math for inbound/outbound portal walls |
+| `portal/vibeJamPortal.ts` | Three.js portal meshes + collision triggers; outbound target is `https://vibej.am/portal/2026`, return portal points back at `params.ref` |
+
+### Match runtime (`client/src/match`)
+
+| File | Responsibility |
+|---|---|
+| `localMatch.ts` | Solo authority: bot fill, scoring, round/match end, both win paths |
+| `onlineMatch.ts` | Reconciles server-authoritative snapshots into local actor state |
+| `botBrain.ts` | Bot navigation, target selection, grab/launch/fire decisions |
+| `arenaQueryAdapter.ts` | Adapter from Three.js arena to transport-neutral helpers in `shared/` |
+| `rosterView.ts` | Pure HUD roster shaping (own team vs enemy) |
 | `simulatedPlayerAvatar.ts` | Lightweight non-human actor rendering |
 
-### `client/src/player`
+### Player (`client/src/player`)
 
 | File | Responsibility |
 |---|---|
-| `localPlayer.ts` | Human-controlled player movement, bar grabbing, launching, damage, and breach scoring |
-| `playerCombat.ts` | Pure hit-zone classification used by human-facing logic |
+| `localPlayer.ts` | Human movement, grab, launch, damage, breach scoring |
+| `playerCombat.ts` | Pure hit-zone classification |
 | `playerSpawn.ts` | Breach-room spawn helpers |
+| `playerAnimationController.ts` | AnimationMixer crossfades for the alien rig |
+| `playerThirdPersonGun.ts` | Third-person gun rig and tuning |
+| `playerGrabPose.ts`, `playerAimPose.ts` | Bar-grab and aim pose math |
+| `playerVictoryDance.ts` | End-of-match winning-team dance animation |
+| `playerDamageGlow.ts`, `teamAccent.ts` | Damage feedback and team color accenting |
+| `onlineGrabSync.ts` | Online-only sync of grab state between server and renderer |
+| `alienRenderAsset.ts` | Loader/wiring for the Quaternius animated alien GLB rigs |
 
-### `client/src/arena`
+### Arena (`client/src/arena`)
 
 | File | Responsibility |
 |---|---|
-| `arena.ts` | Arena facade for layout loading, obstacle collision, breach-room queries, portal barriers, and bar lookup |
-| `breachRoomQueries.ts` | Pure breach-room inside/depth checks |
+| `arena.ts` | Arena facade: layout loading, obstacle collision, breach-room queries, portal barriers, bar lookup, `setPortalDoorsOpen` |
+| `breachRoomQueries.ts` | Pure inside / depth checks |
 | `obstacleCollision.ts` | Pure obstacle bounce helper |
 
-### `client/src/ui` and `client/src/render`
+### Render (`client/src/render`)
 
 | File | Responsibility |
 |---|---|
-| `ui/menu.ts` / `ui/menu/menuView.ts` | Main menu controller and DOM view, including solo match-size selection |
-| `render/hud.ts` | HUD orchestration |
-| `render/hud/scoreboard.ts` | Pure scoreboard HTML builder with bot labels |
+| `scene.ts` | `SceneManager` (Three.js scene, renderer, camera) |
+| `materials.ts` | Shared Three.js materials |
+| `gun.ts` | First-person gun viewmodel |
+| `playerNameTag.ts` | Above-head name tags for online + bot actors |
+| `hud/hud.ts` | HUD orchestration |
+| `hud/scoreboard.ts` | Pure scoreboard HTML builder (Tab-held roster, bot/online badges, ping column when online, frozen state) |
 
----
-
-## Shared
+### UI (`client/src/ui`)
 
 | File | Responsibility |
 |---|---|
-| `shared/match.ts` | Solo match-size types and bot-fill helpers |
-| `shared/player-logic.ts` | Transport-neutral hit classification, launch-power calculation, and breach spawn logic |
-| `shared/vec3.ts` | Lightweight vector math with no Three.js dependency |
-| `shared/schema.ts` | Shared player/game types used by both local solo and future multiplayer work |
-| `shared/constants.ts` | Shared tuning values and bot-name pool |
+| `menu/`, `menu.ts` | Main menu controller and DOM view: solo size selection, Join Online, Rooms & Invites, call sign, settings, credits |
+| `welcome/`, `welcome.ts` | First-launch welcome / call-sign capture |
+| `roomBrowser.ts` | Public room browser, public/private room creation, invite-link detection, direct join |
+| `multiplayerLobby.ts` | Online lobby: rosters, ready check, fill-bots / humans-only controls, invite URL, native share, QR code |
+| `mobileControls.ts` | Touch joystick, look area, GRAB / JUMP / LAUNCH / FIRE / camera-toggle buttons |
+| `instructionsContent.ts`, `creditsContent.ts`, `linkIcons.ts` | Pure builders for the instructions, credits, and external-link markup |
+| `kill-feed.ts` | In-match kill feed |
+| `debrief.ts` | Post-match summary with score, stats, and awards |
+| `sessionMenu.ts` | In-game pause / settings / safe-exit menu |
+| `fullscreen.ts` | Fullscreen toggle (disabled on iPhone Safari, which blocks non-video fullscreen) |
+| `confirmDialog.ts`, `globalCursor.ts`, `designTokens.ts` | UI primitives |
+
+### Networking (`client/src/net`)
+
+| File | Responsibility |
+|---|---|
+| `client.ts` | Colyseus client wrapper |
+| `endpoint.ts` | Resolves `VITE_COLYSEUS_ENDPOINT` (production) vs the Vite proxy (`/matchmake`, `/ws` → `localhost:2567`) in development |
+| `messages.ts` | Client-side message types mirroring the server schema |
+| `reconciliation.ts` | Server-authoritative state reconciliation |
+| `roomDirectory.ts` | Polling + caching for the public room list |
+| `wakeBackend.ts` | Hits `/wake` on the Render server before joining, to defrost cold starts |
+
+### Audio + analytics
+
+| File | Responsibility |
+|---|---|
+| `audio/SoundEngine.ts` | Loads `client/public/audio/*` (theme, hit, laser, countdown) and exposes `play(name)` |
+| `analytics/analytics.ts` | Wraps `@vercel/analytics`'s `track()` with typed events; landing visit properties are gathered once on boot |
+
+### Static assets (`client/public/`)
+
+`favicon.*`, `apple-touch-icon.png`, `android-chrome-*.png`, `site.webmanifest`,
+`orbital-breach-art.png`, `audio/`, `models/`, and `llms.txt` (a machine-readable
+project description served at the production root for LLM crawlers).
 
 ---
 
-## Server
+## Shared (`shared/`)
 
-The current `server/` directory still represents placeholder transport infrastructure on this branch:
+| File | Responsibility |
+|---|---|
+| `constants.ts` | Tuning values: `MATCH_POINT_TARGET`, `ROUND_DURATION_SECONDS`, `TICK_RATE`, freeze / launch / arena / breach-room sizes, bot name pool |
+| `schema.ts` | Player, game, and damage state types reused by client + server |
+| `match.ts` | Solo team-size types and bot-fill helpers |
+| `match-flow.ts` | Pure `findMatchWinner(score, target)` |
+| `player-logic.ts` | Transport-neutral hit classification, launch-power calculation, breach spawn, `findFullFreezeWinner` |
+| `multiplayer.ts` | Wire-format types and helpers for Colyseus messages |
+| `arena-gen.ts` | Deterministic arena layout (Mulberry32 RNG) |
+| `vec3.ts` | Lightweight vec3 math (no Three.js dependency) |
+| `profanity.ts` | Call-sign profanity filter |
 
-- `server/src/net/wsServer.ts` and `server/src/net/messageCodec.ts` stay transport-only
-- `server/src/room.ts` and `server/src/sim.ts` are not expanded to power the bot phase
-- The later Colyseus lobby migration is intentionally deferred to the separate multiplayer branch
+`shared/` is included via tsconfig `include` on both client and server, so a
+single source of truth ships to both runtimes.
 
 ---
 
-## Branch Intent
+## Server (`server/src`)
 
-- `feature/add-ai-bots`: local-only solo match flow with reusable shared gameplay helpers
-- `feature/add-colyseus-multiplayer`: future lobby-first online transport branch, refreshed from `staging` after AI bots merge
+The production server is a Colyseus + Express app on Render.
 
-The important boundary is that gameplay helpers can be shared later, but this branch does not introduce online room flow, matchmaking, or Colyseus dependencies.
+| File | Responsibility |
+|---|---|
+| `index.ts` | Express bootstrap: `helmet`, CORS allowlist (`CLIENT_ORIGIN`), rate limit, mount Colyseus transport, expose `/health`, `/wake`, `/rooms` |
+| `colyseus/OrbitalLobbyRoom.ts` | Room lifecycle: lobby → ready check → countdown → playing → round-end → match-end, authoritative actor state, hit validation, scoring, bot fill, both win paths, stale-player cleanup |
+| `colyseus/state.ts` | `@colyseus/schema` state classes synced to clients |
+| `colyseus/actorDamage.ts` | Authoritative damage application |
+| `colyseus/roomDirectory.ts` | Public room listing exposed via `/rooms` |
+| `room.ts`, `sim.ts`, `player.ts` | Legacy WS sim code retained for tests; the Colyseus path is the production runtime |
+| `net/wsServer.ts`, `net/messageCodec.ts` | Legacy raw-WS transport, no longer hit by production clients |
+
+Environment variables consumed by the server:
+
+| Var | Purpose |
+|---|---|
+| `PORT` | Render-assigned port |
+| `CLIENT_ORIGIN` | Allowed CORS origin (the Vercel domain) |
+| `PUBLIC_ADDRESS` | Public host advertised in `/rooms` payloads for invite URLs |
+| `NODE_ENV` | `production` on Render |
+
+The client picks up `VITE_COLYSEUS_ENDPOINT` at build time. In local dev, the
+Vite server proxies `/matchmake` and `/ws` to `localhost:2567` so the same code
+paths run in both environments.
+
+---
+
+## Deployment
+
+- **Frontend** — Vercel project pointed at `client/`. `vercel.json` (if present)
+  and Vite handle the static build. `@vercel/analytics` and
+  `@vercel/speed-insights` are injected by `client/src/main.ts` so Web Analytics
+  and Speed Insights light up automatically.
+- **Backend** — Render web service running `npm run start --prefix server`
+  (compiled by `npm run build --prefix server` during deploy). Render's free
+  tier sleeps the dyno; the client hits `/wake` before a join to mitigate cold
+  starts.
+- **itch.io page** — `https://dotanv.itch.io` embeds the Vercel build in an
+  iframe. `client/src/embed.ts` detects the iframe parent and `fullscreen.ts`
+  exposes a fullscreen toggle except on iPhone Safari, where non-video
+  fullscreen is unsupported.
+- **Vibe Jam portal** — when `?portal=true&ref=<url>` is on the URL, the inbound
+  return portal in the breach room targets `ref`; the outbound portal in the
+  arena always targets `https://vibej.am/portal/2026`.
+
+---
+
+## Mobile / desktop adaptation
+
+`client/src/platform.ts` detects coarse-pointer touch devices. On touch the
+client renders `mobileControls.ts` (joystick + look area + action buttons),
+hides the keyboard hint overlays, and routes pointer events through the input
+layer. The same Three.js scene runs in both modes.
+
+---
+
+## Stale player cleanup
+
+`OrbitalLobbyRoom` tracks per-client liveness. Clients that disconnect during a
+round have their seats reclaimed at round end so a returning human or new
+join slots back in instead of overfilling the lobby. The same path retires bots
+that fill gaps when a human leaves mid-match.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,156 +1,223 @@
 # Testing Guide
 
-## Setup
+Orbital Breach combines a [vitest](https://vitest.dev/) unit suite with a
+manual smoke checklist for browser-only behavior. The unit suite runs from the
+repo root in a Node environment; smoke tests cover the surfaces that need a
+real browser, multiplayer server, mobile device, or analytics backend.
 
-Tests run from the **repo root** using [vitest](https://vitest.dev/).
-vitest is in root `devDependencies` — no extra install needed.
+---
+
+## Commands
+
+All commands run from the **repo root** unless noted. Use the local
+`node_modules/.bin/tsc` binary — TypeScript is not installed globally.
 
 ```bash
-npm test              # run all tests once (CI-style)
-npm run test:watch    # re-run on file save (development)
+# Unit tests (vitest)
+npm test                   # single run, CI-style
+npm run test:watch         # watch mode
+
+# TypeScript typecheck (run before any commit)
+cd client && node_modules/.bin/tsc --noEmit
+cd server && node_modules/.bin/tsc --noEmit
+
+# Production builds (mirror what Vercel + Render run)
+npm run build --prefix client
+npm run build --prefix server
+
+# Local dev stack (server on :2567, client on :5173, Vite proxies /matchmake + /ws)
+npm run dev
 ```
 
-Config files at repo root:
-- `vitest.config.ts` — test environment, file patterns, Three.js alias
-- `tsconfig.test.json` — TypeScript config scoped to tests + shared/
+The `client` build script also runs `tsc --noEmit` before invoking Vite, so a
+clean `npm run build --prefix client` is a stricter check than typecheck alone.
 
 ---
 
-## How it works
+## Vitest harness
 
-The test environment is **Node.js** (`environment: 'node'` in vitest.config.ts).
-There is no DOM and no browser APIs. Three.js is aliased to
-`client/node_modules/three/build/three.module.js` so geometry math can be
-imported in tests without a WebGL context.
+Config at the repo root:
+- `vitest.config.ts` — `environment: 'node'`, includes `tests/**/*.test.ts` and
+  `shared/**/*.test.ts`, `globals: false`, aliases `three` to
+  `client/node_modules/three/build/three.module.js`.
+- `tsconfig.test.json` — TypeScript scope for the test compile.
 
-```
-tests/                      ← test files live here
-  smoke.test.ts             ← vitest sanity check
-  arena-gen.test.ts         ← shared/arena-gen.ts
-  breachRoomQueries.test.ts ← client/src/arena/breachRoomQueries.ts
-  cameraYawFromBreach.test.ts ← client/src/game/cameraYawFromBreach.ts
-  bulletCollision.test.ts    ← client/src/game/bulletCollision.ts
-shared/**/*.test.ts         ← co-located tests for shared/ modules (also discovered)
-```
+Conventions:
+- Explicit imports — `import { describe, it, expect } from 'vitest';`
+- Import paths are relative to the **repo root**:
+  `import { foo } from '../shared/foo';` /
+  `import { bar } from '../client/src/match/bar';`
+- One `describe` per exported function; tests named as plain statements
+  (`'is deterministic for the same seed'`).
 
----
+### What to unit-test
 
-## What to test
+Pure (side-effect-free) helpers only — no DOM, no scene graph, no socket I/O.
+Good fits include `shared/` utilities, arena geometry, hit math, match-flow,
+roster shaping, parsers, and pure UI builders.
 
-Only **pure (side-effect-free) functions** — those with no DOM, no Three.js scene
-graph, and no WebSocket. These are the best candidates:
+### What to skip
 
-| Category | Examples |
+| Surface | Why |
 |---|---|
-| `shared/` utilities | `generateArenaLayout`, `applyShotSpread`, vec3 math |
-| Arena geometry | `isInBreachRoom`, `isDeepInBreachRoom`, `bounceAgainstBoxes` |
-| Game math helpers | `cameraYawFacingBreachOpening`, `buildShotFromCamera` |
-| Hit classification | `classifyHitZone` in `player/playerCombat.ts` |
+| Three.js `Mesh` / `Scene` / `Renderer` | Needs WebGL |
+| HUD / menu DOM mutation | Node has no `document` |
+| Live Colyseus rooms | Needs a running server + WebSocket |
+| `InputManager`, pointer-lock APIs | Browser-only |
+| GLB animation crossfades | Needs a loaded GLTF + renderer |
 
-### What NOT to test
+For these, rely on the manual smoke checklist below.
 
-| Category | Reason |
+---
+
+## Current coverage (37 test files)
+
+The suite covers physics, arena generation, both win paths, bot AI, online
+reconciliation, portal placement, debrief stats, mobile input logic, embed
+detection, fullscreen behavior, analytics events, room directory, profanity
+filtering, scoreboard / kill-feed builders, and regression cases. The exact
+file list lives in `tests/` and `shared/**/*.test.ts`; run `npm test` to see
+counts and timing.
+
+Notable groups:
+
+| Area | Tests |
 |---|---|
-| Three.js `Mesh` / `Scene` / `Renderer` | Requires browser WebGL context |
-| HUD / menu DOM manipulation | Node environment has no `document` |
-| WebSocket connections | Integration-level; needs a running server |
-| `InputManager` | Coupled to pointer-lock browser APIs |
-| `AnimationMixer` crossfades | Requires a loaded GLTF + Three.js renderer |
-
-For these, rely on the manual golden-path browser check in `CLAUDE.md`.
-
----
-
-## Writing a new test
-
-1. Create `tests/<module-name>.test.ts` (or co-locate as `shared/my-module.test.ts`).
-
-2. Import vitest explicitly — globals are disabled:
-   ```typescript
-   import { describe, it, expect } from 'vitest';
-   ```
-
-3. Import the function under test using a path **relative to the repo root**:
-   ```typescript
-   import { myHelper } from '../shared/my-module';
-   import { isInBreachRoom } from '../client/src/arena/breachRoomQueries';
-   ```
-
-4. One `describe` block per exported function. Name tests as plain statements:
-   ```typescript
-   describe('myHelper', () => {
-     it('returns 0 for empty input', () => { ... });
-     it('handles negative values', () => { ... });
-   });
-   ```
+| Shared logic | `arena-gen`, `physics`, `playerLogic`, `match`, `matchFlow`, `multiplayer`, `profanity` |
+| Solo runtime | `localMatch`, `botBrain`, `roundController`, `matchStatsTracker` |
+| Online runtime | `onlineMatch`, `onlineActorDamage`, `onlineBotTargeting`, `onlineGrabSync`, `onlineRoomLeave`, `reconciliation`, `roomDirectory` |
+| Geometry / collision | `breachRoomQueries`, `bulletCollision`, `projectileActorCollision`, `cameraYawFromBreach` |
+| Vibe Jam | `vibeJamPortal`, `portalPlacement` |
+| UI / platform | `scoreboard`, `scoreboardCursor`, `overlayCursor`, `creditsContent`, `instructionsContent`, `linkIcons`, `teamPresentation`, `firstTimeTutorial`, `embedMode`, `fullscreen`, `mobileInputLogic`, `analytics` |
+| Sanity | `smoke` |
 
 ---
 
-## Example test
+## Adding a test
+
+1. Create `tests/<module>.test.ts` (or co-locate as `shared/<module>.test.ts`).
+2. Import vitest explicitly and the function under test by repo-relative path.
+3. One `describe` per export; statement-style `it` names.
+4. Keep the test pure — no real Colyseus rooms, real renderer, or real DOM.
+
+Example:
 
 ```typescript
 import { describe, it, expect } from 'vitest';
-import { isInBreachRoom } from '../client/src/arena/breachRoomQueries';
-import { BREACH_ROOM_D, BREACH_ROOM_W, BREACH_ROOM_H } from '../shared/constants';
+import { findMatchWinner } from '../shared/match-flow';
 
-const roomZ = { center: { x: 0, y: 0, z: 23 }, openAxis: 'z' as const };
-
-describe('isInBreachRoom', () => {
-  it('accepts room center', () => {
-    expect(isInBreachRoom({ x: 0, y: 0, z: 23 }, roomZ)).toBe(true);
+describe('findMatchWinner', () => {
+  it('returns null while neither team has hit the target', () => {
+    expect(findMatchWinner({ team0: 4, team1: 4 }, 5)).toBeNull();
   });
 
-  it('rejects points past the depth face', () => {
-    const edge = 23 + BREACH_ROOM_D / 2;
-    expect(isInBreachRoom({ x: 0, y: 0, z: edge + 0.01 }, roomZ)).toBe(false);
-    expect(isInBreachRoom({ x: 0, y: 0, z: edge - 0.01 }, roomZ)).toBe(true);
-  });
-
-  it('rejects points outside width or height', () => {
-    expect(isInBreachRoom({ x: BREACH_ROOM_W / 2, y: 0, z: 23 }, roomZ)).toBe(false);
-    expect(isInBreachRoom({ x: 0, y: BREACH_ROOM_H / 2, z: 23 }, roomZ)).toBe(false);
+  it('returns the team that reaches the target first', () => {
+    expect(findMatchWinner({ team0: 5, team1: 3 }, 5)).toBe(0);
   });
 });
 ```
 
----
-
-## Testing Three.js math (without a scene)
-
-Functions that use `THREE.Vector3`, `THREE.Quaternion`, or `THREE.Euler` for pure
-math (no mesh instantiation, no renderer) work fine in tests. The vitest alias
-resolves `three` to the ES module build.
-
-```typescript
-// Fine to test — pure math, no scene
-import * as THREE from 'three';
-import { computeSomething } from '../shared/physics';
-
-it('applies spread correctly', () => {
-  const dir = new THREE.Vector3(0, 0, -1);
-  const result = computeSomething(dir, 0.1);
-  expect(result.length()).toBeCloseTo(1.0);
-});
-```
-
-Anything that calls `new THREE.Mesh(...)`, `scene.add(...)`, or `renderer.render(...)`
-will fail in Node — keep those out of tests.
+Three.js math is fine in tests (the alias resolves `three` to its ES module
+build) as long as you avoid `new THREE.Mesh(...)`, `scene.add(...)`, or
+`renderer.render(...)`.
 
 ---
 
-## Test requirement policy
+## Test policy
 
-Every new feature that adds a pure (side-effect-free) function **must** include vitest
-tests before commit. Extract the math into a standalone function and test it. Visual/scene
-code is exempt (no WebGL in Node), but the logic it delegates to is not.
+Every new feature that adds a pure helper **must** ship with vitest coverage
+for that helper. Extract math and decision logic into pure functions so they
+are testable; keep the WebGL / DOM / socket side at the edges.
 
-## Current test coverage
+---
 
-| Test file | Function(s) covered | Tests |
-|---|---|---|
-| `smoke.test.ts` | — (vitest sanity) | 1 |
-| `arena-gen.test.ts` | `generateArenaLayout` | 7 |
-| `breachRoomQueries.test.ts` | `isInBreachRoom`, `isDeepInBreachRoom` | 6 |
-| `cameraYawFromBreach.test.ts` | `cameraYawFacingBreachOpening` | 3 |
-| `bulletCollision.test.ts` | `bulletHitsBox`, `bulletHitPoint` (swept collision + surface point) | 12 |
-| **Total** | | **30** |
+## Manual smoke checklist
+
+Run before any release-bound merge to `main`. The unit suite cannot exercise
+these paths.
+
+### Desktop browser (Chrome + Firefox at minimum)
+
+- [ ] Boot loads, welcome / call-sign capture works on first visit.
+- [ ] Solo: 1v1, 2v2, 5v5, 10v10, 20v20 — bots fill empty seats; LMB fires; E
+      grabs; Space launches with mouse-Y aim power.
+- [ ] **Win path A — Breach**: float through enemy portal while at least one
+      enemy is unfrozen; round point awarded.
+- [ ] **Win path B — Full freeze**: freeze every enemy; round point awarded
+      even with no breach.
+- [ ] First team to 5 round wins triggers match-end + debrief + victory dance.
+- [ ] HUD: power meter, hit-zone damage state, frozen status, kill feed.
+- [ ] Tab roster shows team rosters with bot badges, frozen status, ping
+      column when online.
+- [ ] Session menu (Esc) → settings, credits, safe-exit. Esc releases cursor.
+- [ ] Help overlay (H) renders.
+
+### Mobile portrait + landscape (iOS Safari + Android Chrome)
+
+- [ ] Touch joystick + look area appear; GRAB / JUMP-LAUNCH / FIRE / 1ST-3RD
+      buttons respond.
+- [ ] Orientation change does not break the layout or the canvas size.
+- [ ] Fullscreen toggle works on Android. On iPhone Safari it is disabled
+      (non-video fullscreen unsupported).
+
+### Online lobby + room browser
+
+- [ ] **Join Online** quick-matches into `orbital_lobby`; ready check starts
+      countdown when both teams are full and humans are ready.
+- [ ] **Rooms & Invites** lists current public rooms from `/rooms`.
+- [ ] Create public + private rooms with custom name, max-player cap from the
+      playlist sizes (2 / 4 / 10 / 20 / 40).
+- [ ] **Fill Lobby** adds bots; **Humans Only** drops them; later human join
+      reclaims a bot seat.
+- [ ] Move To Cyan / Magenta works; ready state, disconnected state, own-pilot
+      highlight all visible.
+
+### Private invite + QR join
+
+- [ ] Invite URL with `?roomId=…` opens directly into the right room.
+- [ ] Copy / Share buttons populate the system share sheet on mobile.
+- [ ] QR code scans into the same room on a second device.
+
+### Vibe Jam portals
+
+- [ ] Outbound portal in the arena opens `https://vibej.am/portal/2026` in a
+      new tab.
+- [ ] Inbound: visit with `?portal=true&ref=<url>` — return portal renders in
+      the breach room and points back at `ref`. Console logs the detected
+      params and ref.
+- [ ] Other portal params (`username`, `color`, etc.) are reflected if used.
+
+### Fullscreen / itch.io embed
+
+- [ ] Direct Vercel URL: fullscreen toggle works on supported browsers.
+- [ ] itch.io page: game runs inside the iframe. The embed shell does not
+      double up controls. Fullscreen via the toggle (where supported) or the
+      itch fullscreen button works.
+
+### Analytics presence
+
+- [ ] DevTools Network shows requests to `_vercel/insights/*` for both
+      Web Analytics and Speed Insights on a fresh page load.
+- [ ] Custom `track()` events fire for the documented landing / match events
+      (see `client/src/analytics/analytics.ts`).
+
+### Disconnect / rejoin cleanup
+
+- [ ] Hard-close the tab mid-round → bot fills the seat at round end.
+- [ ] Rejoin from the same browser into the same room → seat is reclaimed
+      from the bot, not added on top.
+- [ ] Render cold start: first join after idle hits `/wake`; UI shows the
+      warm-up state instead of erroring.
+
+---
+
+## Debugging tips
+
+- Server logs on Render include join / leave / round-result lines from
+  `OrbitalLobbyRoom` — start there for online-only bugs.
+- `/rooms` returns the live public room directory; useful when the browser UI
+  disagrees with the server.
+- `client/src/featureFlags.ts` toggles dev overlays (gun-tune, float-arm-tune,
+  scoreboard cursor) without rebuilding.
+- `?portal=true&ref=…` URL params are the only way to exercise the inbound
+  Vibe Jam path locally.


### PR DESCRIPTION
## Summary

- Rewrites `docs/ARCHITECTURE.md` to match the shipped game: Three.js client, Colyseus + Express server on Render, room browser / private rooms / invites / QR, Vibe Jam portal handoff, mobile touch controls, itch.io embed, Vercel Analytics + Speed Insights, `/rooms` / `/wake` / `/health` endpoints, full `client/src` module map, and stale-player cleanup.
- Rewrites `docs/TESTING.md` with current commands (`npm test`, `npm run test:watch`, client/server typecheck via local `node_modules/.bin/tsc`, prod builds), a tour of the 37-file vitest suite by area, and a manual smoke checklist covering desktop, mobile portrait/landscape, online lobby + room browser, private invite + QR join, Vibe Jam portals, fullscreen / itch embed, analytics presence, and disconnect/rejoin cleanup.
- Fixes the README "The Match" section: round wins happen via **either** breaching the enemy room **or** freezing the enemy team — portal doors open at the start of every round, so breach is not gated on freezing first. Match win remains first team to 5 round wins (this part was already correct).

## Test plan

- [x] `npm test` — 37 files / 216 tests passing.
- [x] `docs/ARCHITECTURE.md` reflects current production architecture.
- [x] `docs/TESTING.md` reflects current commands and smoke-test flow.
- [x] Docs do not reference stale implementation-plan files that were removed.
- [x] Docs align with README current status.
- [x] Links and paths are accurate.
- [x] Markdown renders cleanly on GitHub.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an in-game instructions page accessible from the main menu, featuring objective, round flow, winning scenarios, and control mappings (desktop only)
  * Mobile version includes simplified instructions without key bindings

* **Documentation**
  * Updated win-condition descriptions: portal doors now open at the start of every round as a breach route
  * Clarified full-freeze winning condition
  * Enhanced architecture and testing documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->