### PR TITLE
Add body status HUD

### DIFF
--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -142,7 +142,7 @@ export class HUD {
     this.renderCrosshair(state.dt);
     this.renderGrabPrompt(state.playerPhase, state.nearBar, state.damage, state.team);
     this.renderPowerBar(state.playerPhase, state.launchPower, state.maxLaunchPower, state.team);
-    this.renderDamage(state.damage);
+    this.renderDamage(state.phase, state.damage);
     this.renderTutorial(state.phase, state.tutorialPrompt, state.team);
     this.renderScoreboard(state.tabHeld, state.ownTeam, state.enemyTeam, state.showPing, state.team);
     this.view.help.classList.toggle("ob-help-visible", state.helpVisible);
@@ -302,8 +302,10 @@ export class HUD {
     this.view.powerLabel.style.textShadow = `0 0 8px ${palette.glowColor}`;
   }
 
-  private renderDamage(damage: DamageState): void {
-    this.view.damage.style.display = "block";
+  private renderDamage(phase: GamePhase, damage: DamageState): void {
+    const show = phase === 'PLAYING';
+    this.view.damage.style.display = show ? "block" : "none";
+    if (!show) return;
 
     const signature = damageStateSignature(damage);
     if (signature !== this.lastDamageSignature) {

--- a/client/src/render/hud.ts
+++ b/client/src/render/hud.ts
@@ -1,6 +1,7 @@
 import { MAX_LAUNCH_SPEED } from '../../../shared/constants';
 import type { DamageState, EnemyPlayerInfo, FullPlayerInfo } from '../../../shared/schema';
 import { isTouchDevice } from '../platform';
+import { buildBodyStatusHtml, damageStateSignature } from './hud/bodyStatus';
 import { createHudView, type HudElements } from './hud/hudView';
 import { buildScoreboardHtml } from './hud/scoreboard';
 import type { TutorialPrompt } from './hud/tutorial';
@@ -94,6 +95,7 @@ export class HUD {
   private hitConfirmTeam: 0 | 1 = 0;
   private hitConfirmTimer = 0;
   private isFirstRound = true;
+  private lastDamageSignature = "";
   private prevPhase: GamePhase = 'LOBBY';
   private typewriterTimer = 0;
   private typewriterIdx = 0;
@@ -301,22 +303,13 @@ export class HUD {
   }
 
   private renderDamage(damage: DamageState): void {
-    const parts: Array<{ label: string; tone: "danger" | "warn" | "info" }> = [];
-    if (damage.frozen) parts.push({ label: "FROZEN", tone: "danger" });
-    if (damage.leftArm) parts.push({ label: "LEFT ARM OFFLINE", tone: "warn" });
-    if (damage.rightArm) parts.push({ label: "RIGHT ARM OFFLINE", tone: "warn" });
-    if (damage.leftLeg && damage.rightLeg) {
-      parts.push({ label: "BOTH LEGS 50% LAUNCH", tone: "info" });
-    } else if (damage.leftLeg) {
-      parts.push({ label: "LEFT LEG 75% LAUNCH", tone: "info" });
-    } else if (damage.rightLeg) {
-      parts.push({ label: "RIGHT LEG 75% LAUNCH", tone: "info" });
-    }
+    this.view.damage.style.display = "block";
 
-    this.view.damage.style.display = parts.length > 0 ? "flex" : "none";
-    this.view.damage.innerHTML = parts
-      .map((part) => `<span class="ob-damage-pill ob-damage-pill--${part.tone}">${part.label}</span>`)
-      .join("");
+    const signature = damageStateSignature(damage);
+    if (signature !== this.lastDamageSignature) {
+      this.lastDamageSignature = signature;
+      this.view.damage.innerHTML = buildBodyStatusHtml(damage);
+    }
   }
 
   private renderScoreboard(

--- a/client/src/render/hud/bodyStatus.ts
+++ b/client/src/render/hud/bodyStatus.ts
@@ -1,0 +1,127 @@
+import type { DamageState } from "../../../../shared/schema";
+
+type BodyStatusTone = "clear" | "partial" | "critical";
+
+interface BodyStatusPart {
+  id: "head" | "leftArm" | "core" | "rightArm" | "leftLeg" | "rightLeg";
+  label: string;
+  tone: BodyStatusTone;
+}
+
+interface BodyStatusSummary {
+  title: string;
+  detail: string;
+  mobility: string;
+}
+
+const BODY_PART_LABELS: Array<Pick<BodyStatusPart, "id" | "label">> = [
+  { id: "head", label: "Head" },
+  { id: "leftArm", label: "L Arm" },
+  { id: "core", label: "Core" },
+  { id: "rightArm", label: "R Arm" },
+  { id: "leftLeg", label: "L Leg" },
+  { id: "rightLeg", label: "R Leg" },
+];
+
+export function damageStateSignature(damage: DamageState): string {
+  return [
+    damage.frozen ? "1" : "0",
+    damage.leftArm ? "1" : "0",
+    damage.rightArm ? "1" : "0",
+    damage.leftLeg ? "1" : "0",
+    damage.rightLeg ? "1" : "0",
+  ].join("");
+}
+
+export function getBodyStatusParts(damage: DamageState): BodyStatusPart[] {
+  return BODY_PART_LABELS.map((part) => ({
+    ...part,
+    tone: resolvePartTone(part.id, damage),
+  }));
+}
+
+export function getBodyStatusSummary(damage: DamageState): BodyStatusSummary {
+  if (damage.frozen) {
+    return {
+      title: "Pilot Frozen",
+      detail: "Core systems locked",
+      mobility: "Launch offline",
+    };
+  }
+
+  const disabledCount = [damage.leftArm, damage.rightArm, damage.leftLeg, damage.rightLeg]
+    .filter(Boolean)
+    .length;
+
+  if (disabledCount === 0) {
+    return {
+      title: "Systems Nominal",
+      detail: "No freeze damage",
+      mobility: "Launch 100%",
+    };
+  }
+
+  return {
+    title: "Partial Freeze",
+    detail: `${disabledCount} limb${disabledCount === 1 ? "" : "s"} impaired`,
+    mobility: getMobilityLabel(damage),
+  };
+}
+
+export function buildBodyStatusHtml(damage: DamageState): string {
+  const summary = getBodyStatusSummary(damage);
+  const parts = getBodyStatusParts(damage);
+
+  return `
+    <div class="ob-body-status">
+      <div class="ob-body-status__header">
+        <div class="ob-body-status__eyebrow">Body Status</div>
+        <div class="ob-body-status__title">${summary.title}</div>
+        <div class="ob-body-status__detail">${summary.detail}</div>
+      </div>
+      <div class="ob-body-status__diagram">
+        ${parts.map((part) => (
+          `<div class="ob-body-status__part ob-body-status__part--${part.id} ob-body-status__part--${part.tone}">
+            <span>${part.label}</span>
+          </div>`
+        )).join("")}
+      </div>
+      <div class="ob-body-status__footer">
+        <span class="ob-body-status__metric">${summary.mobility}</span>
+        <span class="ob-body-status__legend">
+          <span class="ob-body-status__swatch ob-body-status__swatch--clear"></span> Clear
+        </span>
+        <span class="ob-body-status__legend">
+          <span class="ob-body-status__swatch ob-body-status__swatch--partial"></span> Impaired
+        </span>
+        <span class="ob-body-status__legend">
+          <span class="ob-body-status__swatch ob-body-status__swatch--critical"></span> Frozen
+        </span>
+      </div>
+    </div>
+  `;
+}
+
+function resolvePartTone(partId: BodyStatusPart["id"], damage: DamageState): BodyStatusTone {
+  if (damage.frozen) return "critical";
+
+  switch (partId) {
+    case "head":
+    case "core":
+      return "clear";
+    case "leftArm":
+      return damage.leftArm ? "partial" : "clear";
+    case "rightArm":
+      return damage.rightArm ? "partial" : "clear";
+    case "leftLeg":
+      return damage.leftLeg ? "partial" : "clear";
+    case "rightLeg":
+      return damage.rightLeg ? "partial" : "clear";
+  }
+}
+
+function getMobilityLabel(damage: DamageState): string {
+  if (damage.leftLeg && damage.rightLeg) return "Launch 50%";
+  if (damage.leftLeg || damage.rightLeg) return "Launch 75%";
+  return "Launch 100%";
+}

--- a/client/src/render/hud/hudView.ts
+++ b/client/src/render/hud/hudView.ts
@@ -276,42 +276,206 @@ const HUD_CSS = `
     left: 18px;
     bottom: 18px;
     display: none;
-    flex-wrap: wrap;
-    gap: 8px;
-    width: min(360px, calc(100vw - 36px));
-    padding: 12px;
-    border-radius: 18px;
+    width: min(260px, calc(100vw - 36px));
+    padding: 14px;
+    border-radius: 24px;
   }
 
-  .ob-damage-pill {
-    display: inline-flex;
-    align-items: center;
-    min-height: 32px;
-    padding: 6px 10px;
-    border-radius: 999px;
+  .ob-body-status {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .ob-body-status__header {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .ob-body-status__eyebrow,
+  .ob-body-status__footer,
+  .ob-body-status__legend,
+  .ob-body-status__metric,
+  .ob-body-status__part span {
     font-family: "JetBrains Mono", monospace;
-    font-size: 11px;
+    text-transform: uppercase;
+  }
+
+  .ob-body-status__eyebrow {
+    color: var(--hud-muted);
+    font-size: 10px;
     font-weight: 700;
+    letter-spacing: 0.18em;
+  }
+
+  .ob-body-status__title {
+    color: var(--hud-text);
+    font-size: 24px;
+    line-height: 1;
     letter-spacing: 0.08em;
     text-transform: uppercase;
   }
 
-  .ob-damage-pill--danger {
-    color: #ffe1f0;
-    background: rgba(255, 94, 165, 0.16);
-    border: 1px solid rgba(255, 94, 165, 0.35);
+  .ob-body-status__detail {
+    color: var(--hud-team);
+    font-size: 13px;
+    letter-spacing: 0.06em;
+    text-shadow: 0 0 12px var(--hud-team-glow);
   }
 
-  .ob-damage-pill--warn {
-    color: #ffe8cb;
-    background: rgba(255, 170, 79, 0.14);
-    border: 1px solid rgba(255, 170, 79, 0.28);
+  .ob-body-status__diagram {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-rows: repeat(4, auto);
+    justify-items: center;
+    align-items: center;
+    gap: 7px 10px;
+    padding: 14px 12px;
+    border-radius: 18px;
+    background:
+      radial-gradient(circle at top, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0) 45%),
+      rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
   }
 
-  .ob-damage-pill--info {
-    color: #ddfaff;
-    background: rgba(116, 245, 255, 0.12);
-    border: 1px solid rgba(116, 245, 255, 0.24);
+  .ob-body-status__part {
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    min-width: 40px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(157, 184, 200, 0.1);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  }
+
+  .ob-body-status__part span {
+    position: absolute;
+    top: calc(100% + 4px);
+    color: var(--hud-muted);
+    font-size: 8px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    white-space: nowrap;
+  }
+
+  .ob-body-status__part--head {
+    grid-column: 2;
+    grid-row: 1;
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+  }
+
+  .ob-body-status__part--leftArm {
+    grid-column: 1;
+    grid-row: 2;
+    width: 28px;
+    height: 74px;
+    border-radius: 18px;
+  }
+
+  .ob-body-status__part--core {
+    grid-column: 2;
+    grid-row: 2 / span 2;
+    width: 58px;
+    height: 98px;
+    border-radius: 28px;
+  }
+
+  .ob-body-status__part--rightArm {
+    grid-column: 3;
+    grid-row: 2;
+    width: 28px;
+    height: 74px;
+    border-radius: 18px;
+  }
+
+  .ob-body-status__part--leftLeg {
+    grid-column: 2;
+    grid-row: 4;
+    justify-self: end;
+    width: 24px;
+    height: 82px;
+    margin-right: 18px;
+    border-radius: 18px;
+  }
+
+  .ob-body-status__part--rightLeg {
+    grid-column: 2;
+    grid-row: 4;
+    justify-self: start;
+    width: 24px;
+    height: 82px;
+    margin-left: 18px;
+    border-radius: 18px;
+  }
+
+  .ob-body-status__part--clear {
+    background: linear-gradient(180deg, rgba(157, 184, 200, 0.22), rgba(157, 184, 200, 0.08));
+    border-color: rgba(157, 184, 200, 0.24);
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+      0 0 16px rgba(157, 184, 200, 0.06);
+  }
+
+  .ob-body-status__part--partial {
+    background: linear-gradient(180deg, rgba(255, 176, 77, 0.85), rgba(255, 121, 63, 0.4));
+    border-color: rgba(255, 193, 122, 0.78);
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 248, 231, 0.08),
+      0 0 18px rgba(255, 162, 71, 0.28);
+  }
+
+  .ob-body-status__part--critical {
+    background: linear-gradient(180deg, rgba(255, 130, 239, 0.96), rgba(116, 245, 255, 0.32));
+    border-color: rgba(255, 190, 247, 0.8);
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 240, 252, 0.12),
+      0 0 22px rgba(255, 130, 239, 0.34);
+  }
+
+  .ob-body-status__footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px 10px;
+    color: var(--hud-muted);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+  }
+
+  .ob-body-status__metric {
+    color: var(--hud-text);
+    margin-right: auto;
+  }
+
+  .ob-body-status__legend {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .ob-body-status__swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+  }
+
+  .ob-body-status__swatch--clear {
+    background: rgba(157, 184, 200, 0.26);
+  }
+
+  .ob-body-status__swatch--partial {
+    background: rgba(255, 176, 77, 0.86);
+  }
+
+  .ob-body-status__swatch--critical {
+    background: rgba(255, 130, 239, 0.9);
   }
 
   .ob-tutorial {
@@ -675,10 +839,56 @@ const HUD_CSS = `
 
     .ob-damage-panel {
       left: 12px;
-      right: 12px;
       bottom: 12px;
-      width: auto;
-      padding: 10px;
+      width: min(220px, calc(100vw - 24px));
+      padding: 12px;
+    }
+
+    .ob-body-status__title {
+      font-size: 19px;
+    }
+
+    .ob-body-status__detail {
+      font-size: 12px;
+    }
+
+    .ob-body-status__diagram {
+      gap: 6px 8px;
+      padding: 12px 10px;
+    }
+
+    .ob-body-status__part span {
+      font-size: 7px;
+    }
+
+    .ob-body-status__part--head {
+      width: 30px;
+      height: 30px;
+    }
+
+    .ob-body-status__part--leftArm,
+    .ob-body-status__part--rightArm {
+      width: 24px;
+      height: 64px;
+    }
+
+    .ob-body-status__part--core {
+      width: 48px;
+      height: 84px;
+    }
+
+    .ob-body-status__part--leftLeg,
+    .ob-body-status__part--rightLeg {
+      width: 20px;
+      height: 70px;
+    }
+
+    .ob-body-status__part--leftLeg {
+      margin-right: 14px;
+    }
+
+    .ob-body-status__part--rightLeg {
+      margin-left: 14px;
     }
 
     .ob-scoreboard-overlay {

--- a/tests/bodyStatusHud.test.ts
+++ b/tests/bodyStatusHud.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBodyStatusHtml,
+  damageStateSignature,
+  getBodyStatusParts,
+  getBodyStatusSummary,
+} from "../client/src/render/hud/bodyStatus";
+import type { DamageState } from "../shared/schema";
+
+function makeDamageState(overrides: Partial<DamageState> = {}): DamageState {
+  return {
+    frozen: false,
+    leftArm: false,
+    rightArm: false,
+    leftLeg: false,
+    rightLeg: false,
+    ...overrides,
+  };
+}
+
+describe("body status HUD", () => {
+  it("shows a nominal silhouette when the player is undamaged", () => {
+    const damage = makeDamageState();
+
+    expect(getBodyStatusSummary(damage)).toEqual({
+      title: "Systems Nominal",
+      detail: "No freeze damage",
+      mobility: "Launch 100%",
+    });
+    expect(getBodyStatusParts(damage).every((part) => part.tone === "clear")).toBe(true);
+    expect(buildBodyStatusHtml(damage)).toContain("Body Status");
+  });
+
+  it("marks only damaged limbs as partially frozen", () => {
+    const damage = makeDamageState({ leftArm: true, rightLeg: true });
+    const parts = getBodyStatusParts(damage);
+
+    expect(getBodyStatusSummary(damage)).toEqual({
+      title: "Partial Freeze",
+      detail: "2 limbs impaired",
+      mobility: "Launch 75%",
+    });
+    expect(parts.find((part) => part.id === "leftArm")?.tone).toBe("partial");
+    expect(parts.find((part) => part.id === "rightLeg")?.tone).toBe("partial");
+    expect(parts.find((part) => part.id === "core")?.tone).toBe("clear");
+  });
+
+  it("promotes the whole silhouette to critical when the player is frozen", () => {
+    const damage = makeDamageState({
+      frozen: true,
+      leftArm: true,
+      rightArm: true,
+      leftLeg: true,
+      rightLeg: true,
+    });
+    const parts = getBodyStatusParts(damage);
+    const html = buildBodyStatusHtml(damage);
+
+    expect(getBodyStatusSummary(damage)).toEqual({
+      title: "Pilot Frozen",
+      detail: "Core systems locked",
+      mobility: "Launch offline",
+    });
+    expect(parts.every((part) => part.tone === "critical")).toBe(true);
+    expect(html).toContain("ob-body-status__part--critical");
+  });
+
+  it("tracks body status signatures for cheap HUD rerenders", () => {
+    expect(damageStateSignature(makeDamageState())).toBe("00000");
+    expect(
+      damageStateSignature(makeDamageState({ frozen: true, leftArm: true, rightLeg: true })),
+    ).toBe("11001");
+  });
+});

--- a/tests/bodyStatusHud.test.ts
+++ b/tests/bodyStatusHud.test.ts
@@ -73,3 +73,79 @@ describe("body status HUD", () => {
     ).toBe("11001");
   });
 });
+
+describe("getBodyStatusSummary — wording and mobility ladder", () => {
+  it("uses singular wording for exactly one impaired limb", () => {
+    expect(getBodyStatusSummary(makeDamageState({ rightArm: true }))).toEqual({
+      title: "Partial Freeze",
+      detail: "1 limb impaired",
+      mobility: "Launch 100%",
+    });
+  });
+
+  it("steps mobility down with leg damage: 100% → 75% → 50%", () => {
+    expect(getBodyStatusSummary(makeDamageState({ leftArm: true, rightArm: true })).mobility)
+      .toBe("Launch 100%"); // arms never cost launch power
+    expect(getBodyStatusSummary(makeDamageState({ leftLeg: true })).mobility).toBe("Launch 75%");
+    expect(getBodyStatusSummary(makeDamageState({ rightLeg: true })).mobility).toBe("Launch 75%");
+    expect(getBodyStatusSummary(makeDamageState({ leftLeg: true, rightLeg: true })).mobility)
+      .toBe("Launch 50%");
+  });
+
+  it("reports frozen even when no individual limbs are flagged (head/body hit)", () => {
+    const summary = getBodyStatusSummary(makeDamageState({ frozen: true }));
+    expect(summary.title).toBe("Pilot Frozen");
+    expect(summary.mobility).toBe("Launch offline");
+  });
+});
+
+describe("damageStateSignature — rerender gating", () => {
+  it("is collision-free across all 32 damage combinations", () => {
+    const signatures = new Set<string>();
+    for (let mask = 0; mask < 32; mask += 1) {
+      signatures.add(damageStateSignature(makeDamageState({
+        frozen: (mask & 1) !== 0,
+        leftArm: (mask & 2) !== 0,
+        rightArm: (mask & 4) !== 0,
+        leftLeg: (mask & 8) !== 0,
+        rightLeg: (mask & 16) !== 0,
+      })));
+    }
+    expect(signatures.size).toBe(32);
+  });
+});
+
+describe("getBodyStatusParts — diagram layout", () => {
+  it("keeps the mirror-view part order: L Arm reads screen-left of R Arm", () => {
+    const ids = getBodyStatusParts(makeDamageState()).map((part) => part.id);
+    expect(ids).toEqual(["head", "leftArm", "core", "rightArm", "leftLeg", "rightLeg"]);
+    expect(ids.indexOf("leftArm")).toBeLessThan(ids.indexOf("rightArm"));
+    expect(ids.indexOf("leftLeg")).toBeLessThan(ids.indexOf("rightLeg"));
+  });
+
+  it("never marks head or core as partial — torso hits freeze outright", () => {
+    const damage = makeDamageState({ leftArm: true, rightArm: true, leftLeg: true, rightLeg: true });
+    const parts = getBodyStatusParts(damage);
+    expect(parts.find((part) => part.id === "head")?.tone).toBe("clear");
+    expect(parts.find((part) => part.id === "core")?.tone).toBe("clear");
+  });
+});
+
+describe("buildBodyStatusHtml — tone classes", () => {
+  it("renders each part with its own tone modifier class", () => {
+    const html = buildBodyStatusHtml(makeDamageState({ leftArm: true }));
+    expect(html).toContain("ob-body-status__part--leftArm ob-body-status__part--partial");
+    expect(html).toContain("ob-body-status__part--rightArm ob-body-status__part--clear");
+    expect(html).not.toContain("ob-body-status__part--critical");
+  });
+
+  it("includes the legend and summary copy", () => {
+    const html = buildBodyStatusHtml(makeDamageState({ leftLeg: true }));
+    expect(html).toContain("Partial Freeze");
+    expect(html).toContain("1 limb impaired");
+    expect(html).toContain("Launch 75%");
+    expect(html).toContain("ob-body-status__swatch--clear");
+    expect(html).toContain("ob-body-status__swatch--partial");
+    expect(html).toContain("ob-body-status__swatch--critical");
+  });
+});


### PR DESCRIPTION
## Summary
- replace the old text damage pills with a persistent body-status HUD panel
- map local `DamageState` onto color-coded body regions with a compact status summary
- add coverage for the body-status mapping and rerender signature helper

## Validation
- `npm run build --prefix client`
- `npx vitest run`

## QA checklist
- [ ] Verify body status HUD is hidden in lobby/countdown/round-end screens
- [ ] Verify L/R Arm orientation feels natural — "L Arm" sits screen-left and "R Arm" screen-right (mirror view, not pilot view); confirm it reads correctly to a player

Closes #127