### PR TITLE
feat(debug): collider editor with hitzone adjustment tools

### DIFF
--- a/client/src/game/colliderEditor.ts
+++ b/client/src/game/colliderEditor.ts
@@ -1,0 +1,526 @@
+import * as THREE from 'three';
+import type { HitZone } from '../player/playerTypes';
+import {
+  type ColliderShape,
+  type HitZoneCollider,
+  cloneColliders,
+  defaultHitZoneColliders,
+  makeCollider,
+  serializeColliders,
+} from '../player/hitZoneColliders';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const MOVE_STEP   = 0.005;   // world-units per frame at 60 fps
+const RESIZE_STEP = 0.002;
+const ROT_STEP    = 0.005;   // radians per frame
+
+const ZONE_COLORS: Record<HitZone, number> = {
+  head:     0xff4444,
+  body:     0xffaa00,
+  leftArm:  0x44aaff,
+  rightArm: 0x44ffdd,
+  leftLeg:  0xaa44ff,
+  rightLeg: 0xffff44,
+};
+
+const ZONE_LABELS: Record<HitZone, string> = {
+  head:     'Head',
+  body:     'Body',
+  leftArm:  'Left Arm',
+  rightArm: 'Right Arm',
+  leftLeg:  'Left Leg',
+  rightLeg: 'Right Leg',
+};
+
+const ALL_ZONES: HitZone[]      = ['head', 'body', 'leftArm', 'rightArm', 'leftLeg', 'rightLeg'];
+const ALL_SHAPES: ColliderShape[] = ['box', 'sphere', 'capsule'];
+const SPHERE_SEGS = 10;
+
+// ── Mesh builders ────────────────────────────────────────────────────────────
+
+function makeBoxMesh(col: HitZoneCollider): THREE.Mesh {
+  const geo = new THREE.BoxGeometry(
+    col.size.x * 2, col.size.y * 2, col.size.z * 2,
+  );
+  const mat = new THREE.MeshBasicMaterial({
+    color: ZONE_COLORS[col.zone],
+    wireframe: true,
+    transparent: true,
+    opacity: 0.9,
+  });
+  return new THREE.Mesh(geo, mat);
+}
+
+function makeSphereMesh(col: HitZoneCollider): THREE.Mesh {
+  const geo = new THREE.SphereGeometry(col.size.x, SPHERE_SEGS, SPHERE_SEGS / 2);
+  const mat = new THREE.MeshBasicMaterial({
+    color: ZONE_COLORS[col.zone],
+    wireframe: true,
+    transparent: true,
+    opacity: 0.9,
+  });
+  return new THREE.Mesh(geo, mat);
+}
+
+function makeCapsuleMesh(col: HitZoneCollider): THREE.Mesh {
+  // Approximated as a cylinder for wireframe display
+  const geo = new THREE.CylinderGeometry(col.size.x, col.size.x, col.size.y * 2, 10, 1, true);
+  const mat = new THREE.MeshBasicMaterial({
+    color: ZONE_COLORS[col.zone],
+    wireframe: true,
+    transparent: true,
+    opacity: 0.9,
+  });
+  return new THREE.Mesh(geo, mat);
+}
+
+function buildMesh(col: HitZoneCollider): THREE.Mesh {
+  if (col.shape === 'sphere')  return makeSphereMesh(col);
+  if (col.shape === 'capsule') return makeCapsuleMesh(col);
+  return makeBoxMesh(col);
+}
+
+function disposeMesh(m: THREE.Mesh): void {
+  m.geometry.dispose();
+  const mat = m.material;
+  if (Array.isArray(mat)) mat.forEach(x => x.dispose());
+  else mat.dispose();
+}
+
+// ── ColliderEditor ───────────────────────────────────────────────────────────
+
+export class ColliderEditor {
+  private visible       = false;
+  private colliders     : HitZoneCollider[] = cloneColliders(defaultHitZoneColliders);
+  private selectedIndex = 0;
+
+  private group  = new THREE.Group();
+  private meshes : THREE.Mesh[] = [];
+
+  private panel     : HTMLDivElement;
+  private listEl    : HTMLDivElement;
+  private propsEl   : HTMLDivElement;
+
+  // Keydown listener registered on window for discrete actions (add/delete/cycle)
+  private readonly boundKeyDown: (e: KeyboardEvent) => void;
+
+  public constructor(private readonly scene: THREE.Scene) {
+    this.group.visible = false;
+    scene.add(this.group);
+
+    const { panel, listEl, propsEl } = this.createPanel();
+    this.panel   = panel;
+    this.listEl  = listEl;
+    this.propsEl = propsEl;
+
+    this.rebuildAllMeshes();
+
+    this.boundKeyDown = this.onKeyDown.bind(this);
+    window.addEventListener('keydown', this.boundKeyDown);
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  public isVisible(): boolean { return this.visible; }
+
+  public toggle(): void { this.setVisible(!this.visible); }
+
+  public setVisible(v: boolean): void {
+    this.visible            = v;
+    this.group.visible      = v;
+    this.panel.style.display = v ? 'flex' : 'none';
+    if (v) this.renderPanel();
+  }
+
+  /**
+   * Called each frame from gameApp when the editor might be visible.
+   * axes — from input.getColliderEditorAxes(); playerPos — local player world pos.
+   */
+  public tick(
+    playerPos: THREE.Vector3,
+    axes: {
+      move:     { x: number; y: number; z: number };
+      resize:   { x: number; y: number; z: number };
+      rotation: { x: number; y: number; z: number };
+    },
+  ): void {
+    if (!this.visible) return;
+    this.applyAxes(axes);
+    this.updateMeshWorldPositions(playerPos);
+    this.renderPanel();
+  }
+
+  public dispose(): void {
+    window.removeEventListener('keydown', this.boundKeyDown);
+    this.clearAllMeshes();
+    this.scene.remove(this.group);
+    this.panel.remove();
+  }
+
+  // ── Axis application ───────────────────────────────────────────────────────
+
+  private applyAxes(axes: {
+    move:     { x: number; y: number; z: number };
+    resize:   { x: number; y: number; z: number };
+    rotation: { x: number; y: number; z: number };
+  }): void {
+    const col = this.colliders[this.selectedIndex];
+    if (!col) return;
+
+    const m = axes.move;
+    const r = axes.resize;
+    const rot = axes.rotation;
+
+    if (m.x || m.y || m.z) {
+      col.position.x += m.x * MOVE_STEP;
+      col.position.y += m.y * MOVE_STEP;
+      col.position.z += m.z * MOVE_STEP;
+    }
+    if (r.x || r.y || r.z) {
+      col.size.x = Math.max(0.01, col.size.x + r.x * RESIZE_STEP);
+      col.size.y = Math.max(0.01, col.size.y + r.y * RESIZE_STEP);
+      col.size.z = Math.max(0.01, col.size.z + r.z * RESIZE_STEP);
+    }
+    if (rot.x || rot.y || rot.z) {
+      col.rotation.x += rot.x * ROT_STEP;
+      col.rotation.y += rot.y * ROT_STEP;
+      col.rotation.z += rot.z * ROT_STEP;
+    }
+
+    if (m.x || m.y || m.z || r.x || r.y || r.z || rot.x || rot.y || rot.z) {
+      this.refreshMesh(this.selectedIndex);
+    }
+  }
+
+  // ── Three.js mesh management ───────────────────────────────────────────────
+
+  private rebuildAllMeshes(): void {
+    this.clearAllMeshes();
+    for (let i = 0; i < this.colliders.length; i++) {
+      const mesh = buildMesh(this.colliders[i]);
+      this.group.add(mesh);
+      this.meshes.push(mesh);
+    }
+  }
+
+  private clearAllMeshes(): void {
+    for (const m of this.meshes) {
+      this.group.remove(m);
+      disposeMesh(m);
+    }
+    this.meshes = [];
+  }
+
+  /** Rebuild the mesh for collider at index (shape/size changed). */
+  private refreshMesh(index: number): void {
+    const old = this.meshes[index];
+    if (old) {
+      this.group.remove(old);
+      disposeMesh(old);
+    }
+    const col  = this.colliders[index];
+    const mesh = buildMesh(col);
+    this.group.add(mesh);
+    this.meshes[index] = mesh;
+    this.applyMeshTransform(index);
+    this.highlightSelected();
+  }
+
+  /** Position/rotate each mesh relative to the player world pos. */
+  private updateMeshWorldPositions(playerPos: THREE.Vector3): void {
+    for (let i = 0; i < this.colliders.length; i++) {
+      const col  = this.colliders[i];
+      const mesh = this.meshes[i];
+      if (!mesh) continue;
+      mesh.position.set(
+        playerPos.x + col.position.x,
+        playerPos.y + col.position.y,
+        playerPos.z + col.position.z,
+      );
+      mesh.rotation.set(col.rotation.x, col.rotation.y, col.rotation.z);
+    }
+  }
+
+  private applyMeshTransform(index: number): void {
+    const col  = this.colliders[index];
+    const mesh = this.meshes[index];
+    if (!mesh) return;
+    mesh.rotation.set(col.rotation.x, col.rotation.y, col.rotation.z);
+  }
+
+  private highlightSelected(): void {
+    for (let i = 0; i < this.meshes.length; i++) {
+      const mesh = this.meshes[i];
+      if (!mesh) continue;
+      const mat = mesh.material as THREE.MeshBasicMaterial;
+      mat.opacity  = i === this.selectedIndex ? 1.0 : 0.45;
+      mat.color.setHex(
+        i === this.selectedIndex
+          ? 0xffffff
+          : ZONE_COLORS[this.colliders[i].zone],
+      );
+    }
+  }
+
+  // ── Keyboard (discrete actions) ────────────────────────────────────────────
+
+  private onKeyDown(e: KeyboardEvent): void {
+    if (!this.visible) return;
+    // Don't steal keys from text fields
+    const tag = (document.activeElement as HTMLElement | null)?.tagName ?? '';
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+    switch (e.code) {
+      case 'Comma':      this.selectPrev();      e.preventDefault(); break;
+      case 'Period':     this.selectNext();      e.preventDefault(); break;
+      case 'KeyN':       this.addCollider();     e.preventDefault(); break;
+      case 'Delete':     this.deleteSelected();  e.preventDefault(); break;
+      case 'KeyG':       this.cycleZone();       e.preventDefault(); break;
+      case 'KeyF':       this.cycleShape();      e.preventDefault(); break;
+      case 'Enter':      void this.printColliders(); e.preventDefault(); break;
+      case 'Backspace':  this.resetCollider();   e.preventDefault(); break;
+    }
+  }
+
+  private selectPrev(): void {
+    if (this.colliders.length === 0) return;
+    this.selectedIndex = (this.selectedIndex - 1 + this.colliders.length) % this.colliders.length;
+    this.highlightSelected();
+  }
+
+  private selectNext(): void {
+    if (this.colliders.length === 0) return;
+    this.selectedIndex = (this.selectedIndex + 1) % this.colliders.length;
+    this.highlightSelected();
+  }
+
+  private addCollider(): void {
+    const zone  = ALL_ZONES[this.selectedIndex % ALL_ZONES.length];
+    const col   = makeCollider(zone, 'box');
+    this.colliders.push(col);
+    const mesh = buildMesh(col);
+    this.group.add(mesh);
+    this.meshes.push(mesh);
+    this.selectedIndex = this.colliders.length - 1;
+    this.highlightSelected();
+  }
+
+  private deleteSelected(): void {
+    if (this.colliders.length === 0) return;
+    const mesh = this.meshes[this.selectedIndex];
+    if (mesh) {
+      this.group.remove(mesh);
+      disposeMesh(mesh);
+    }
+    this.colliders.splice(this.selectedIndex, 1);
+    this.meshes.splice(this.selectedIndex, 1);
+    this.selectedIndex = Math.min(this.selectedIndex, this.colliders.length - 1);
+    this.highlightSelected();
+  }
+
+  private cycleZone(): void {
+    const col = this.colliders[this.selectedIndex];
+    if (!col) return;
+    const idx  = ALL_ZONES.indexOf(col.zone);
+    col.zone   = ALL_ZONES[(idx + 1) % ALL_ZONES.length];
+    this.refreshMesh(this.selectedIndex);
+  }
+
+  private cycleShape(): void {
+    const col  = this.colliders[this.selectedIndex];
+    if (!col) return;
+    const idx  = ALL_SHAPES.indexOf(col.shape);
+    col.shape  = ALL_SHAPES[(idx + 1) % ALL_SHAPES.length];
+    this.refreshMesh(this.selectedIndex);
+  }
+
+  private resetCollider(): void {
+    const col = this.colliders[this.selectedIndex];
+    if (!col) return;
+    col.position = { x: 0, y: 0, z: 0 };
+    col.size     = { x: 0.15, y: 0.15, z: 0.15 };
+    col.rotation = { x: 0, y: 0, z: 0 };
+    this.refreshMesh(this.selectedIndex);
+  }
+
+  private async printColliders(): Promise<void> {
+    const json = serializeColliders(this.colliders);
+    console.info('[ColliderEditor] Current colliders:\n' + json);
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(json);
+        console.info('[ColliderEditor] Copied to clipboard.');
+      }
+    } catch {
+      // clipboard not available (pointer locked) — values already in console
+    }
+  }
+
+  // ── DOM panel ─────────────────────────────────────────────────────────────
+
+  private createPanel(): { panel: HTMLDivElement; listEl: HTMLDivElement; propsEl: HTMLDivElement } {
+    const panel = document.createElement('div');
+    Object.assign(panel.style, {
+      position:       'fixed',
+      top:            '50%',
+      right:          '16px',
+      transform:      'translateY(-50%)',
+      zIndex:         '200',
+      width:          '310px',
+      maxHeight:      '90vh',
+      overflowY:      'auto',
+      display:        'none',
+      flexDirection:  'column',
+      gap:            '6px',
+      padding:        '12px',
+      background:     'rgba(2, 8, 24, 0.90)',
+      border:         '1px solid rgba(0,255,200,0.4)',
+      borderRadius:   '10px',
+      color:          '#c8fff0',
+      font:           '11px/1.5 monospace',
+      pointerEvents:  'none',
+    });
+
+    const title = document.createElement('div');
+    Object.assign(title.style, {
+      fontSize: '13px',
+      fontWeight: 'bold',
+      color: '#00ffd0',
+      borderBottom: '1px solid rgba(0,255,200,0.2)',
+      paddingBottom: '6px',
+      marginBottom: '4px',
+    });
+    title.textContent = '▣ COLLIDER EDITOR';
+
+    const listLabel = this.makeLabel('COLLIDERS');
+    const listEl    = document.createElement('div');
+    Object.assign(listEl.style, { display: 'flex', flexDirection: 'column', gap: '2px' });
+
+    const propsLabel = this.makeLabel('SELECTED');
+    const propsEl    = document.createElement('div');
+
+    const help = document.createElement('div');
+    Object.assign(help.style, {
+      marginTop: '6px',
+      borderTop: '1px solid rgba(0,255,200,0.15)',
+      paddingTop: '6px',
+      color: 'rgba(180,255,230,0.55)',
+      fontSize: '10px',
+      lineHeight: '1.6',
+    });
+    help.innerHTML = [
+      ',/. — prev/next collider',
+      'Arrows/PgUp/PgDn — move XYZ',
+      'Shift+Arrows/PgUp/PgDn — resize',
+      'I/K J/L U/O — rotate',
+      'N — new collider',
+      'Delete — delete selected',
+      'G — cycle body part',
+      'F — cycle shape',
+      'Enter — print/copy JSON',
+      'Backspace — reset to zero',
+      '] — close editor',
+    ].join('<br>');
+
+    panel.append(title, listLabel, listEl, propsLabel, propsEl, help);
+    document.body.appendChild(panel);
+
+    return { panel, listEl, propsEl };
+  }
+
+  private makeLabel(text: string): HTMLDivElement {
+    const el = document.createElement('div');
+    Object.assign(el.style, {
+      fontSize: '9px',
+      letterSpacing: '0.1em',
+      color: 'rgba(0,255,200,0.5)',
+      marginBottom: '2px',
+    });
+    el.textContent = text;
+    return el;
+  }
+
+  private renderPanel(): void {
+    this.renderList();
+    this.renderProps();
+  }
+
+  private renderList(): void {
+    this.listEl.innerHTML = '';
+    for (let i = 0; i < this.colliders.length; i++) {
+      const col     = this.colliders[i];
+      const isActive = i === this.selectedIndex;
+      const row      = document.createElement('div');
+      const hex      = ZONE_COLORS[col.zone].toString(16).padStart(6, '0');
+      Object.assign(row.style, {
+        display:      'flex',
+        alignItems:   'center',
+        gap:          '6px',
+        padding:      '3px 6px',
+        borderRadius: '4px',
+        background:   isActive ? 'rgba(0,255,200,0.12)' : 'transparent',
+        border:       isActive ? '1px solid rgba(0,255,200,0.35)' : '1px solid transparent',
+      });
+      const dot = document.createElement('span');
+      Object.assign(dot.style, {
+        display:      'inline-block',
+        width:        '8px',
+        height:       '8px',
+        borderRadius: col.shape === 'sphere' ? '50%' : '2px',
+        background:   '#' + hex,
+        flexShrink:   '0',
+      });
+      const label = document.createElement('span');
+      label.textContent = `${i}: ${ZONE_LABELS[col.zone]} (${col.shape})`;
+      row.append(dot, label);
+      if (isActive) {
+        const arrow = document.createElement('span');
+        arrow.style.marginLeft = 'auto';
+        arrow.style.color = '#00ffd0';
+        arrow.textContent = '◀';
+        row.appendChild(arrow);
+      }
+      this.listEl.appendChild(row);
+    }
+    if (this.colliders.length === 0) {
+      const empty = document.createElement('div');
+      empty.style.color = 'rgba(180,255,230,0.35)';
+      empty.textContent = '(empty — press N to add)';
+      this.listEl.appendChild(empty);
+    }
+  }
+
+  private renderProps(): void {
+    const col = this.colliders[this.selectedIndex];
+    if (!col) {
+      this.propsEl.textContent = '';
+      return;
+    }
+    const p = col.position;
+    const s = col.size;
+    const r = col.rotation;
+    const hex = ZONE_COLORS[col.zone].toString(16).padStart(6, '0');
+    this.propsEl.innerHTML = `
+<div style="display:grid;grid-template-columns:60px 1fr;gap:2px 8px;margin-top:4px">
+  <span style="color:rgba(180,255,230,0.5)">zone</span>
+  <span style="color:#${hex}">${ZONE_LABELS[col.zone]}</span>
+  <span style="color:rgba(180,255,230,0.5)">shape</span>
+  <span>${col.shape}</span>
+  <span style="color:rgba(180,255,230,0.5)">pos</span>
+  <span>${fmt(p.x)} ${fmt(p.y)} ${fmt(p.z)}</span>
+  <span style="color:rgba(180,255,230,0.5)">size</span>
+  <span>${fmt(s.x)} ${fmt(s.y)} ${fmt(s.z)}</span>
+  <span style="color:rgba(180,255,230,0.5)">rot°</span>
+  <span>${fmtDeg(r.x)} ${fmtDeg(r.y)} ${fmtDeg(r.z)}</span>
+</div>`.trim();
+  }
+}
+
+function fmt(n: number): string {
+  return n.toFixed(3).padStart(7);
+}
+
+function fmtDeg(rad: number): string {
+  return ((rad * 180) / Math.PI).toFixed(1).padStart(6) + '°';
+}

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -44,6 +44,7 @@ import { ProjectileSystem } from "./projectileSystem";
 import { RoundController } from "./roundController";
 import { GunTuneOverlay } from "./gunTuneOverlay";
 import { CollisionVisualizer } from "./collisionVisualizer";
+import { ColliderEditor } from "./colliderEditor";
 import { shouldShowDesktopOverlayCursor } from "./overlayCursor";
 import { buildShotFromCamera } from "./weaponFire";
 import { NetClient } from "../net/client";
@@ -100,6 +101,7 @@ export class App {
   private gun: GunViewModel;
   private gunTuneOverlay = new GunTuneOverlay();
   private collisionVis!: CollisionVisualizer;
+  private colliderEditor!: ColliderEditor;
   private hud: HUD;
   private input: InputManager;
   private killFeed = new KillFeed();
@@ -150,7 +152,8 @@ export class App {
     this.projectiles = new ProjectileSystem(this.sceneMgr.getScene());
     this.match = new LocalMatch(this.sceneMgr.getScene());
     this.onlineMatch = new OnlineMatch(this.sceneMgr.getScene());
-    this.collisionVis = new CollisionVisualizer(this.sceneMgr.getScene());
+    this.collisionVis   = new CollisionVisualizer(this.sceneMgr.getScene());
+    this.colliderEditor = new ColliderEditor(this.sceneMgr.getScene());
     this.hud.setVisible(false);
     this.killFeed.setVisible(false);
     this.sessionMenu.setLauncherVisible(false);
@@ -574,6 +577,7 @@ export class App {
     );
     this.tickGunTuning();
     this.tickCollisionVis();
+    this.tickColliderEditor();
     this.matchStats.observePlayers(this.match.getMatchStatsActors(this.player), {
       accumulateTravel: this.round.isPlaying(),
     });
@@ -1677,6 +1681,17 @@ export class App {
     const statsActors = this.match.getMatchStatsActors(this.player);
     const positions = statsActors.map((a) => new THREE.Vector3(a.position.x, a.position.y, a.position.z));
     this.collisionVis.updateActors(positions);
+  }
+
+  // ── Collider editor ─────────────────────────────────────────────────────────
+
+  private tickColliderEditor(): void {
+    if (this.input.consumeColliderEditorToggle()) {
+      this.colliderEditor.toggle();
+    }
+    if (!this.colliderEditor.isVisible()) return;
+    const axes = this.input.getColliderEditorAxes();
+    this.colliderEditor.tick(this.player.getPosition(), axes);
   }
 
   // ── Gun tuning overlays ─────────────────────────────────────────────────────

--- a/client/src/game/gameApp.ts
+++ b/client/src/game/gameApp.ts
@@ -1673,7 +1673,7 @@ export class App {
   // ── Collision visualizer ────────────────────────────────────────────────────
 
   private tickCollisionVis(): void {
-    if (this.input.consumeCollisionVisToggle()) {
+    if (import.meta.env.DEV && this.input.consumeCollisionVisToggle()) {
       this.collisionVis.toggle();
     }
     if (!this.collisionVis.isVisible()) return;
@@ -1686,6 +1686,7 @@ export class App {
   // ── Collider editor ─────────────────────────────────────────────────────────
 
   private tickColliderEditor(): void {
+    if (!import.meta.env.DEV) return;
     if (this.input.consumeColliderEditorToggle()) {
       this.colliderEditor.toggle();
     }

--- a/client/src/input.ts
+++ b/client/src/input.ts
@@ -18,6 +18,7 @@ export class InputManager {
   private menuTogglePressed = false;
   private helpPressed = false;
   private collisionVisTogglePressed = false;
+  private colliderEditorTogglePressed = false;
   public onTabHoldChange: ((held: boolean) => void) | null = null;
 
   // Mobile touch input state
@@ -41,8 +42,9 @@ export class InputManager {
       if (e.code === 'KeyP' && !e.repeat) this.gunTuneTogglePressed = true;
       if (e.code === 'Enter' && !e.repeat) this.gunTunePrintPressed = true;
       if (e.code === 'Escape' && !e.repeat) this.menuTogglePressed = true;
-      if (e.code === 'KeyH'   && !e.repeat) this.helpPressed = true;
-      if (e.code === 'KeyC'   && !e.repeat) this.collisionVisTogglePressed = true;
+      if (e.code === 'KeyH'        && !e.repeat) this.helpPressed = true;
+      if (e.code === 'BracketLeft' && !e.repeat) this.collisionVisTogglePressed = true;
+      if (e.code === 'BracketRight'&& !e.repeat) this.colliderEditorTogglePressed = true;
       // Only intercept navigation/delete keys when focus is NOT in a text field,
       // so the Call Sign input and other fields retain normal keyboard behaviour.
       const tag = (document.activeElement as HTMLElement | null)?.tagName ?? '';
@@ -291,11 +293,50 @@ export class InputManager {
     return v && !this.uiBlocked;
   }
 
-  /** Toggle collision visualizer — KeyC. */
+  /** Toggle collision visualizer — BracketLeft ([). */
   public consumeCollisionVisToggle(): boolean {
     const v = this.collisionVisTogglePressed;
     this.collisionVisTogglePressed = false;
     return v;
+  }
+
+  /** Toggle collider editor — BracketRight (]). */
+  public consumeColliderEditorToggle(): boolean {
+    const v = this.colliderEditorTogglePressed;
+    this.colliderEditorTogglePressed = false;
+    return v;
+  }
+
+  /**
+   * Axes for the collider editor (same keys as gun tuner).
+   * No-Shift: move position. Shift: resize.
+   * Rotation: I/K J/L U/O (same as gun tuner).
+   */
+  public getColliderEditorAxes(): {
+    move: { x: number; y: number; z: number };
+    resize: { x: number; y: number; z: number };
+    rotation: { x: number; y: number; z: number };
+  } {
+    if (this.uiBlocked) {
+      return {
+        move:     { x: 0, y: 0, z: 0 },
+        resize:   { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+      };
+    }
+    const shift = this.keys.has('ShiftLeft') || this.keys.has('ShiftRight');
+    const dx = (this.keys.has('ArrowRight') ? 1 : 0) - (this.keys.has('ArrowLeft') ? 1 : 0);
+    const dy = (this.keys.has('PageUp')  ? 1 : 0) - (this.keys.has('PageDown') ? 1 : 0);
+    const dz = (this.keys.has('ArrowDown') ? 1 : 0) - (this.keys.has('ArrowUp') ? 1 : 0);
+    return {
+      move:   shift ? { x: 0, y: 0, z: 0 } : { x: dx, y: dy, z: dz },
+      resize: shift ? { x: dx, y: dy, z: dz } : { x: 0, y: 0, z: 0 },
+      rotation: {
+        x: (this.keys.has('KeyK') ? 1 : 0) - (this.keys.has('KeyI') ? 1 : 0),
+        y: (this.keys.has('KeyL') ? 1 : 0) - (this.keys.has('KeyJ') ? 1 : 0),
+        z: (this.keys.has('KeyO') ? 1 : 0) - (this.keys.has('KeyU') ? 1 : 0),
+      },
+    };
   }
 
   public getGunTuneAxes(): {
@@ -380,6 +421,8 @@ export class InputManager {
     this.gunTuneResetPressed = false;
     this.gunTunePrintPressed = false;
     this.menuTogglePressed = false;
+    this.collisionVisTogglePressed = false;
+    this.colliderEditorTogglePressed = false;
     // mobileControlsActive is intentionally preserved across blur/visibility changes
     if (tabWasHeld) this.onTabHoldChange?.(false);
   }

--- a/client/src/player/hitZoneColliders.ts
+++ b/client/src/player/hitZoneColliders.ts
@@ -1,0 +1,85 @@
+import type { HitZone } from './playerTypes';
+
+export type ColliderShape = 'box' | 'sphere' | 'capsule';
+
+export interface HitZoneCollider {
+  id: string;
+  zone: HitZone;
+  shape: ColliderShape;
+  /** Offset from player physics origin (feet-level y=0 for typical spawn, but origin is at body center) */
+  position: { x: number; y: number; z: number };
+  /** box: half-extents xyz; sphere: x=radius (y,z unused); capsule: x=radius, y=half-height */
+  size: { x: number; y: number; z: number };
+  /** Euler angles in radians (XYZ order) */
+  rotation: { x: number; y: number; z: number };
+}
+
+let _nextId = 1;
+function nextId(): string { return `col_${_nextId++}`; }
+
+/**
+ * Starting collider set for the alien model.
+ * Player physics origin is at the center of the PLAYER_RADIUS (0.8) sphere.
+ * HITBOX_OFFSET_Y = -0.35 means the hit sphere centre is 0.35 units below origin.
+ * These are rough defaults — use ] (collider editor) to tune them in-game.
+ */
+export const defaultHitZoneColliders: HitZoneCollider[] = [
+  {
+    id: nextId(), zone: 'head', shape: 'sphere',
+    position: { x: 0, y: 0.12, z: 0 },
+    size:     { x: 0.18, y: 0.18, z: 0.18 },
+    rotation: { x: 0, y: 0, z: 0 },
+  },
+  {
+    id: nextId(), zone: 'body', shape: 'box',
+    position: { x: 0, y: -0.18, z: 0 },
+    size:     { x: 0.19, y: 0.23, z: 0.14 },
+    rotation: { x: 0, y: 0, z: 0 },
+  },
+  {
+    id: nextId(), zone: 'leftArm', shape: 'box',
+    position: { x: -0.33, y: -0.14, z: 0 },
+    size:     { x: 0.13, y: 0.21, z: 0.10 },
+    rotation: { x: 0, y: 0, z: 0 },
+  },
+  {
+    id: nextId(), zone: 'rightArm', shape: 'box',
+    position: { x: 0.33, y: -0.14, z: 0 },
+    size:     { x: 0.13, y: 0.21, z: 0.10 },
+    rotation: { x: 0, y: 0, z: 0 },
+  },
+  {
+    id: nextId(), zone: 'leftLeg', shape: 'box',
+    position: { x: -0.13, y: -0.54, z: 0 },
+    size:     { x: 0.10, y: 0.23, z: 0.10 },
+    rotation: { x: 0, y: 0, z: 0 },
+  },
+  {
+    id: nextId(), zone: 'rightLeg', shape: 'box',
+    position: { x: 0.13, y: -0.54, z: 0 },
+    size:     { x: 0.10, y: 0.23, z: 0.10 },
+    rotation: { x: 0, y: 0, z: 0 },
+  },
+];
+
+export function makeCollider(zone: HitZone, shape: ColliderShape): HitZoneCollider {
+  return {
+    id: nextId(), zone, shape,
+    position: { x: 0, y: 0, z: 0 },
+    size:     { x: 0.15, y: 0.15, z: 0.15 },
+    rotation: { x: 0, y: 0, z: 0 },
+  };
+}
+
+export function cloneColliders(src: HitZoneCollider[]): HitZoneCollider[] {
+  return src.map(c => ({
+    ...c,
+    position: { ...c.position },
+    size:     { ...c.size },
+    rotation: { ...c.rotation },
+  }));
+}
+
+export function serializeColliders(colliders: HitZoneCollider[]): string {
+  return JSON.stringify(colliders, null, 2);
+}

--- a/client/src/ui/sessionMenu.ts
+++ b/client/src/ui/sessionMenu.ts
@@ -743,7 +743,7 @@ export class SessionMenu {
                   <span id="session-menu-collisionvis-value" class="ob-session-value"></span>
                 </div>
                 <label class="ob-session-toggle">
-                  <span class="ob-session-toggle-copy">Overlay wireframe collision volumes — player sphere, obstacle AABBs, grab bars, breach room bounds. Press C in-game to toggle.</span>
+                  <span class="ob-session-toggle-copy">Overlay wireframe collision volumes — player sphere, obstacle AABBs, grab bars, breach room bounds. Press [ in-game to toggle.</span>
                   <input id="session-menu-collisionvis" class="ob-session-checkbox" type="checkbox" />
                 </label>
               </div>


### PR DESCRIPTION
## Summary

Revival of closed PR #124, rebased onto current staging.

- Remaps collision visualizer hotkey: `C` → `[` (BracketLeft)
- Adds `]` (BracketRight) to toggle collider editor
- New `client/src/player/hitZoneColliders.ts`: `HitZoneCollider` type + alien model zone defaults
- New `client/src/game/colliderEditor.ts`: Three.js wireframe overlays per body zone, DOM inspector panel, keyboard-driven move/resize/rotate/add/delete, zone/shape cycling, JSON print+clipboard export
- `input.ts`: `consumeColliderEditorToggle()` + `getColliderEditorAxes()` (Shift = resize, no-Shift = move, IJKL/UO = rotate)
- `gameApp.ts`: `tickColliderEditor()` wired into game loop; both `[` and `]` keybinds gated behind `import.meta.env.DEV` — not accessible in production builds

## Notes

- Cherry-picked single commit `1686538` from `claude/confident-elion-624b6f` onto fresh staging base
- No conflicts — collision visualizer (previously `C`) was already merged into staging; this PR only adds the editor and remaps the vis key
- TypeScript compiles clean on both client and server

Closes #137

## Test plan

- [ ] `[` toggles wireframe collision overlay (previously `C`)
- [ ] `]` opens/closes the collider editor DOM panel
- [ ] Move/resize/rotate controls work (IJKL / UO, Shift = resize mode)
- [ ] JSON export copies to clipboard
- [ ] Shooting, grab, breach, and all other features unaffected
- [ ] In production build, `[` and `]` have no effect