### PR TITLE
fix: technical win round-end line break

### DIFF
--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -368,8 +368,10 @@ const HUD_CSS = `
     display: none;
     position: absolute;
     inset: 0;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 0.18em;
     padding: 24px;
     background: linear-gradient(180deg, rgba(2, 8, 14, 0.38), rgba(2, 8, 14, 0.64));
     font-size: clamp(34px, 5vw, 56px);

--- a/tests/teamPresentation.test.ts
+++ b/tests/teamPresentation.test.ts
@@ -97,7 +97,9 @@ describe("player-relative team UI helpers", () => {
     const roundHtml = buildRoundEndHtml({ team: 1 });
     const freezeHtml = buildRoundEndHtml({ team: 1, kind: "freeze", enemyTeam: 0 });
     const matchHtml = buildRoundEndHtml({ team: 0, matchScore: { team0: 5, team1: 3 } });
+    const technicalWinHtml = buildRoundEndHtml({ team: 0, kind: "disconnect" });
     const tieHtml = buildRoundEndHtml("tie");
+    const hudView = readFileSync(new URL("../client/src/render/hud/hudView.ts", import.meta.url), "utf8");
 
     expect(roundHtml).toContain("ob-round-end__line");
     expect(roundHtml).toContain("ob-round-end__team--magenta");
@@ -111,6 +113,13 @@ describe("player-relative team UI helpers", () => {
     expect(matchHtml).toContain("ob-round-end__team--cyan");
     expect(matchHtml).toContain("WINS");
     expect(matchHtml).toContain("5 - 3");
+    expect(technicalWinHtml).toContain("TECHNICAL WIN!");
+    expect(technicalWinHtml).toContain("All humans on ");
+    expect(technicalWinHtml).toContain(" disconnected");
+    expect((technicalWinHtml.match(/ob-round-end__line/g) ?? [])).toHaveLength(2);
+    expect(technicalWinHtml).toContain("ob-round-end__team--magenta");
+    expect(technicalWinHtml).toContain("MAGENTA");
+    expect(hudView).toContain("flex-direction: column;");
     expect(tieHtml).toContain(">TIE<");
   });
 });


### PR DESCRIPTION
## Summary
- stack the round-end overlay vertically so multi-line messages render on separate rows
- keep the disconnect banner HTML unchanged and cover it with regression assertions
- add a CSS assertion to protect the stacked overlay layout

## Validation
- `npm run build --prefix client`
- `npx vitest run tests/teamPresentation.test.ts`
- `npx vitest run` *(currently fails on existing unrelated tests in `tests/itchIndexCursor.test.ts` and `tests/instructionsContent.test.ts` on top of `staging`)*

Closes #112