### PR TITLE
chore(version): bump game version to v0.6

### DIFF
--- a/client/src/ui/menu/menuView.ts
+++ b/client/src/ui/menu/menuView.ts
@@ -670,7 +670,7 @@ export function createMenuView(savedName: string, matchSize: MatchTeamSize): Men
 
       <!-- TOPBAR -->
       <div class="ob-topbar">
-        <div class="ob-topbar-brand">ORBITAL BREACH <em>v0.4 · ZERO-G ARENA</em></div>
+        <div class="ob-topbar-brand">ORBITAL BREACH <em>v0.6 · ZERO-G ARENA</em></div>
         <div class="ob-topbar-right">
           <span><span class="ob-topbar-dot"></span>LINK SYNC</span>
           <span class="ob-clock" id="ob-clock">00:00:00 UTC</span>


### PR DESCRIPTION
## Summary

- Bumps the in-game version label from `v0.4` to `v0.6` in the main menu top-left
- `v0.5` = Vibe Jam 2026 submission (May 1, 2026) — the jam milestone
- `v0.6` = all post-jam polish shipped since then: itch landing, fullscreen sync, welcome screen, victory orbit camera, space-themed callsigns, disconnect handling sweep, tab-switch freeze fix, mobile fixes
- Keeps plenty of room before 1.0

## Change

`client/src/ui/menu/menuView.ts` line 673 — one string change.

## Test plan

- [ ] Start dev server, open main menu — confirm top-left reads `ORBITAL BREACH v0.6 · ZERO-G ARENA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version label from v0.4 to v0.6 in the menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DotanVG/Orbital-Breach/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->