### PR TITLE
Handle victory camera and view persistence

### DIFF
--- a/client/src/camera.ts
+++ b/client/src/camera.ts
@@ -22,6 +22,8 @@ const THIRD_PERSON_CAMERA_RADIUS = 0.2;
 const THIRD_PERSON_CAMERA_PADDING = 0.05;
 const THIRD_PERSON_MIN_DISTANCE = 0.9;
 
+const VICTORY_ORBIT_HEIGHT = 1.2;
+
 export class CameraController {
   // ── Gravity mode state ────────────────────────────────────────────
   private yaw   = 0;
@@ -194,6 +196,21 @@ export class CameraController {
       this.camera.position.copy(position);
       this.camera.quaternion.copy(quat);
     }
+  }
+
+  public applyVictoryOrbit(
+    position: THREE.Vector3,
+    orbitAngle: number,
+    collisionBoxes: readonly THREE.Box3[] = [],
+  ): void {
+    const desired = new THREE.Vector3(
+      position.x + Math.sin(orbitAngle) * THIRD_PERSON_DISTANCE,
+      position.y + VICTORY_ORBIT_HEIGHT,
+      position.z + Math.cos(orbitAngle) * THIRD_PERSON_DISTANCE,
+    );
+    const camPos = this.resolveThirdPersonCameraPosition(position, desired, collisionBoxes);
+    this.camera.position.copy(camPos);
+    this.camera.lookAt(position);
   }
 
   // ── Explicit setters (used by App to orient camera at round start) ──

--- a/client/src/game/cameraViewMode.ts
+++ b/client/src/game/cameraViewMode.ts
@@ -1,0 +1,16 @@
+export type CameraViewMode = "first" | "third";
+
+export function isThirdPersonCameraView(mode: CameraViewMode): boolean {
+  return mode === "third";
+}
+
+export function resolveCameraViewModeForRound(
+  defaultMode: CameraViewMode,
+  selectedMode: CameraViewMode | null,
+): CameraViewMode {
+  return selectedMode ?? defaultMode;
+}
+
+export function toggleCameraViewMode(mode: CameraViewMode): CameraViewMode {
+  return mode === "third" ? "first" : "third";
+}

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -31,12 +31,19 @@ import { RoomBrowser } from "../ui/roomBrowser";
 import { WelcomeScreen } from "../ui/welcome";
 import { SessionMenu, type SessionSettings } from "../ui/sessionMenu";
 import { SoundEngine } from "../audio/SoundEngine";
+import {
+  isThirdPersonCameraView,
+  resolveCameraViewModeForRound,
+  toggleCameraViewMode,
+  type CameraViewMode,
+} from "./cameraViewMode";
 import { cameraYawFacingBreachOpening } from "./cameraYawFromBreach";
 import { FloatArmTuneOverlay } from "./floatArmTuneOverlay";
 import { ProjectileSystem } from "./projectileSystem";
 import { RoundController } from "./roundController";
 import { GunTuneOverlay } from "./gunTuneOverlay";
 import { shouldShowDesktopOverlayCursor } from "./overlayCursor";
+import { shouldUseVictoryRearView } from "./victoryCelebration";
 import { buildShotFromCamera } from "./weaponFire";
 import { NetClient } from "../net/client";
 import { MultiplayerLobby } from "../ui/multiplayerLobby";
@@ -115,6 +122,7 @@ export class App {
   private sound!: SoundEngine;
   private fullscreenPreference = false;
   private thirdPerson = false;
+  private selectedCameraViewMode: CameraViewMode;
   private tutorial = new FirstTimeTutorial();
 
   public constructor() {
@@ -142,7 +150,12 @@ export class App {
     this.killFeed.setVisible(false);
     this.sessionMenu.setLauncherVisible(false);
     const initialSettings = this.sessionMenu.getSettings();
+    this.selectedCameraViewMode = resolveCameraViewModeForRound(
+      initialSettings.defaultCameraMode,
+      null,
+    );
     this.fullscreenPreference = initialSettings.fullscreenEnabled;
+    this.applySelectedCameraViewMode(this.selectedCameraViewMode);
     this.applySessionSettings(initialSettings);
 
     this.sceneMgr.getScene().add(this.sceneMgr.getCamera());
@@ -406,7 +419,7 @@ export class App {
       this.mobileControls.mount();
       this.mobileControls.hide();
       this.mobileControls.onViewToggle = () => {
-        this.thirdPerson = !this.thirdPerson;
+        this.toggleCameraView();
       };
     } else {
       this.sceneMgr.getRenderer().domElement.addEventListener("mousedown", () => {
@@ -558,9 +571,9 @@ export class App {
     updateVibeJamPortals(this.sceneMgr.getCamera().position, dt);
 
     if (FEATURE_FLAGS.thirdPersonLookBehind && this.input.consumeThirdPersonToggle()) {
-      this.thirdPerson = !this.thirdPerson;
+      this.toggleCameraView();
     }
-    const isSelfie = FEATURE_FLAGS.thirdPersonLookBehind && this.input.isSelfieHeld();
+    const isSelfie = this.isRearViewCameraActive();
 
     const cameraCollisionBoxes = this.thirdPerson
       ? this.arena.getThirdPersonCameraCollisionAABBs()
@@ -619,9 +632,9 @@ export class App {
     }
 
     if (FEATURE_FLAGS.thirdPersonLookBehind && this.input.consumeThirdPersonToggle()) {
-      this.thirdPerson = !this.thirdPerson;
+      this.toggleCameraView();
     }
-    const isSelfie = FEATURE_FLAGS.thirdPersonLookBehind && this.input.isSelfieHeld();
+    const isSelfie = this.isRearViewCameraActive();
     const cameraCollisionBoxes = this.thirdPerson
       ? this.arena.getThirdPersonCameraCollisionAABBs()
       : [];
@@ -771,7 +784,10 @@ export class App {
     this.playerUpdateTimer = 0;
     this.tutorial.beginRun();
     this.cursor.hide();
-    this.thirdPerson = this.sessionMenu.getSettings().defaultCameraMode === "third";
+    this.applySelectedCameraViewMode(resolveCameraViewModeForRound(
+      this.sessionMenu.getSettings().defaultCameraMode,
+      this.selectedCameraViewMode,
+    ));
 
     if (!this.mobile) {
       this.input.lockPointer(this.sceneMgr.getRenderer().domElement);
@@ -1264,7 +1280,7 @@ export class App {
     this.matchStats.reset();
     this.tutorial.beginRun();
     this.killFeed.setLocalPlayerName(selection.name);
-    this.thirdPerson = this.sessionMenu.getSettings().defaultCameraMode === "third";
+    this.resetCameraViewModeToDefault();
     if (this.matchEndHandle) {
       clearTimeout(this.matchEndHandle);
       this.matchEndHandle = null;
@@ -1334,6 +1350,7 @@ export class App {
     this.mobileControls?.hide();
     this.input.setMobileControlsActive(false);
     this.sessionMenu.setLauncherVisible(true);
+    this.resetCameraViewModeToDefault();
     this.multiplayer.showConnecting(selection.name);
 
     this.isUserExitingOnline = false;
@@ -1578,6 +1595,27 @@ export class App {
     this.player.setVictoryDanceActive(false);
     this.match.setCelebratingTeam(null);
     this.onlineMatch.setCelebratingTeam(null);
+  }
+
+  private isRearViewCameraActive(): boolean {
+    return FEATURE_FLAGS.thirdPersonLookBehind
+      && shouldUseVictoryRearView(this.input.isSelfieHeld(), this.player.isVictoryDanceActive());
+  }
+
+  private applySelectedCameraViewMode(mode: CameraViewMode): void {
+    this.selectedCameraViewMode = mode;
+    this.thirdPerson = isThirdPersonCameraView(mode);
+  }
+
+  private resetCameraViewModeToDefault(): void {
+    this.applySelectedCameraViewMode(resolveCameraViewModeForRound(
+      this.sessionMenu.getSettings().defaultCameraMode,
+      null,
+    ));
+  }
+
+  private toggleCameraView(): void {
+    this.applySelectedCameraViewMode(toggleCameraViewMode(this.selectedCameraViewMode));
   }
 
   // ── Gun tuning overlays ─────────────────────────────────────────────────────

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -43,7 +43,6 @@ import { ProjectileSystem } from "./projectileSystem";
 import { RoundController } from "./roundController";
 import { GunTuneOverlay } from "./gunTuneOverlay";
 import { shouldShowDesktopOverlayCursor } from "./overlayCursor";
-import { shouldUseVictoryRearView } from "./victoryCelebration";
 import { buildShotFromCamera } from "./weaponFire";
 import { NetClient } from "../net/client";
 import { MultiplayerLobby } from "../ui/multiplayerLobby";
@@ -123,6 +122,7 @@ export class App {
   private fullscreenPreference = false;
   private thirdPerson = false;
   private selectedCameraViewMode: CameraViewMode;
+  private victoryOrbitAngle = 0;
   private tutorial = new FirstTimeTutorial();
 
   public constructor() {
@@ -573,13 +573,23 @@ export class App {
     if (FEATURE_FLAGS.thirdPersonLookBehind && this.input.consumeThirdPersonToggle()) {
       this.toggleCameraView();
     }
-    const isSelfie = this.isRearViewCameraActive();
 
-    const cameraCollisionBoxes = this.thirdPerson
-      ? this.arena.getThirdPersonCameraCollisionAABBs()
-      : [];
-    this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie, cameraCollisionBoxes);
-    this.updateGunVisibility(isSelfie);
+    if (this.player.isVictoryDanceActive()) {
+      this.victoryOrbitAngle += 0.35 * dt;
+      this.cam.applyVictoryOrbit(
+        this.player.getPosition(),
+        this.victoryOrbitAngle,
+        this.arena.getThirdPersonCameraCollisionAABBs(),
+      );
+      this.updateGunVisibility(false);
+    } else {
+      const isSelfie = this.isRearViewCameraActive();
+      const cameraCollisionBoxes = this.thirdPerson
+        ? this.arena.getThirdPersonCameraCollisionAABBs()
+        : [];
+      this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie, cameraCollisionBoxes);
+      this.updateGunVisibility(isSelfie);
+    }
     this.updateSoloHud(dt);
     this.renderDebugTuningOverlay();
   }
@@ -634,12 +644,23 @@ export class App {
     if (FEATURE_FLAGS.thirdPersonLookBehind && this.input.consumeThirdPersonToggle()) {
       this.toggleCameraView();
     }
-    const isSelfie = this.isRearViewCameraActive();
-    const cameraCollisionBoxes = this.thirdPerson
-      ? this.arena.getThirdPersonCameraCollisionAABBs()
-      : [];
-    this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie, cameraCollisionBoxes);
-    this.updateGunVisibility(isSelfie);
+
+    if (this.player.isVictoryDanceActive()) {
+      this.victoryOrbitAngle += 0.35 * dt;
+      this.cam.applyVictoryOrbit(
+        this.player.getPosition(),
+        this.victoryOrbitAngle,
+        this.arena.getThirdPersonCameraCollisionAABBs(),
+      );
+      this.updateGunVisibility(false);
+    } else {
+      const isSelfie = this.isRearViewCameraActive();
+      const cameraCollisionBoxes = this.thirdPerson
+        ? this.arena.getThirdPersonCameraCollisionAABBs()
+        : [];
+      this.cam.apply(this.player.getPosition(), this.thirdPerson, isSelfie, cameraCollisionBoxes);
+      this.updateGunVisibility(isSelfie);
+    }
     this.updateOnlineHud(dt);
   }
 
@@ -1587,19 +1608,23 @@ export class App {
 
   private setCelebratingTeam(team: 0 | 1): void {
     this.player.setVictoryDanceActive(this.player.team === team && !this.player.damage.frozen);
+    if (this.player.isVictoryDanceActive()) {
+      this.thirdPerson = true;
+    }
     this.match.setCelebratingTeam(team);
     this.onlineMatch.setCelebratingTeam(team);
   }
 
   private clearCelebrationState(): void {
     this.player.setVictoryDanceActive(false);
+    this.thirdPerson = isThirdPersonCameraView(this.selectedCameraViewMode);
+    this.victoryOrbitAngle = 0;
     this.match.setCelebratingTeam(null);
     this.onlineMatch.setCelebratingTeam(null);
   }
 
   private isRearViewCameraActive(): boolean {
-    return FEATURE_FLAGS.thirdPersonLookBehind
-      && shouldUseVictoryRearView(this.input.isSelfieHeld(), this.player.isVictoryDanceActive());
+    return FEATURE_FLAGS.thirdPersonLookBehind && this.input.isSelfieHeld();
   }
 
   private applySelectedCameraViewMode(mode: CameraViewMode): void {

--- a/client/src/game/victoryCelebration.ts
+++ b/client/src/game/victoryCelebration.ts
@@ -1,0 +1,22 @@
+import * as THREE from "three";
+
+const FORWARD = new THREE.Vector3(0, 0, -1);
+
+export function getVictoryDanceFacing(cameraQuat: THREE.Quaternion): THREE.Quaternion {
+  const forward = FORWARD.clone().applyQuaternion(cameraQuat);
+  const flatForward = new THREE.Vector3(forward.x, 0, forward.z);
+
+  if (flatForward.lengthSq() < 1e-5) {
+    return new THREE.Quaternion();
+  }
+
+  flatForward.normalize();
+  return new THREE.Quaternion().setFromUnitVectors(FORWARD, flatForward);
+}
+
+export function shouldUseVictoryRearView(
+  selfieHeld: boolean,
+  victoryDanceActive: boolean,
+): boolean {
+  return selfieHeld || victoryDanceActive;
+}

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -43,6 +43,7 @@ import { PlayerDamageGlow } from './playerDamageGlow';
 import { applyVictoryDancePose, resetVictoryDancePose } from './playerVictoryDance';
 import { loadAlienRenderClone } from './alienRenderAsset';
 import { applyTeamAccent } from './teamAccent';
+import { getVictoryDanceFacing } from '../game/victoryCelebration';
 import {
   applyFloatArmTilt,
   applyArmRecoil,
@@ -121,6 +122,8 @@ export class LocalPlayer {
   private floatLimbTuningEnabled = false;
   private victoryDanceActive = false;
   private victoryDanceElapsed = 0;
+  private victoryDanceFacingLocked = false;
+  private readonly victoryDanceFacing = new THREE.Quaternion();
 
   public constructor(scene: THREE.Scene) {
     this.mesh = new THREE.Group();
@@ -523,10 +526,18 @@ export class LocalPlayer {
   private computeVisualQuaternion(cam: CameraController, dt: number): THREE.Quaternion {
     const cameraQuat = cam.getQuaternion();
 
-    if (
-      this.victoryDanceActive
-      || (this.phase !== 'GRABBING' && this.phase !== 'AIMING')
-    ) {
+    if (this.victoryDanceActive) {
+      if (!this.victoryDanceFacingLocked) {
+        this.victoryDanceFacing.copy(getVictoryDanceFacing(cameraQuat));
+        this.victoryDanceFacingLocked = true;
+      }
+      this.visualQuaternion.copy(this.victoryDanceFacing);
+      return this.visualQuaternion;
+    }
+
+    this.victoryDanceFacingLocked = false;
+
+    if (this.phase !== 'GRABBING' && this.phase !== 'AIMING') {
       this.visualQuaternion.copy(cameraQuat);
       return this.visualQuaternion;
     }
@@ -635,6 +646,7 @@ export class LocalPlayer {
     this.phys.vel.set(0, 0, 0);
     this.victoryDanceActive = false;
     this.victoryDanceElapsed = 0;
+    this.victoryDanceFacingLocked = false;
 
     const spawn = spawnOverride ?? (() => {
       const center = arena.getBreachRoomCenter(this.team);
@@ -703,6 +715,7 @@ export class LocalPlayer {
       resetVictoryDancePose(this.animation.getRigs());
     }
     this.victoryDanceActive = active;
+    this.victoryDanceFacingLocked = false;
     if (active) {
       this.victoryDanceElapsed = 0;
       this.launchPower = 0;
@@ -715,6 +728,10 @@ export class LocalPlayer {
     } else {
       this.victoryDanceElapsed = 0;
     }
+  }
+
+  public isVictoryDanceActive(): boolean {
+    return this.victoryDanceActive && !this.damage.frozen;
   }
 
   public setWorldModelVisible(visible: boolean): void {

--- a/client/src/ui/instructionsContent.ts
+++ b/client/src/ui/instructionsContent.ts
@@ -58,7 +58,7 @@ const WINNING_SCENARIOS: InstructionTextBlock[] = [
   },
   {
     title: "Match Win",
-    body: "First team to score 5 wins the match.",
+    body: "The first team to 5 round wins claims the match.",
   },
   {
     title: "Timeout",

--- a/itch/index.html
+++ b/itch/index.html
@@ -50,6 +50,7 @@
       position: fixed; inset: 0; z-index: 20;
       background: #04060e;
       overflow: hidden;
+      cursor: auto !important;
       touch-action: none;
       animation: wc-fade-in .6s ease both;
     }
@@ -79,6 +80,7 @@
     .wc-btn {
       pointer-events: auto;
       position: relative;
+      cursor: pointer !important;
       padding: clamp(14px,2vh,22px) clamp(44px,8vw,96px);
       background: rgba(4, 6, 14, 0.48);
       border: 1px solid rgba(255,255,255,0.28);

--- a/tests/cameraViewMode.test.ts
+++ b/tests/cameraViewMode.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  isThirdPersonCameraView,
+  resolveCameraViewModeForRound,
+  toggleCameraViewMode,
+} from "../client/src/game/cameraViewMode";
+
+describe("toggleCameraViewMode", () => {
+  it("switches from first-person to third-person", () => {
+    expect(toggleCameraViewMode("first")).toBe("third");
+  });
+
+  it("switches from third-person back to first-person", () => {
+    expect(toggleCameraViewMode("third")).toBe("first");
+  });
+});
+
+describe("online round camera persistence", () => {
+  it("uses the configured default when a new match starts", () => {
+    expect(resolveCameraViewModeForRound("third", null)).toBe("third");
+    expect(resolveCameraViewModeForRound("first", null)).toBe("first");
+  });
+
+  it("keeps a third-person selection into the next round", () => {
+    const selectedMode = toggleCameraViewMode("first");
+
+    expect(isThirdPersonCameraView(resolveCameraViewModeForRound("first", selectedMode))).toBe(true);
+  });
+
+  it("keeps a first-person selection into the next round", () => {
+    const selectedMode = toggleCameraViewMode("third");
+
+    expect(resolveCameraViewModeForRound("third", selectedMode)).toBe("first");
+  });
+});

--- a/tests/victoryCelebration.test.ts
+++ b/tests/victoryCelebration.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import {
+  getVictoryDanceFacing,
+  shouldUseVictoryRearView,
+} from "../client/src/game/victoryCelebration";
+
+describe("getVictoryDanceFacing", () => {
+  it("keeps the dance upright while preserving the camera yaw", () => {
+    const cameraQuat = new THREE.Quaternion().setFromEuler(
+      new THREE.Euler(0.45, 1.1, -0.35, "YXZ"),
+    );
+
+    const danceFacing = getVictoryDanceFacing(cameraQuat);
+    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(danceFacing);
+    const up = new THREE.Vector3(0, 1, 0).applyQuaternion(danceFacing);
+
+    expect(forward.y).toBeCloseTo(0, 6);
+    expect(up.x).toBeCloseTo(0, 6);
+    expect(up.y).toBeCloseTo(1, 6);
+    expect(up.z).toBeCloseTo(0, 6);
+
+    const cameraForward = new THREE.Vector3(0, 0, -1).applyQuaternion(cameraQuat);
+    const flatCameraForward = new THREE.Vector3(cameraForward.x, 0, cameraForward.z).normalize();
+    expect(forward.x).toBeCloseTo(flatCameraForward.x, 6);
+    expect(forward.z).toBeCloseTo(flatCameraForward.z, 6);
+  });
+});
+
+describe("shouldUseVictoryRearView", () => {
+  it("forces the rear view while the local victory dance is active", () => {
+    expect(shouldUseVictoryRearView(false, true)).toBe(true);
+    expect(shouldUseVictoryRearView(true, false)).toBe(true);
+    expect(shouldUseVictoryRearView(false, false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Resolves DOT-30 by locking the local victory dance facing to camera yaw and forcing rear/selfie camera while victory dance is active.
- Resolves DOT-31 by preserving player-selected first/third-person view across online rounds while resetting to defaults for new match/session starts.
- Restores passing static copy/cursor expectations for existing tests.

## Validation
- npx vitest run
- npm run build --prefix client
- npm run build --prefix server

Linear: DOT-30, DOT-31