### PR TITLE
perf: eliminate per-tick/per-frame heap allocations in hot paths

### DIFF
--- a/client/src/arena/obstacleCollision.ts
+++ b/client/src/arena/obstacleCollision.ts
@@ -26,23 +26,22 @@ export function bounceAgainstBoxes(state: PhysicsState, boxes: THREE.Box3[]): vo
       state.pos.z < minZ || state.pos.z > maxZ
     ) continue;
 
-    const overlaps = {
-      x: Math.min(state.pos.x - minX, maxX - state.pos.x),
-      y: Math.min(state.pos.y - minY, maxY - state.pos.y),
-      z: Math.min(state.pos.z - minZ, maxZ - state.pos.z),
-    };
+    const ovX = Math.min(state.pos.x - minX, maxX - state.pos.x);
+    const ovY = Math.min(state.pos.y - minY, maxY - state.pos.y);
+    const ovZ = Math.min(state.pos.z - minZ, maxZ - state.pos.z);
 
-    let minAx: 'x' | 'y' | 'z' = 'x';
-    if (overlaps.y < overlaps[minAx]) minAx = 'y';
-    if (overlaps.z < overlaps[minAx]) minAx = 'z';
-
-    const centerX = (minX + maxX) / 2;
-    const centerY = (minY + maxY) / 2;
-    const centerZ = (minZ + maxZ) / 2;
-    const centers = { x: centerX, y: centerY, z: centerZ };
-
-    const dir = Math.sign(state.pos[minAx] - centers[minAx]);
-    state.pos[minAx] += dir * overlaps[minAx];
-    state.vel[minAx] *= -0.5;
+    if (ovX <= ovY && ovX <= ovZ) {
+      const dir = Math.sign(state.pos.x - (minX + maxX) / 2);
+      state.pos.x += dir * ovX;
+      state.vel.x *= -0.5;
+    } else if (ovY <= ovX && ovY <= ovZ) {
+      const dir = Math.sign(state.pos.y - (minY + maxY) / 2);
+      state.pos.y += dir * ovY;
+      state.vel.y *= -0.5;
+    } else {
+      const dir = Math.sign(state.pos.z - (minZ + maxZ) / 2);
+      state.pos.z += dir * ovZ;
+      state.vel.z *= -0.5;
+    }
   }
 }

--- a/client/src/game/obstacleGrid.ts
+++ b/client/src/game/obstacleGrid.ts
@@ -1,0 +1,95 @@
+import * as THREE from "three";
+import { ARENA_SIZE } from "../../../shared/constants";
+
+const GRID_DIVS = 4;                          // 4×4×4 = 64 cells
+const CELL_SIZE = ARENA_SIZE / GRID_DIVS;     // 10 world-units per cell
+const ARENA_HALF = ARENA_SIZE / 2;            // 20
+
+/**
+ * Uniform 3-D grid over the arena that maps obstacle boxes to the cells
+ * they overlap. Used by ProjectileSystem to cull the obstacle list for
+ * each bullet segment check — expected ~10× fewer AABB tests vs brute-force.
+ *
+ * query() is allocation-free: results are written into a reused internal
+ * buffer. Callers must consume the result immediately; the buffer is
+ * overwritten on the next query().
+ *
+ * Build once per round (obstacles are static). Discard on round reset.
+ */
+export class ObstacleGrid {
+  private readonly cells: number[][];    // cellIndex → [boxIndex, ...]
+  private readonly boxes: THREE.Box3[];
+  private readonly boxGen: Int32Array;   // per-box: query-gen when last emitted
+  private queryGen = 0;
+  private readonly resultBuf: THREE.Box3[] = [];
+
+  public constructor(boxes: THREE.Box3[]) {
+    this.boxes = boxes;
+    this.boxGen = new Int32Array(boxes.length);
+
+    const totalCells = GRID_DIVS * GRID_DIVS * GRID_DIVS;
+    this.cells = Array.from({ length: totalCells }, () => []);
+
+    for (let bi = 0; bi < boxes.length; bi++) {
+      const box = boxes[bi];
+      const minCx = clamp(Math.floor((box.min.x + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+      const minCy = clamp(Math.floor((box.min.y + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+      const minCz = clamp(Math.floor((box.min.z + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+      const maxCx = clamp(Math.floor((box.max.x + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+      const maxCy = clamp(Math.floor((box.max.y + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+      const maxCz = clamp(Math.floor((box.max.z + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+
+      for (let cx = minCx; cx <= maxCx; cx++) {
+        for (let cy = minCy; cy <= maxCy; cy++) {
+          for (let cz = minCz; cz <= maxCz; cz++) {
+            this.cells[cx * GRID_DIVS * GRID_DIVS + cy * GRID_DIVS + cz].push(bi);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns candidate obstacle boxes whose grid cells overlap the bullet
+   * segment [a → b]. The returned array is the internal result buffer —
+   * read it immediately and do not store the reference.
+   */
+  public query(a: THREE.Vector3, b: THREE.Vector3): THREE.Box3[] {
+    const gen = ++this.queryGen;
+    this.resultBuf.length = 0;
+
+    const minCx = clamp(Math.floor((Math.min(a.x, b.x) + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+    const minCy = clamp(Math.floor((Math.min(a.y, b.y) + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+    const minCz = clamp(Math.floor((Math.min(a.z, b.z) + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+    const maxCx = clamp(Math.floor((Math.max(a.x, b.x) + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+    const maxCy = clamp(Math.floor((Math.max(a.y, b.y) + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+    const maxCz = clamp(Math.floor((Math.max(a.z, b.z) + ARENA_HALF) / CELL_SIZE), 0, GRID_DIVS - 1);
+
+    for (let cx = minCx; cx <= maxCx; cx++) {
+      for (let cy = minCy; cy <= maxCy; cy++) {
+        for (let cz = minCz; cz <= maxCz; cz++) {
+          for (const bi of this.cells[cx * GRID_DIVS * GRID_DIVS + cy * GRID_DIVS + cz]) {
+            if (this.boxGen[bi] !== gen) {
+              this.boxGen[bi] = gen;
+              this.resultBuf.push(this.boxes[bi]);
+            }
+          }
+        }
+      }
+    }
+
+    return this.resultBuf;
+  }
+
+  public get boxCount(): number { return this.boxes.length; }
+  public get divs(): number { return GRID_DIVS; }
+  public get cellSize(): number { return CELL_SIZE; }
+}
+
+export function buildObstacleGrid(boxes: THREE.Box3[]): ObstacleGrid {
+  return new ObstacleGrid(boxes);
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}

--- a/client/src/game/projectileSystem.ts
+++ b/client/src/game/projectileSystem.ts
@@ -2,6 +2,7 @@ import * as THREE from "three";
 import { ARENA_SIZE } from "../../../shared/constants";
 import { Projectile, type ProjectileTrailMode } from "../projectile";
 import { bulletHitPoint } from "./bulletCollision";
+import { buildObstacleGrid, type ObstacleGrid } from "./obstacleGrid";
 import { segmentSphereHitPoint } from "./projectileActorCollision";
 
 const BULLET_RADIUS = 0.07;
@@ -70,6 +71,7 @@ export class ProjectileSystem {
   private readonly tmpTangentA = new THREE.Vector3();
   private readonly tmpTangentB = new THREE.Vector3();
   private readonly tmpCrossHelper = new THREE.Vector3();
+  private obstacleGrid: ObstacleGrid | null = null;
 
   public constructor(private readonly scene: THREE.Scene) {}
 
@@ -92,6 +94,10 @@ export class ProjectileSystem {
     onPortalHit: (pos: THREE.Vector3, color: number) => void,
     onActorHit: (hit: ProjectileActorHit) => void,
   ): void {
+    if (!this.obstacleGrid && solidBoxes.length > 0) {
+      this.obstacleGrid = buildObstacleGrid(solidBoxes);
+    }
+
     const fxMode = this.currentFxMode();
     const trailMode = this.currentTrailMode(fxMode);
 
@@ -165,6 +171,8 @@ export class ProjectileSystem {
   }
 
   public clear(): void {
+    this.obstacleGrid = null;
+
     for (const projectile of this.projectiles) {
       projectile.dispose();
       this.projectilePool.push(projectile);
@@ -255,7 +263,11 @@ export class ProjectileSystem {
   ): CollisionHit | null {
     let nearest: CollisionHit | null = null;
 
-    for (const box of solidBoxes) {
+    const obstacleCandidates = this.obstacleGrid
+      ? this.obstacleGrid.query(oldPos, newPos)
+      : solidBoxes;
+
+    for (const box of obstacleCandidates) {
       const hit = bulletHitPoint(oldPos, newPos, box, BULLET_RADIUS);
       if (!hit) continue;
       const distance = hit.distanceToSquared(oldPos);

--- a/client/src/game/projectileSystem.ts
+++ b/client/src/game/projectileSystem.ts
@@ -58,11 +58,18 @@ type CollisionHit =
 
 export class ProjectileSystem {
   private flashes: HitFlash[] = [];
+  private freeFlashes: number[] = [];
   private projectilePool: Projectile[] = [];
   private projectiles: Projectile[] = [];
   private sparks: SparkBurst[] = [];
+  private freeSparks: number[] = [];
   private readonly tmpDirection = new THREE.Vector3();
   private readonly tmpSparkNormal = new THREE.Vector3();
+  private readonly tmpInwardNormal = new THREE.Vector3();
+  private readonly tmpClampedPos = new THREE.Vector3();
+  private readonly tmpTangentA = new THREE.Vector3();
+  private readonly tmpTangentB = new THREE.Vector3();
+  private readonly tmpCrossHelper = new THREE.Vector3();
 
   public constructor(private readonly scene: THREE.Scene) {}
 
@@ -164,20 +171,24 @@ export class ProjectileSystem {
     }
     this.projectiles = [];
 
-    for (const flash of this.flashes) {
-      flash.active = false;
-      flash.light.visible = false;
+    this.freeFlashes.length = 0;
+    for (let i = 0; i < this.flashes.length; i++) {
+      this.flashes[i].active = false;
+      this.flashes[i].light.visible = false;
+      this.freeFlashes.push(i);
     }
 
-    for (const spark of this.sparks) {
-      spark.active = false;
-      spark.points.visible = false;
+    this.freeSparks.length = 0;
+    for (let i = 0; i < this.sparks.length; i++) {
+      this.sparks[i].active = false;
+      this.sparks[i].points.visible = false;
+      this.freeSparks.push(i);
     }
   }
 
   private acquireFlash(): HitFlash | null {
-    const existing = this.flashes.find((flash) => !flash.active);
-    if (existing) return existing;
+    const freeIdx = this.freeFlashes.pop();
+    if (freeIdx !== undefined) return this.flashes[freeIdx];
     if (this.flashes.length >= MAX_FLASH_POOL) return null;
 
     const light = new THREE.PointLight(0xffffff, 0, 0, 2);
@@ -190,8 +201,8 @@ export class ProjectileSystem {
   }
 
   private acquireSparkBurst(): SparkBurst | null {
-    const existing = this.sparks.find((spark) => !spark.active);
-    if (existing) return existing;
+    const freeIdx = this.freeSparks.pop();
+    if (freeIdx !== undefined) return this.sparks[freeIdx];
     if (this.sparks.length >= MAX_SPARK_POOL) return null;
 
     const positions = new Float32Array(SPARK_COUNT * 3);
@@ -281,9 +292,9 @@ export class ProjectileSystem {
     const ax = Math.abs(clampedPos.x);
     const ay = Math.abs(clampedPos.y);
     const az = Math.abs(clampedPos.z);
-    if (ax >= ay && ax >= az) return new THREE.Vector3(-Math.sign(clampedPos.x), 0, 0);
-    if (ay >= ax && ay >= az) return new THREE.Vector3(0, -Math.sign(clampedPos.y), 0);
-    return new THREE.Vector3(0, 0, -Math.sign(clampedPos.z));
+    if (ax >= ay && ax >= az) return this.tmpInwardNormal.set(-Math.sign(clampedPos.x), 0, 0);
+    if (ay >= ax && ay >= az) return this.tmpInwardNormal.set(0, -Math.sign(clampedPos.y), 0);
+    return this.tmpInwardNormal.set(0, 0, -Math.sign(clampedPos.z));
   }
 
   private isAtArenaBoundary(pos: THREE.Vector3): boolean {
@@ -295,7 +306,7 @@ export class ProjectileSystem {
   }
 
   private clampToArena(pos: THREE.Vector3): THREE.Vector3 {
-    return new THREE.Vector3(
+    return this.tmpClampedPos.set(
       Math.max(-ARENA_LIMIT, Math.min(ARENA_LIMIT, pos.x)),
       Math.max(-ARENA_LIMIT, Math.min(ARENA_LIMIT, pos.y)),
       Math.max(-ARENA_LIMIT, Math.min(ARENA_LIMIT, pos.z)),
@@ -303,17 +314,16 @@ export class ProjectileSystem {
   }
 
   private recycleDeadProjectiles(): void {
-    if (this.projectiles.length === 0) return;
-
-    const active: Projectile[] = [];
-    for (const projectile of this.projectiles) {
-      if (projectile.dead) {
-        this.projectilePool.push(projectile);
+    let write = 0;
+    for (let read = 0; read < this.projectiles.length; read++) {
+      const p = this.projectiles[read];
+      if (p.dead) {
+        this.projectilePool.push(p);
       } else {
-        active.push(projectile);
+        this.projectiles[write++] = p;
       }
     }
-    this.projectiles = active;
+    this.projectiles.length = write;
   }
 
   private spawnFlash(
@@ -350,13 +360,13 @@ export class ProjectileSystem {
     const spark = this.acquireSparkBurst();
     if (!spark) return;
 
-    const nrm = normal ?? new THREE.Vector3(0, 1, 0);
-    const tangentA = new THREE.Vector3();
-    const tangentB = new THREE.Vector3();
+    const nrm = normal ?? this.tmpSparkNormal.set(0, 1, 0);
+    const tangentA = this.tmpTangentA;
+    const tangentB = this.tmpTangentB;
     if (Math.abs(nrm.x) < 0.9) {
-      tangentA.crossVectors(nrm, new THREE.Vector3(1, 0, 0)).normalize();
+      tangentA.crossVectors(nrm, this.tmpCrossHelper.set(1, 0, 0)).normalize();
     } else {
-      tangentA.crossVectors(nrm, new THREE.Vector3(0, 1, 0)).normalize();
+      tangentA.crossVectors(nrm, this.tmpCrossHelper.set(0, 1, 0)).normalize();
     }
     tangentB.crossVectors(nrm, tangentA);
     const phiMax = normal ? Math.PI / 2 : Math.PI;
@@ -398,7 +408,8 @@ export class ProjectileSystem {
   }
 
   private updateFlashes(dt: number): void {
-    for (const flash of this.flashes) {
+    for (let i = 0; i < this.flashes.length; i++) {
+      const flash = this.flashes[i];
       if (!flash.active) continue;
 
       flash.age += dt;
@@ -408,19 +419,21 @@ export class ProjectileSystem {
       if (flash.age >= FLASH_DURATION) {
         flash.active = false;
         flash.light.visible = false;
+        this.freeFlashes.push(i);
       }
     }
   }
 
   private updateSparks(dt: number): void {
-    for (const spark of this.sparks) {
+    for (let i = 0; i < this.sparks.length; i++) {
+      const spark = this.sparks[i];
       if (!spark.active) continue;
 
       spark.age += dt;
-      for (let i = 0; i < spark.count; i += 1) {
-        spark.positions[i * 3] += spark.velocities[i * 3] * dt;
-        spark.positions[i * 3 + 1] += spark.velocities[i * 3 + 1] * dt;
-        spark.positions[i * 3 + 2] += spark.velocities[i * 3 + 2] * dt;
+      for (let j = 0; j < spark.count; j += 1) {
+        spark.positions[j * 3] += spark.velocities[j * 3] * dt;
+        spark.positions[j * 3 + 1] += spark.velocities[j * 3 + 1] * dt;
+        spark.positions[j * 3 + 2] += spark.velocities[j * 3 + 2] * dt;
       }
       (spark.points.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
       (spark.points.material as THREE.PointsMaterial).opacity = Math.max(0, 1 - (spark.age / SPARK_DURATION) ** 2);
@@ -428,6 +441,7 @@ export class ProjectileSystem {
       if (spark.age >= SPARK_DURATION) {
         spark.active = false;
         spark.points.visible = false;
+        this.freeSparks.push(i);
       }
     }
   }

--- a/server/src/sim.ts
+++ b/server/src/sim.ts
@@ -23,6 +23,11 @@ export default class Sim {
   public gamePhase: GamePhase = "LOBBY";
   public seq = 0;
 
+  // Scratch objects — reused every tick to avoid per-tick allocation
+  private readonly _fwd = { x: 0, y: 0, z: 0 };
+  private readonly _right = { x: 0, y: 0, z: 0 };
+  private _snapshotPlayers: ReturnType<ServerPlayer["toNetState"]>[] = [];
+
   public addPlayer(p: ServerPlayer): void {
     this.players.set(p.id, p);
   }
@@ -74,7 +79,8 @@ export default class Sim {
     }
 
     p.seq = inp.seq;
-    p.rot = { ...p.rot, ...inp.rot };
+    p.rot.yaw = inp.rot.yaw;
+    p.rot.pitch = inp.rot.pitch;
   }
 
   private integratePlayer(p: ServerPlayer, dt: number): void {
@@ -88,15 +94,15 @@ export default class Sim {
     const sy = Math.sin(yaw);
     const cp = Math.cos(pitch);
     const sp = Math.sin(pitch);
-    const forward = { x: -sy * cp, y: sp, z: -cy * cp };
-    const right = { x: cy, y: 0, z: -sy };
+    this._fwd.x = -sy * cp; this._fwd.y = sp; this._fwd.z = -cy * cp;
+    this._right.x = cy; this._right.y = 0; this._right.z = -sy;
     const ax = inp.walkAxes;
     const scale = ACCEL * dt;
 
     // walkAxes is {x, z} only — no y thrust in zero-G arena
-    p.vel.x += (right.x * ax.x + forward.x * ax.z) * scale;
-    p.vel.y += (right.y * ax.x + forward.y * ax.z) * scale;
-    p.vel.z += (right.z * ax.x + forward.z * ax.z) * scale;
+    p.vel.x += (this._right.x * ax.x + this._fwd.x * ax.z) * scale;
+    p.vel.y += (this._right.y * ax.x + this._fwd.y * ax.z) * scale;
+    p.vel.z += (this._right.z * ax.x + this._fwd.z * ax.z) * scale;
 
     p.vel.x *= DAMPING;
     p.vel.y *= DAMPING;
@@ -157,8 +163,8 @@ export default class Sim {
   }
 
   private resetPos(p: ServerPlayer): void {
-    p.pos = p.team === 0 ? { x: 0, y: 0, z: -15 } : { x: 0, y: 0, z: 15 };
-    p.vel = { x: 0, y: 0, z: 0 };
+    p.pos.x = 0; p.pos.y = 0; p.pos.z = p.team === 0 ? -15 : 15;
+    p.vel.x = 0; p.vel.y = 0; p.vel.z = 0;
   }
 
   public handleShot(shooterId: string, targetId: string): void {
@@ -185,11 +191,18 @@ export default class Sim {
   }
 
   public getSnapshot(): ServerStateMsg {
+    const snap = this._snapshotPlayers;
+    let i = 0;
+    for (const p of this.players.values()) {
+      snap[i++] = p.toNetState();
+    }
+    snap.length = i;
+
     return {
       t:          "state",
       seq:        ++this.seq,
-      players:    [...this.players.values()].map((p) => p.toNetState()),
-      score:      { ...this.score },
+      players:    snap,
+      score:      this.score,
       arenaState: this.arenaStateId,
       phase:      this.gamePhase,
     };

--- a/tests/obstacleGrid.test.ts
+++ b/tests/obstacleGrid.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from "vitest";
+import * as THREE from "three";
+import { ObstacleGrid, buildObstacleGrid } from "../client/src/game/obstacleGrid";
+import { bulletHitPoint } from "../client/src/game/bulletCollision";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function box(cx: number, cy: number, cz: number, hw: number, hh: number, hd: number): THREE.Box3 {
+  return new THREE.Box3(
+    new THREE.Vector3(cx - hw, cy - hh, cz - hd),
+    new THREE.Vector3(cx + hw, cy + hh, cz + hd),
+  );
+}
+
+function v(x: number, y: number, z: number): THREE.Vector3 {
+  return new THREE.Vector3(x, y, z);
+}
+
+/** Seeded LCG — deterministic across runs. */
+function lcg(seed: number) {
+  let s = seed;
+  return () => { s = (1664525 * s + 1013904223) & 0xffffffff; return (s >>> 0) / 0xffffffff; };
+}
+
+/** Brute-force obstacle check — the O(n²) baseline. */
+function bruteForceHit(
+  oldPos: THREE.Vector3,
+  newPos: THREE.Vector3,
+  boxes: THREE.Box3[],
+  radius: number,
+): THREE.Vector3 | null {
+  let nearest: THREE.Vector3 | null = null;
+  let nearestDist = Infinity;
+  for (const b of boxes) {
+    const hit = bulletHitPoint(oldPos, newPos, b, radius);
+    if (!hit) continue;
+    const d = hit.distanceToSquared(oldPos);
+    if (d < nearestDist) { nearestDist = d; nearest = hit; }
+  }
+  return nearest;
+}
+
+/** Grid-accelerated obstacle check — the O(cells) path. */
+function gridHit(
+  oldPos: THREE.Vector3,
+  newPos: THREE.Vector3,
+  grid: ObstacleGrid,
+  radius: number,
+): THREE.Vector3 | null {
+  const candidates = grid.query(oldPos, newPos);
+  return bruteForceHit(oldPos, newPos, candidates, radius);
+}
+
+// ── unit tests ────────────────────────────────────────────────────────────────
+
+describe("ObstacleGrid — construction", () => {
+  it("reports correct box count", () => {
+    const boxes = [box(0, 0, 0, 1, 1, 1), box(5, 5, 5, 1, 1, 1)];
+    const grid = buildObstacleGrid(boxes);
+    expect(grid.boxCount).toBe(2);
+  });
+
+  it("uses 4 divisions and 10-unit cells", () => {
+    const grid = buildObstacleGrid([]);
+    expect(grid.divs).toBe(4);
+    expect(grid.cellSize).toBe(10);
+  });
+
+  it("handles empty box list", () => {
+    const grid = buildObstacleGrid([]);
+    const result = grid.query(v(0, 0, 0), v(1, 0, 0));
+    expect(result.length).toBe(0);
+  });
+
+  it("boxes outside arena bounds are clamped to nearest cell", () => {
+    const outOfBounds = box(100, 100, 100, 1, 1, 1);
+    expect(() => buildObstacleGrid([outOfBounds])).not.toThrow();
+  });
+});
+
+describe("ObstacleGrid — query correctness", () => {
+  it("returns a box in the same cell as the segment", () => {
+    // Box at (5, 5, 5), segment passing near it in same 10-unit cell
+    const boxes = [box(5, 5, 5, 1, 1, 1)];
+    const grid = buildObstacleGrid(boxes);
+    const candidates = grid.query(v(3, 5, 5), v(9, 5, 5));
+    expect(candidates).toContain(boxes[0]);
+  });
+
+  it("does not return a box in a completely different cell", () => {
+    // Box far away in cell (3,3,3), segment in cell (0,0,0)
+    const farBox = box(17, 17, 17, 1, 1, 1);
+    const nearBox = box(-17, -17, -17, 1, 1, 1);
+    const grid = buildObstacleGrid([nearBox, farBox]);
+    const candidates = grid.query(v(-19, -19, -19), v(-15, -19, -19));
+    expect(candidates).toContain(nearBox);
+    expect(candidates).not.toContain(farBox);
+  });
+
+  it("returns the same box only once even if it spans multiple cells", () => {
+    // Box spanning 3 cells on X axis
+    const bigBox = new THREE.Box3(v(-15, -1, -1), v(15, 1, 1));
+    const grid = buildObstacleGrid([bigBox]);
+    const candidates = grid.query(v(-19, 0, 0), v(19, 0, 0));
+    expect(candidates.filter(b => b === bigBox).length).toBe(1);
+  });
+
+  it("result buffer is reused — second query overwrites first", () => {
+    const boxes = [box(0, 0, 0, 1, 1, 1), box(15, 15, 15, 1, 1, 1)];
+    const grid = buildObstacleGrid(boxes);
+    const first = grid.query(v(-1, -1, -1), v(1, 1, 1));
+    const second = grid.query(v(14, 14, 14), v(16, 16, 16));
+    // Both references point to the same buffer — same object identity
+    expect(first).toBe(second);
+    // After second query, buffer contains only the second cell's box
+    expect(second).toContain(boxes[1]);
+    expect(second).not.toContain(boxes[0]);
+  });
+});
+
+describe("ObstacleGrid — hit correctness vs brute-force", () => {
+  const BULLET_RADIUS = 0.07;
+  const rng = lcg(42);
+  const HALF = 20;
+
+  function randCoord() { return (rng() * 2 - 1) * (HALF - 2); }
+
+  // Generate 44 obstacles (mirrors the max-obstacle arena)
+  const obstacles: THREE.Box3[] = Array.from({ length: 44 }, () => {
+    const cx = randCoord(); const cy = randCoord(); const cz = randCoord();
+    const hw = 0.5 + rng() * 2.5;
+    const hh = 0.5 + rng() * 2.5;
+    const hd = 0.5 + rng() * 2.5;
+    return box(cx, cy, cz, hw, hh, hd);
+  });
+
+  const grid = buildObstacleGrid(obstacles);
+
+  it("grid and brute-force agree on 200 random bullet segments", () => {
+    let mismatches = 0;
+    for (let i = 0; i < 200; i++) {
+      const ox = randCoord(); const oy = randCoord(); const oz = randCoord();
+      const dx = (rng() - 0.5); const dy = (rng() - 0.5); const dz = (rng() - 0.5);
+      const len = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+      const oldPos = v(ox, oy, oz);
+      const newPos = v(ox + dx / len * 0.5, oy + dy / len * 0.5, oz + dz / len * 0.5);
+
+      const expected = bruteForceHit(oldPos, newPos, obstacles, BULLET_RADIUS);
+      const actual   = gridHit(oldPos, newPos, grid, BULLET_RADIUS);
+
+      const bothNull = expected === null && actual === null;
+      const bothHit  = expected !== null && actual !== null
+        && Math.abs(expected.x - actual.x) < 0.001
+        && Math.abs(expected.y - actual.y) < 0.001
+        && Math.abs(expected.z - actual.z) < 0.001;
+
+      if (!bothNull && !bothHit) mismatches++;
+    }
+    expect(mismatches).toBe(0);
+  });
+});
+
+// ── benchmark ─────────────────────────────────────────────────────────────────
+
+describe("ObstacleGrid — benchmark (480 bullets × 44 obstacles)", () => {
+  const BULLET_RADIUS = 0.07;
+  const BULLET_SPEED  = 30; // world-units/sec
+  const DT            = 1 / 60; // 60 fps
+  const SEGMENT_LEN   = BULLET_SPEED * DT; // ~0.5 units
+  const N_BULLETS     = 480;
+  const N_OBSTACLES   = 44;
+  const ITERATIONS    = 50; // frames to simulate
+  const HALF          = 20;
+
+  const rng = lcg(1337);
+  function randCoord() { return (rng() * 2 - 1) * (HALF - 2); }
+
+  // Static obstacles
+  const obstacles: THREE.Box3[] = Array.from({ length: N_OBSTACLES }, () => {
+    const cx = randCoord(); const cy = randCoord(); const cz = randCoord();
+    return box(cx, cy, cz, 0.5 + rng() * 2.5, 0.5 + rng() * 1.5, 0.5 + rng() * 2.5);
+  });
+
+  // Static bullet origins + directions (simulate 480 bullets in flight)
+  const bulletOrigins = Array.from({ length: N_BULLETS }, () =>
+    v(randCoord(), randCoord(), randCoord()),
+  );
+  const bulletDirs = Array.from({ length: N_BULLETS }, () => {
+    const dx = rng() - 0.5; const dy = rng() - 0.5; const dz = rng() - 0.5;
+    const len = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+    return v(dx / len, dy / len, dz / len);
+  });
+
+  const grid = buildObstacleGrid(obstacles);
+  const tmpNew = v(0, 0, 0);
+
+  it("grid is faster than brute-force and produces equivalent results", () => {
+    let bruteChecks = 0;
+    let gridChecks  = 0;
+
+    // ── brute-force baseline ─────────────────────────────────────────────────
+    const t0brute = performance.now();
+    for (let frame = 0; frame < ITERATIONS; frame++) {
+      for (let bi = 0; bi < N_BULLETS; bi++) {
+        const o = bulletOrigins[bi];
+        const d = bulletDirs[bi];
+        tmpNew.set(
+          o.x + d.x * SEGMENT_LEN,
+          o.y + d.y * SEGMENT_LEN,
+          o.z + d.z * SEGMENT_LEN,
+        );
+        bruteForceHit(o, tmpNew, obstacles, BULLET_RADIUS);
+        bruteChecks += obstacles.length;
+      }
+    }
+    const bruteMs = performance.now() - t0brute;
+
+    // ── spatial grid ─────────────────────────────────────────────────────────
+    const t0grid = performance.now();
+    for (let frame = 0; frame < ITERATIONS; frame++) {
+      for (let bi = 0; bi < N_BULLETS; bi++) {
+        const o = bulletOrigins[bi];
+        const d = bulletDirs[bi];
+        tmpNew.set(
+          o.x + d.x * SEGMENT_LEN,
+          o.y + d.y * SEGMENT_LEN,
+          o.z + d.z * SEGMENT_LEN,
+        );
+        const candidates = grid.query(o, tmpNew);
+        bruteForceHit(o, tmpNew, candidates, BULLET_RADIUS);
+        gridChecks += candidates.length;
+      }
+    }
+    const gridMs = performance.now() - t0grid;
+
+    const speedup        = bruteMs / gridMs;
+    const avgBruteChecks = bruteChecks / (ITERATIONS * N_BULLETS);
+    const avgGridChecks  = gridChecks  / (ITERATIONS * N_BULLETS);
+    const checkReduction = ((avgBruteChecks - avgGridChecks) / avgBruteChecks * 100).toFixed(1);
+
+    console.log("\n=== Obstacle collision benchmark ===");
+    console.log(`Bullets: ${N_BULLETS}  |  Obstacles: ${N_OBSTACLES}  |  Frames: ${ITERATIONS}`);
+    console.log(`Brute-force : ${bruteMs.toFixed(2)} ms  (avg ${avgBruteChecks} checks/bullet)`);
+    console.log(`Spatial grid: ${gridMs.toFixed(2)} ms  (avg ${avgGridChecks.toFixed(1)} checks/bullet)`);
+    console.log(`Speedup: ${speedup.toFixed(2)}×  |  Check reduction: ${checkReduction}%`);
+    console.log("====================================\n");
+
+    // Grid must check fewer obstacles on average
+    expect(avgGridChecks).toBeLessThan(avgBruteChecks);
+    // Grid must be at least 2× faster (conservative — typically 5–10×)
+    expect(speedup).toBeGreaterThan(2);
+  });
+});


### PR DESCRIPTION
Closes #121
Closes #123

## What changed

Two commits on this branch targeting the main CPU bottlenecks in 20v20 bot mode.

---

### Commit 1 — Eliminate per-tick/per-frame heap allocations

Profiled the hot paths and killed the highest-frequency allocations with no behavior change.

| File | Fix |
|---|---|
| `server/src/sim.ts` | `applyInput`: assign yaw/pitch in-place (no object spread); `integratePlayer`: reuse `_fwd`/`_right` scratch objects; `resetPos`: assign pos/vel fields in-place; `getSnapshot`: reuse `_snapshotPlayers` array + pass `score` by reference (immediately JSON-serialized) |
| `client/src/arena/obstacleCollision.ts` | `bounceAgainstBoxes`: replace `overlaps{}`/`centers{}` literals with 6 inline `let` vars — 2 allocations × n_boxes × n_players × 60 fps eliminated |
| `client/src/game/projectileSystem.ts` | O(1) free-index stacks for flash/spark pools (was O(n) `.find()`); two-pointer `recycleDeadProjectiles` (no new array); cache `tmpInwardNormal`, `tmpClampedPos`, `tmpTangentA/B/tmpCrossHelper` (eliminates ~3 Vector3 allocations per impact burst) |

---

### Commit 2 — Spatial grid for bullet-obstacle collision (10× speedup)

Adds `ObstacleGrid` — a uniform 4×4×4 grid (64 cells, 10 world-units each) that indexes static obstacle boxes once per round. Each bullet segment query finds its AABB's overlapping cells and only tests boxes in those cells.

**Benchmark — 20v20 worst case (480 bullets, 44 obstacles, 50 frames at 60 fps):**

```
Brute-force : 75 ms  (avg 44 checks/bullet)
Spatial grid:  7 ms  (avg 1.4 checks/bullet)
Speedup: 10.6×  |  Check reduction: 96.8%
```

Implementation highlights:
- `client/src/game/obstacleGrid.ts` — pure class, no scene/DOM deps; `query()` is allocation-free (generation-counter deduplication, reused result buffer)
- Integrated into `ProjectileSystem` via lazy build on first `update()` after `clear()` — **zero changes to `gameApp.ts` or `arena.ts`**
- `portalBoxes` (2 boxes, dynamic) still checked brute-force — negligible
- `tests/obstacleGrid.test.ts` — 9 unit tests (construction, query correctness, 200-segment randomised hit agreement) + 1 benchmark test that asserts >2× speedup and prints measured numbers

---

## Test plan

- [x] `npm test` — 42 files, 243 tests, all green
- [x] New `obstacleGrid` tests: 10/10 pass, benchmark asserts >2× (measured 10.6×)
- [x] TypeScript: no new errors in changed files
- [ ] Manual: load 20v20 bot game — Chrome DevTools Memory timeline shows reduced GC pressure during combat
- [ ] Manual: shooting, bar-grab, and breach-win still work correctly