### PR TITLE
Fix online player freeze when switching browser tabs

### DIFF
--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -127,6 +127,7 @@ export class App {
     this.input.onTabHoldChange = (held) => {
       this.handleScoreboardTabHoldChange(held);
     };
+    this.syncBackgroundInputPolicy();
     this.cam = new CameraController(this.sceneMgr.getCamera());
     this.arena = new Arena(this.sceneMgr.getScene());
     this.player = new LocalPlayer(this.sceneMgr.getScene());
@@ -479,7 +480,10 @@ export class App {
 
     // Resume music when user returns to tab/app (AudioContext suspends on hide)
     document.addEventListener('visibilitychange', () => {
-      if (!document.hidden) this.sound.tryResumeMusic();
+      if (!document.hidden) {
+        this.sound.tryResumeMusic();
+        this.resyncLocalOnlineActorFromLatestSnapshot();
+      }
     });
     // iOS back/forward cache restore — context is suspended on bfcache restore
     window.addEventListener('pageshow', (e) => {
@@ -1075,6 +1079,7 @@ export class App {
     this.clearCelebrationState();
     this.debrief.hide();
     this.appMode = "menu";
+    this.syncBackgroundInputPolicy();
     this.cursor.show();
     this.matchOver = false;
     this.projectiles.clear();
@@ -1261,6 +1266,7 @@ export class App {
     this.debrief.hide();
     this.clearCelebrationState();
     this.appMode = "solo";
+    this.syncBackgroundInputPolicy();
     this.cursor.hide();
     this.matchOver = false;
     this.onlineBreachReported = false;
@@ -1318,6 +1324,7 @@ export class App {
       && inviteRoomId !== null
       && resolvedTarget.roomId === inviteRoomId;
     this.appMode = "online";
+    this.syncBackgroundInputPolicy();
     this.onlinePlayerName = selection.name;
     this.killFeed.setLocalPlayerName(selection.name);
     this.onlineGameActive = false;
@@ -1386,6 +1393,7 @@ export class App {
     this.clearCelebrationState();
     this.matchStats.reset();
     this.appMode = "menu";
+    this.syncBackgroundInputPolicy();
     this.onlineGameActive = false;
     this.onlineRoundActive = false;
     this.cursor.show();
@@ -1716,7 +1724,26 @@ export class App {
   private syncLocalOnlineActor(snapshot: MultiplayerRoomSnapshot): void {
     const selfActor = snapshot.actors.find((actor) => actor.id === snapshot.sessionId);
     if (!selfActor) return;
+    if (document.hidden) {
+      this.player.applyAuthoritativeOnlineMotion(selfActor);
+    }
     this.player.applyAuthoritativeOnlineState(selfActor);
+  }
+
+  private resyncLocalOnlineActorFromLatestSnapshot(): void {
+    if (this.appMode !== "online" || !this.onlineGameActive) return;
+    const snapshot = this.latestOnlineSnapshot;
+    if (!snapshot) return;
+
+    const selfActor = snapshot.actors.find((actor) => actor.id === snapshot.sessionId);
+    if (!selfActor) return;
+
+    this.player.applyAuthoritativeOnlineMotion(selfActor);
+    this.player.applyAuthoritativeOnlineState(selfActor);
+  }
+
+  private syncBackgroundInputPolicy(): void {
+    this.input.setBackgroundStateClearingEnabled(this.appMode !== "online");
   }
 
   private isGameplaySceneActive(): boolean {

--- a/client/src/input.ts
+++ b/client/src/input.ts
@@ -26,6 +26,7 @@ export class InputManager {
   private mobileMoveZ = 0;
   private mobileControlsActive = false;
   private uiBlocked = false;
+  private clearStateOnBackground = true;
 
   public mouseSensitivity = 0.002;
 
@@ -89,11 +90,13 @@ export class InputManager {
     });
 
     window.addEventListener('blur', () => {
-      this.clearState();
+      if (this.clearStateOnBackground) {
+        this.clearState();
+      }
     });
 
     document.addEventListener('visibilitychange', () => {
-      if (document.hidden) {
+      if (document.hidden && this.clearStateOnBackground) {
         this.clearState();
       }
     });
@@ -154,6 +157,10 @@ export class InputManager {
   /** Returns true when the player can control the game (pointer locked on desktop, or mobile controls active). */
   public canControlGame(): boolean {
     return !this.uiBlocked && (this.mobileControlsActive || this.isLocked());
+  }
+
+  public setBackgroundStateClearingEnabled(enabled: boolean): void {
+    this.clearStateOnBackground = enabled;
   }
 
   // ── Mouse delta ───────────────────────────────────────────────────

--- a/client/src/player/localPlayer.ts
+++ b/client/src/player/localPlayer.ts
@@ -684,6 +684,14 @@ export class LocalPlayer {
     this.phase = nextPhase;
   }
 
+  public applyAuthoritativeOnlineMotion(actor: Pick<
+    OnlineActorSnapshot,
+    'posX' | 'posY' | 'posZ' | 'velX' | 'velY' | 'velZ'
+  >): void {
+    this.phys.pos.set(actor.posX, actor.posY, actor.posZ);
+    this.phys.vel.set(actor.velX, actor.velY, actor.velZ);
+  }
+
   public getPosition(): THREE.Vector3 {
     return this.phys.pos;
   }

--- a/server/src/colyseus/OrbitalLobbyRoom.ts
+++ b/server/src/colyseus/OrbitalLobbyRoom.ts
@@ -44,6 +44,12 @@ import {
 import type { PlayerPhase } from "../../../shared/schema";
 import { generateSpawnPositions, resolveActorCollisions, type CollisionBody } from "../../../shared/player-logic";
 import { applyHitToOnlineActor, isHitZone, normalizeAuthoritativePhase } from "./actorDamage";
+import {
+  bounceActorInArena,
+  integrateZeroGActor,
+  isActorInEnemyBreachRoom,
+  shouldServerSimulateHumanActor,
+} from "./onlineActorSimulation";
 import type { OrbitalRoomMetadata } from "./roomDirectory";
 import { ActorState, LobbyMemberState, OrbitalLobbyState } from "./state";
 
@@ -497,6 +503,7 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
 
     this.matchTick = setInterval(() => {
       this.tickBots(MATCH_TICK_MS / 1000);
+      this.tickStaleHumanActors(MATCH_TICK_MS / 1000);
       this.resolveOnlineBotCollisions();
     }, MATCH_TICK_MS);
   }
@@ -771,6 +778,26 @@ export class OrbitalLobbyRoom extends Room<{ state: OrbitalLobbyState }> {
         } else {
           this.botFireTimers.set(actor.id, nextFireTimer);
         }
+      }
+    }
+  }
+
+  private tickStaleHumanActors(dt: number): void {
+    if (this.state.phase !== "PLAYING") return;
+
+    const now = Date.now();
+    for (const actor of this.state.actors.values()) {
+      const lastUpdate = this.lastPlayerUpdate.get(actor.id) ?? now;
+      if (!shouldServerSimulateHumanActor(actor, now - lastUpdate)) {
+        continue;
+      }
+
+      integrateZeroGActor(actor, dt);
+      bounceActorInArena(actor, this.botGoalAxis);
+
+      if (!this.roundResolved && isActorInEnemyBreachRoom(actor, this.botGoalAxis, this.botGoalSigns)) {
+        actor.phase = "BREACH";
+        this.awardOnlineRoundPoint(actor.team, actor.id, actor.name, "breach");
       }
     }
   }
@@ -1161,19 +1188,12 @@ function botIdHash(id: string): number {
 }
 
 function botIntegrateZeroG(actor: ActorState, dt: number): void {
-  const speed = Math.hypot(actor.velX, actor.velY, actor.velZ);
-  if (speed > MAX_LAUNCH_SPEED) {
-    const scale = MAX_LAUNCH_SPEED / speed;
-    actor.velX *= scale;
-    actor.velY *= scale;
-    actor.velZ *= scale;
-  }
-  actor.posX += actor.velX * dt;
-  actor.posY += actor.velY * dt;
-  actor.posZ += actor.velZ * dt;
+  integrateZeroGActor(actor, dt);
 }
 
 function botBounceArena(actor: ActorState, goalAxis: "x" | "z"): void {
+  bounceActorInArena(actor, goalAxis);
+  return;
   const half = ARENA_SIZE / 2 - PLAYER_RADIUS;
   const perpAxis: "x" | "z" = goalAxis === "x" ? "z" : "x";
 

--- a/server/src/colyseus/onlineActorSimulation.ts
+++ b/server/src/colyseus/onlineActorSimulation.ts
@@ -1,0 +1,153 @@
+import {
+  ARENA_SIZE,
+  BREACH_ROOM_D,
+  BREACH_ROOM_H,
+  BREACH_ROOM_W,
+  MAX_LAUNCH_SPEED,
+  PLAYER_RADIUS,
+} from "../../../shared/constants";
+
+export const PLAYER_UPDATE_STALE_MS = 250;
+
+export interface ServerSimulatedOnlineActor {
+  frozen: boolean;
+  isBot: boolean;
+  phase: string;
+  posX: number;
+  posY: number;
+  posZ: number;
+  team: 0 | 1;
+  velX: number;
+  velY: number;
+  velZ: number;
+}
+
+export function shouldServerSimulateHumanActor(
+  actor: Pick<ServerSimulatedOnlineActor, "frozen" | "isBot" | "phase">,
+  lastUpdateAgeMs: number,
+): boolean {
+  return !actor.isBot
+    && !actor.frozen
+    && actor.phase === "FLOATING"
+    && lastUpdateAgeMs >= PLAYER_UPDATE_STALE_MS;
+}
+
+export function integrateZeroGActor(actor: ServerSimulatedOnlineActor, dt: number): void {
+  const speed = Math.hypot(actor.velX, actor.velY, actor.velZ);
+  if (speed > MAX_LAUNCH_SPEED) {
+    const scale = MAX_LAUNCH_SPEED / speed;
+    actor.velX *= scale;
+    actor.velY *= scale;
+    actor.velZ *= scale;
+  }
+
+  actor.posX += actor.velX * dt;
+  actor.posY += actor.velY * dt;
+  actor.posZ += actor.velZ * dt;
+}
+
+export function bounceActorInArena(
+  actor: ServerSimulatedOnlineActor,
+  goalAxis: "x" | "z",
+): void {
+  const half = ARENA_SIZE / 2 - PLAYER_RADIUS;
+  const perpAxis: "x" | "z" = goalAxis === "x" ? "z" : "x";
+
+  if (actor.posY < -half) {
+    actor.posY = -half;
+    actor.velY = Math.abs(actor.velY);
+  } else if (actor.posY > half) {
+    actor.posY = half;
+    actor.velY = -Math.abs(actor.velY);
+  }
+
+  if (perpAxis === "x") {
+    if (actor.posX < -half) {
+      actor.posX = -half;
+      actor.velX = Math.abs(actor.velX);
+    } else if (actor.posX > half) {
+      actor.posX = half;
+      actor.velX = -Math.abs(actor.velX);
+    }
+  } else {
+    if (actor.posZ < -half) {
+      actor.posZ = -half;
+      actor.velZ = Math.abs(actor.velZ);
+    } else if (actor.posZ > half) {
+      actor.posZ = half;
+      actor.velZ = -Math.abs(actor.velZ);
+    }
+  }
+
+  const perpPos = perpAxis === "x" ? actor.posX : actor.posZ;
+  const inPortal = Math.abs(actor.posY) < BREACH_ROOM_H / 2 - PLAYER_RADIUS
+    && Math.abs(perpPos) < BREACH_ROOM_W / 2 - PLAYER_RADIUS;
+  const maxDepth = ARENA_SIZE / 2 + BREACH_ROOM_D - PLAYER_RADIUS;
+
+  if (goalAxis === "x") {
+    if (actor.posX < -half) {
+      if (inPortal) {
+        if (actor.posX < -maxDepth) {
+          actor.posX = -maxDepth;
+          actor.velX = Math.abs(actor.velX);
+        }
+      } else {
+        actor.posX = -half;
+        actor.velX = Math.abs(actor.velX);
+      }
+    } else if (actor.posX > half) {
+      if (inPortal) {
+        if (actor.posX > maxDepth) {
+          actor.posX = maxDepth;
+          actor.velX = -Math.abs(actor.velX);
+        }
+      } else {
+        actor.posX = half;
+        actor.velX = -Math.abs(actor.velX);
+      }
+    }
+  } else {
+    if (actor.posZ < -half) {
+      if (inPortal) {
+        if (actor.posZ < -maxDepth) {
+          actor.posZ = -maxDepth;
+          actor.velZ = Math.abs(actor.velZ);
+        }
+      } else {
+        actor.posZ = -half;
+        actor.velZ = Math.abs(actor.velZ);
+      }
+    } else if (actor.posZ > half) {
+      if (inPortal) {
+        if (actor.posZ > maxDepth) {
+          actor.posZ = maxDepth;
+          actor.velZ = -Math.abs(actor.velZ);
+        }
+      } else {
+        actor.posZ = half;
+        actor.velZ = -Math.abs(actor.velZ);
+      }
+    }
+  }
+}
+
+export function isActorInEnemyBreachRoom(
+  actor: Pick<ServerSimulatedOnlineActor, "posX" | "posY" | "posZ" | "team">,
+  goalAxis: "x" | "z",
+  goalSigns: { team0: 1 | -1; team1: 1 | -1 },
+): boolean {
+  const enemyTeam = (actor.team === 0 ? 1 : 0) as 0 | 1;
+  const enemySign = enemyTeam === 0 ? goalSigns.team0 : goalSigns.team1;
+  const perpAxis: "x" | "z" = goalAxis === "x" ? "z" : "x";
+  const goalPos = goalAxis === "x" ? actor.posX : actor.posZ;
+  const perpPos = perpAxis === "x" ? actor.posX : actor.posZ;
+  const arenaEdge = enemySign * (ARENA_SIZE / 2);
+  const roomBack = enemySign * (ARENA_SIZE / 2 + BREACH_ROOM_D);
+  const inDepth = enemySign > 0
+    ? goalPos > arenaEdge && goalPos < roomBack
+    : goalPos < arenaEdge && goalPos > roomBack;
+
+  return inDepth
+    && Math.abs(actor.posY) < BREACH_ROOM_H / 2
+    && Math.abs(perpPos) < BREACH_ROOM_W / 2;
+}

--- a/tests/onlineActorSimulation.test.ts
+++ b/tests/onlineActorSimulation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PLAYER_UPDATE_STALE_MS,
+  bounceActorInArena,
+  integrateZeroGActor,
+  isActorInEnemyBreachRoom,
+  shouldServerSimulateHumanActor,
+  type ServerSimulatedOnlineActor,
+} from "../server/src/colyseus/onlineActorSimulation";
+
+function makeActor(overrides: Partial<ServerSimulatedOnlineActor> = {}): ServerSimulatedOnlineActor {
+  return {
+    frozen: false,
+    isBot: false,
+    phase: "FLOATING",
+    posX: 0,
+    posY: 0,
+    posZ: 0,
+    team: 0,
+    velX: 0,
+    velY: 0,
+    velZ: 0,
+    ...overrides,
+  };
+}
+
+describe("onlineActorSimulation", () => {
+  it("hands floating human actors to the server after updates go stale", () => {
+    expect(shouldServerSimulateHumanActor(makeActor(), PLAYER_UPDATE_STALE_MS - 1)).toBe(false);
+    expect(shouldServerSimulateHumanActor(makeActor(), PLAYER_UPDATE_STALE_MS)).toBe(true);
+    expect(shouldServerSimulateHumanActor(makeActor({ phase: "GRABBING" }), PLAYER_UPDATE_STALE_MS)).toBe(false);
+    expect(shouldServerSimulateHumanActor(makeActor({ frozen: true }), PLAYER_UPDATE_STALE_MS)).toBe(false);
+  });
+
+  it("continues zero-g drift and preserves portal-room bounds", () => {
+    const actor = makeActor({
+      posX: 24.9,
+      velX: 4,
+    });
+
+    integrateZeroGActor(actor, 0.5);
+    bounceActorInArena(actor, "x");
+
+    expect(actor.posX).toBeCloseTo(25.2, 5);
+    expect(actor.velX).toBeLessThan(0);
+  });
+
+  it("detects when a drifting actor reaches the enemy breach room", () => {
+    const goalSigns = { team0: 1 as const, team1: -1 as const };
+    const actor = makeActor({
+      team: 0,
+      posX: -23,
+      posY: 0,
+      posZ: 0,
+    });
+
+    expect(isActorInEnemyBreachRoom(actor, "x", goalSigns)).toBe(true);
+    expect(isActorInEnemyBreachRoom(makeActor({ team: 0, posX: 19 }), "x", goalSigns)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- continue stale online human actors server-side while they are floating so background-tab throttling no longer freezes them in place
- stop clearing online input state on blur/visibility loss and resync the local actor from authoritative room snapshots when the tab returns
- add focused coverage for the stale-update handoff and zero-g continuation helpers

## Validation
- `npm run build --prefix client`
- `npm run build --prefix server`
- `npx vitest run tests/onlineActorSimulation.test.ts`
- `npx vitest run` *(remaining unrelated baseline failures: `tests/instructionsContent.test.ts`, `tests/itchIndexCursor.test.ts`)*

Closes #113