### PR TITLE
test: expand unit coverage + reproducible vitest harness (QA pass)

### DIFF
--- a/.claude/hooks/session-start.mjs
+++ b/.claude/hooks/session-start.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * SessionStart hook — Claude Code on the web only.
+ *
+ * The root package.json (vitest harness + concurrently) is deliberately
+ * gitignored (see .gitignore: "Root-level dev tooling — not part of
+ * deployable code"), so a fresh clone cannot run `npm test`. This hook
+ * recreates it and installs root + client + server dependencies so tests
+ * and typechecks work immediately in remote sessions.
+ *
+ * Local sessions exit immediately — developer machines manage their own
+ * root package.json. Vercel never sees this file: vercel.json pins
+ * installCommand/buildCommand to client/ only, and the file stays
+ * untracked either way.
+ */
+import { execSync } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+if (process.env.CLAUDE_CODE_REMOTE !== "true") {
+  process.exit(0);
+}
+
+const root = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
+// Keep in sync with the "Root harness package.json" section of docs/TESTING.md.
+const harnessPackageJson = `{
+  "name": "orbital-breach-root",
+  "private": true,
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "dev": "concurrently \\"npm run dev --prefix server\\" \\"npm run dev --prefix client\\""
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@vitest/coverage-v8": "^3.2.4",
+    "concurrently": "^9.1.0",
+    "vitest": "^3.2.4"
+  }
+}
+`;
+
+const rootPackageJson = join(root, "package.json");
+if (!existsSync(rootPackageJson)) {
+  writeFileSync(rootPackageJson, harnessPackageJson);
+  console.log("session-start: created gitignored root package.json (vitest harness)");
+}
+
+function install(label, cwd) {
+  console.log(`session-start: npm install (${label})`);
+  execSync("npm install --no-audit --no-fund", { cwd, stdio: "inherit" });
+}
+
+install("root", root);
+install("client", join(root, "client"));
+install("server", join(root, "server"));
+
+console.log("session-start: dependencies ready — `npm test` runs from the repo root");

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,17 @@
     "vercel@claude-plugins-official": true
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/session-start.mjs",
+            "timeout": 600
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -42,6 +42,36 @@ Config at the repo root:
   `client/node_modules/three/build/three.module.js`.
 - `tsconfig.test.json` — TypeScript scope for the test compile.
 
+### Root harness package.json (gitignored — recreate on fresh clones)
+
+The root `package.json` is deliberately **gitignored** (root-level dev tooling,
+not part of deployable code — Vercel builds from `client/` only, see
+`vercel.json`). A fresh clone therefore cannot run `npm test` until it exists.
+Recreate it with exactly this content, then `npm install`:
+
+```json
+{
+  "name": "orbital-breach-root",
+  "private": true,
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "dev": "concurrently \"npm run dev --prefix server\" \"npm run dev --prefix client\""
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@vitest/coverage-v8": "^3.2.4",
+    "concurrently": "^9.1.0",
+    "vitest": "^3.2.4"
+  }
+}
+```
+
+Claude Code on the web does this automatically via the SessionStart hook
+(`.claude/hooks/session-start.mjs`), which also installs `client/` and
+`server/` dependencies. If you change the harness deps, update both this
+section and the hook — they must stay in sync.
+
 Conventions:
 - Explicit imports — `import { describe, it, expect } from 'vitest';`
 - Import paths are relative to the **repo root**:

--- a/tests/match.test.ts
+++ b/tests/match.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { getSoloBotFill } from "../shared/match";
+import { getSoloBotFill, isMatchTeamSize, MATCH_TEAM_SIZES } from "../shared/match";
 import { buildHudRosters } from "../client/src/match/rosterView";
+
+describe("isMatchTeamSize", () => {
+  it("accepts every supported team size", () => {
+    for (const size of MATCH_TEAM_SIZES) {
+      expect(isMatchTeamSize(size)).toBe(true);
+    }
+  });
+
+  it("rejects sizes outside the supported set", () => {
+    expect(isMatchTeamSize(0)).toBe(false);
+    expect(isMatchTeamSize(3)).toBe(false);
+    expect(isMatchTeamSize(-1)).toBe(false);
+    expect(isMatchTeamSize(21)).toBe(false);
+  });
+});
 
 describe("getSoloBotFill", () => {
   it("fills a 1v1 skirmish with one enemy bot", () => {
@@ -21,6 +36,19 @@ describe("getSoloBotFill", () => {
     });
     expect(getSoloBotFill(10, 0).totalBots).toBe(19);
     expect(getSoloBotFill(20, 0).totalBots).toBe(39);
+  });
+
+  it("leaves the bot seat open on team 1 when the human plays magenta", () => {
+    expect(getSoloBotFill(2, 1)).toEqual({
+      team0Bots: 2,
+      team1Bots: 1,
+      totalBots: 3,
+      totalPlayers: 4,
+    });
+  });
+
+  it("defaults the human to team 0", () => {
+    expect(getSoloBotFill(1)).toEqual(getSoloBotFill(1, 0));
   });
 });
 

--- a/tests/messageCodec.test.ts
+++ b/tests/messageCodec.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseClientMsg, sendEvent, sendState } from "../server/src/net/messageCodec";
+import type { ServerStateMsg } from "../shared/schema";
+
+// WebSocket readyState constants (per the WHATWG spec, mirrored by `ws`).
+// Importing `ws` here would require it at the repo root, so use the raw values.
+const OPEN = 1;
+const CLOSING = 2;
+const CLOSED = 3;
+
+type SendableSocket = Parameters<typeof sendState>[0];
+
+function fakeSocket(readyState: number) {
+  return { readyState, send: vi.fn() } as unknown as SendableSocket & {
+    send: ReturnType<typeof vi.fn>;
+  };
+}
+
+const stateMsg: ServerStateMsg = {
+  t: "state",
+  seq: 1,
+  players: [],
+  score: { team0: 0, team1: 0 },
+  arenaState: "A",
+  phase: "LOBBY",
+};
+
+describe("parseClientMsg", () => {
+  it("parses a well-formed client message", () => {
+    const msg = parseClientMsg('{"t":"input","seq":3}');
+    expect(msg).toEqual({ t: "input", seq: 3 });
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseClientMsg("{not json")).toBeNull();
+  });
+
+  it("returns null for JSON that is not an object", () => {
+    expect(parseClientMsg('"input"')).toBeNull();
+    expect(parseClientMsg("42")).toBeNull();
+    expect(parseClientMsg("null")).toBeNull();
+  });
+
+  it("returns null when the type tag is missing or not a string", () => {
+    expect(parseClientMsg("{}")).toBeNull();
+    expect(parseClientMsg('{"t":7}')).toBeNull();
+  });
+});
+
+describe("sendState", () => {
+  it("serializes the snapshot to an open socket", () => {
+    const ws = fakeSocket(OPEN);
+    sendState(ws, stateMsg);
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(ws.send.mock.calls[0][0] as string)).toEqual(stateMsg);
+  });
+
+  it("drops the frame when the socket is not open", () => {
+    const ws = fakeSocket(CLOSED);
+    sendState(ws, stateMsg);
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendEvent", () => {
+  it("wraps type and data in an event envelope", () => {
+    const ws = fakeSocket(OPEN);
+    sendEvent(ws, "score", { team: 1 });
+    expect(JSON.parse(ws.send.mock.calls[0][0] as string)).toEqual({
+      t: "event",
+      type: "score",
+      data: { team: 1 },
+    });
+  });
+
+  it("drops the event when the socket is closing", () => {
+    const ws = fakeSocket(CLOSING);
+    sendEvent(ws, "score", { team: 0 });
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+});

--- a/tests/objectPool.test.ts
+++ b/tests/objectPool.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { ObjectPool } from "../client/src/util/pool";
+
+describe("ObjectPool", () => {
+  it("uses the factory when the pool is empty", () => {
+    const pool = new ObjectPool<{ n: number }>();
+    let built = 0;
+    const item = pool.acquire(() => ({ n: ++built }));
+    expect(item).toEqual({ n: 1 });
+    expect(built).toBe(1);
+  });
+
+  it("reuses released items instead of calling the factory", () => {
+    const pool = new ObjectPool<{ n: number }>();
+    let built = 0;
+    const factory = () => ({ n: ++built });
+
+    const first = pool.acquire(factory);
+    pool.release(first);
+    const second = pool.acquire(factory);
+
+    expect(second).toBe(first);
+    expect(built).toBe(1);
+  });
+
+  it("hands back released items in LIFO order", () => {
+    const pool = new ObjectPool<string>();
+    pool.release("a");
+    pool.release("b");
+    expect(pool.acquire(() => "new")).toBe("b");
+    expect(pool.acquire(() => "new")).toBe("a");
+    expect(pool.acquire(() => "new")).toBe("new");
+  });
+});

--- a/tests/obstacleCollision.test.ts
+++ b/tests/obstacleCollision.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { bounceAgainstBoxes } from "../client/src/arena/obstacleCollision";
+import type { PhysicsState } from "../client/src/physics";
+
+function makeState(pos: [number, number, number], vel: [number, number, number]): PhysicsState {
+  return {
+    pos: new THREE.Vector3(...pos),
+    vel: new THREE.Vector3(...vel),
+  };
+}
+
+function unitBoxAtOrigin(): THREE.Box3 {
+  return new THREE.Box3(new THREE.Vector3(-1, -1, -1), new THREE.Vector3(1, 1, 1));
+}
+
+describe("bounceAgainstBoxes", () => {
+  it("leaves a player outside every box untouched", () => {
+    const state = makeState([5, 5, 5], [1, 2, 3]);
+    bounceAgainstBoxes(state, [unitBoxAtOrigin()]);
+    expect(state.pos.toArray()).toEqual([5, 5, 5]);
+    expect(state.vel.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it("pushes a penetrating player out along the shallowest axis and damps that velocity axis by -0.5", () => {
+    // Near +X face: X penetration is shallowest, so resolution must be on X only.
+    const state = makeState([0.9, 0.1, 0.2], [-4, 1, 1]);
+    bounceAgainstBoxes(state, [unitBoxAtOrigin()], 0.05);
+    expect(state.pos.x).toBeCloseTo(1.05, 5); // box max + padding
+    expect(state.pos.y).toBeCloseTo(0.1, 5);
+    expect(state.pos.z).toBeCloseTo(0.2, 5);
+    expect(state.vel.x).toBeCloseTo(2, 5); // -4 * -0.5
+    expect(state.vel.y).toBeCloseTo(1, 5);
+    expect(state.vel.z).toBeCloseTo(1, 5);
+  });
+
+  it("resolves on Y when Y penetration is shallowest", () => {
+    const state = makeState([0.1, -0.9, 0.1], [0, 6, 0]);
+    bounceAgainstBoxes(state, [unitBoxAtOrigin()], 0.05);
+    expect(state.pos.y).toBeCloseTo(-1.05, 5); // pushed out the -Y face
+    expect(state.pos.x).toBeCloseTo(0.1, 5);
+    expect(state.pos.z).toBeCloseTo(0.1, 5);
+    expect(state.vel.y).toBeCloseTo(-3, 5); // 6 * -0.5
+  });
+
+  it("resolves on Z when Z penetration is shallowest", () => {
+    const state = makeState([0.1, 0.1, 0.95], [0, 0, -2]);
+    bounceAgainstBoxes(state, [unitBoxAtOrigin()], 0.05);
+    expect(state.pos.z).toBeCloseTo(1.05, 5);
+    expect(state.vel.z).toBeCloseTo(1, 5); // -2 * -0.5
+  });
+
+  it("respects the padding parameter when deciding containment", () => {
+    // 0.1 outside the raw box face: only collides once padding >= 0.1.
+    const grazing = makeState([1.1, 0, 0], [-1, 0, 0]);
+    bounceAgainstBoxes(grazing, [unitBoxAtOrigin()], 0.05);
+    expect(grazing.pos.x).toBeCloseTo(1.1, 5);
+    expect(grazing.vel.x).toBeCloseTo(-1, 5);
+
+    const padded = makeState([1.1, 0, 0], [-1, 0, 0]);
+    bounceAgainstBoxes(padded, [unitBoxAtOrigin()], 0.2);
+    expect(padded.pos.x).toBeCloseTo(1.2, 5); // box max + padding
+    expect(padded.vel.x).toBeCloseTo(0.5, 5);
+  });
+
+  it("checks every box in the list, not just the first", () => {
+    const farBox = new THREE.Box3(
+      new THREE.Vector3(9, -1, -1),
+      new THREE.Vector3(11, 1, 1),
+    );
+    const state = makeState([10.9, 0, 0], [-1, 0, 0]);
+    bounceAgainstBoxes(state, [unitBoxAtOrigin(), farBox], 0.05);
+    expect(state.pos.x).toBeCloseTo(11.05, 5);
+    expect(state.vel.x).toBeCloseTo(0.5, 5);
+  });
+});

--- a/tests/physicsBounds.test.ts
+++ b/tests/physicsBounds.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import {
+  bounceArena,
+  clampBreachRoom,
+  integrateZeroG,
+  type PhysicsState,
+} from "../client/src/physics";
+import {
+  ARENA_SIZE,
+  BREACH_ROOM_D,
+  BREACH_ROOM_H,
+  BREACH_ROOM_W,
+  MAX_LAUNCH_SPEED,
+  PLAYER_RADIUS,
+} from "../shared/constants";
+
+const LIMIT = ARENA_SIZE / 2 - PLAYER_RADIUS;
+
+function makeState(pos: [number, number, number], vel: [number, number, number]): PhysicsState {
+  return {
+    pos: new THREE.Vector3(...pos),
+    vel: new THREE.Vector3(...vel),
+  };
+}
+
+describe("integrateZeroG", () => {
+  it("advances position by velocity with no bleed (true zero-G)", () => {
+    const state = makeState([1, 2, 3], [2, -4, 6]);
+    integrateZeroG(state, 0.5);
+    expect(state.pos.toArray()).toEqual([2, 0, 6]);
+    expect(state.vel.toArray()).toEqual([2, -4, 6]);
+  });
+
+  it("clamps speed to MAX_LAUNCH_SPEED", () => {
+    const state = makeState([0, 0, 0], [MAX_LAUNCH_SPEED * 2, 0, 0]);
+    integrateZeroG(state, 1);
+    expect(state.vel.length()).toBeCloseTo(MAX_LAUNCH_SPEED, 5);
+    expect(state.pos.x).toBeCloseTo(MAX_LAUNCH_SPEED, 5);
+  });
+});
+
+describe("bounceArena", () => {
+  it("reflects velocity off a solid wall and clamps position to the limit", () => {
+    const state = makeState([LIMIT + 2, 0, 0], [3, 0, 0]);
+    bounceArena(state);
+    expect(state.pos.x).toBe(LIMIT);
+    expect(state.vel.x).toBe(-3);
+
+    const low = makeState([0, -LIMIT - 1, 0], [0, -2, 0]);
+    bounceArena(low);
+    expect(low.pos.y).toBe(-LIMIT);
+    expect(low.vel.y).toBe(2);
+  });
+
+  it("does not re-reflect velocity already pointing back into the arena", () => {
+    const state = makeState([LIMIT + 2, 0, 0], [-3, 0, 0]);
+    bounceArena(state);
+    expect(state.pos.x).toBe(LIMIT);
+    expect(state.vel.x).toBe(-3); // sign preserved
+  });
+
+  it("lets a player pass through an open portal face within the opening", () => {
+    const state = makeState([0, 0, LIMIT + 0.5], [0, 0, 5]);
+    bounceArena(state, "z", "x", { positive: true, negative: false });
+    expect(state.pos.z).toBeCloseTo(LIMIT + 0.5, 6); // passthrough, no clamp
+    expect(state.vel.z).toBe(5);
+  });
+
+  it("bounces on the portal face when the door is closed", () => {
+    const state = makeState([0, 0, LIMIT + 0.5], [0, 0, 5]);
+    bounceArena(state, "z", "x", { positive: false, negative: false });
+    expect(state.pos.z).toBe(LIMIT);
+    expect(state.vel.z).toBe(-5);
+  });
+
+  it("bounces outside the portal opening even when the door is open", () => {
+    const wideX = BREACH_ROOM_W / 2 + 1; // outside the opening width
+    const state = makeState([wideX, 0, LIMIT + 0.5], [0, 0, 5]);
+    bounceArena(state, "z", "x", { positive: true, negative: true });
+    expect(state.pos.z).toBe(LIMIT);
+    expect(state.vel.z).toBe(-5);
+  });
+});
+
+describe("clampBreachRoom", () => {
+  const center = new THREE.Vector3(0, 0, 0);
+  const depthHalf = BREACH_ROOM_D / 2 - PLAYER_RADIUS - 0.3;
+  const heightHalf = BREACH_ROOM_H / 2 - PLAYER_RADIUS;
+  const widthHalf = BREACH_ROOM_W / 2 - PLAYER_RADIUS;
+
+  it("clamps a player against the side walls and kills outward velocity", () => {
+    const state = makeState([widthHalf + 2, 0, 0], [4, 0, 0]);
+    clampBreachRoom(state, center, "z", 1);
+    expect(state.pos.x).toBeCloseTo(widthHalf, 6);
+    expect(state.vel.x).toBe(0);
+  });
+
+  it("leaves the portal-facing side open so the player can exit", () => {
+    const state = makeState([0, 0, depthHalf + 3], [0, 0, 2]);
+    clampBreachRoom(state, center, "z", 1);
+    expect(state.pos.z).toBeCloseTo(depthHalf + 3, 6);
+    expect(state.vel.z).toBe(2);
+  });
+
+  it("seals the portal side when the door is closed", () => {
+    const state = makeState([0, 0, depthHalf + 3], [0, 0, 2]);
+    clampBreachRoom(state, center, "z", 1, false);
+    expect(state.pos.z).toBeCloseTo(depthHalf, 6);
+    expect(state.vel.z).toBe(0);
+  });
+
+  it("respects the open sign — negative-facing rooms open on the other side", () => {
+    const open = makeState([0, 0, -(depthHalf + 3)], [0, 0, -2]);
+    clampBreachRoom(open, center, "z", -1);
+    expect(open.pos.z).toBeCloseTo(-(depthHalf + 3), 6);
+
+    const sealed = makeState([0, 0, depthHalf + 3], [0, 0, 2]);
+    clampBreachRoom(sealed, center, "z", -1);
+    expect(sealed.pos.z).toBeCloseTo(depthHalf, 6); // back wall on +Z stays solid
+  });
+
+  it("stops a falling player hard at the floor", () => {
+    const state = makeState([0, -heightHalf - 5, 0], [0, -9, 0]);
+    clampBreachRoom(state, center, "z", 1);
+    expect(state.pos.y).toBeCloseTo(-heightHalf, 6);
+    expect(state.vel.y).toBe(0);
+  });
+
+  it("clamps against the ceiling and zeroes upward velocity", () => {
+    const state = makeState([0, heightHalf + 5, 0], [0, 9, 0]);
+    clampBreachRoom(state, center, "z", 1);
+    expect(state.pos.y).toBeCloseTo(heightHalf, 6);
+    expect(state.vel.y).toBe(0);
+  });
+});

--- a/tests/playerLogic.test.ts
+++ b/tests/playerLogic.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  allLimbsDamaged,
   classifyHitZone,
   applyHit,
+  findFullFreezeWinner,
   generateSpawnPositions,
   maxLaunchPower,
   resolveActorCollisions,
@@ -243,5 +245,99 @@ describe("resolveActorCollisions", () => {
     // pointing away from each other, so the approach guard should leave them.
     expect(a.vel.x).toBeCloseTo(-3, 4);
     expect(b.vel.x).toBeCloseTo(3, 4);
+  });
+});
+
+describe("allLimbsDamaged", () => {
+  it("is true only when all four limbs are hit", () => {
+    expect(
+      allLimbsDamaged({ frozen: false, leftArm: true, rightArm: true, leftLeg: true, rightLeg: true }),
+    ).toBe(true);
+    expect(
+      allLimbsDamaged({ frozen: false, leftArm: true, rightArm: true, leftLeg: true, rightLeg: false }),
+    ).toBe(false);
+    expect(
+      allLimbsDamaged({ frozen: true, leftArm: false, rightArm: false, leftLeg: false, rightLeg: false }),
+    ).toBe(false);
+  });
+});
+
+describe("applyHit — arm asymmetry", () => {
+  function grabbingState() {
+    return {
+      damage: { frozen: false, leftArm: false, rightArm: false, leftLeg: false, rightLeg: false },
+      deaths: 0,
+      grabbedBarPos: { x: 1, y: 2, z: 3 },
+      launchPower: 5,
+      phase: "GRABBING" as const,
+      vel: { x: 0, y: 0, z: 0 },
+    };
+  }
+
+  it("a left-arm hit drops the grab and sends the player FLOATING", () => {
+    const state = grabbingState();
+    const killed = applyHit(state, "leftArm", { x: 0, y: 0, z: 0 });
+    expect(killed).toBe(false);
+    expect(state.phase).toBe("FLOATING");
+    expect(state.grabbedBarPos).toBeNull();
+    expect(state.damage.leftArm).toBe(true);
+  });
+
+  it("a right-arm hit does NOT drop the grab", () => {
+    const state = grabbingState();
+    const killed = applyHit(state, "rightArm", { x: 0, y: 0, z: 0 });
+    expect(killed).toBe(false);
+    expect(state.phase).toBe("GRABBING");
+    expect(state.grabbedBarPos).toEqual({ x: 1, y: 2, z: 3 });
+    expect(state.damage.rightArm).toBe(true);
+  });
+
+  it("adds the impulse to the player's velocity", () => {
+    const state = grabbingState();
+    applyHit(state, "rightArm", { x: 2, y: -1, z: 0.5 });
+    expect(state.vel).toEqual({ x: 2, y: -1, z: 0.5 });
+  });
+});
+
+describe("findFullFreezeWinner", () => {
+  const actor = (team: 0 | 1, frozen: boolean) => ({ team, frozen });
+
+  it("returns null while both teams still have active players", () => {
+    expect(
+      findFullFreezeWinner([actor(0, false), actor(0, true), actor(1, false)]),
+    ).toBeNull();
+  });
+
+  it("returns the surviving team when the other is fully frozen", () => {
+    expect(findFullFreezeWinner([actor(0, true), actor(1, false)])).toBe(1);
+    expect(findFullFreezeWinner([actor(0, false), actor(1, true), actor(1, true)])).toBe(0);
+  });
+
+  it("returns null on a mutual full freeze (no winner)", () => {
+    expect(findFullFreezeWinner([actor(0, true), actor(1, true)])).toBeNull();
+  });
+
+  it("returns null when either team has no players at all", () => {
+    expect(findFullFreezeWinner([actor(0, true)])).toBeNull();
+    expect(findFullFreezeWinner([])).toBeNull();
+  });
+});
+
+describe("generateSpawnPositions — edge cases", () => {
+  const arena = {
+    getBreachRoomCenter: () => ({ x: 0, y: 0, z: -23 }),
+    getBreachOpenAxis: () => "z" as const,
+    getBreachOpenSign: () => 1 as const,
+  };
+
+  it("returns an empty list for a non-positive count", () => {
+    expect(generateSpawnPositions(0, 0, arena)).toEqual([]);
+    expect(generateSpawnPositions(0, -3, arena)).toEqual([]);
+  });
+
+  it("is deterministic for the same seed", () => {
+    const a = generateSpawnPositions(0, 5, arena, 42);
+    const b = generateSpawnPositions(0, 5, arena, 42);
+    expect(a).toEqual(b);
   });
 });

--- a/tests/playerVictoryDance.test.ts
+++ b/tests/playerVictoryDance.test.ts
@@ -56,7 +56,9 @@ expect.extend({
 });
 
 declare module "vitest" {
-  interface Assertion<T = unknown> {
+  // Default must match vitest's own `Assertion<T = any>` declaration exactly,
+  // or TS2428 "identical type parameters" fires under tsconfig.test.json.
+  interface Assertion<T = any> {
     toEqualQuaternions(expected: Record<string, THREE.Quaternion>): T;
   }
   interface AsymmetricMatchersContaining {

--- a/tests/serverSim.test.ts
+++ b/tests/serverSim.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import Sim from "../server/src/sim";
+import ServerPlayer from "../server/src/player";
+import type { ClientInputMsg } from "../shared/schema";
+import {
+  ARENA_SIZE,
+  FREEZE_TIME,
+  INVULN_TIME,
+  MAX_SPEED,
+  PLAYER_RADIUS,
+  RESPAWN_TIME,
+} from "../shared/constants";
+
+function makeInput(overrides: Partial<ClientInputMsg> = {}): ClientInputMsg {
+  return {
+    t: "input",
+    id: "p1",
+    seq: 1,
+    walkAxes: { x: 0, z: 0 },
+    grab: false,
+    aiming: false,
+    fire: false,
+    rot: { yaw: 0, pitch: 0 },
+    phase: "FLOATING",
+    ...overrides,
+  };
+}
+
+describe("ServerPlayer", () => {
+  it("spawns on its team's side with zeroed velocity and undamaged limbs", () => {
+    const cyan = new ServerPlayer("Cyan", 0);
+    const magenta = new ServerPlayer("Magenta", 1);
+    expect(cyan.pos).toEqual({ x: 0, y: 0, z: -15 });
+    expect(magenta.pos).toEqual({ x: 0, y: 0, z: 15 });
+    expect(cyan.vel).toEqual({ x: 0, y: 0, z: 0 });
+    expect(cyan.damage).toEqual({
+      frozen: false,
+      rightArm: false,
+      leftArm: false,
+      leftLeg: false,
+      rightLeg: false,
+    });
+    expect(cyan.id).not.toBe(magenta.id);
+  });
+
+  it("maps server state to net phase in toNetState", () => {
+    const p = new ServerPlayer("Pilot", 0);
+    expect(p.toNetState().phase).toBe("FLOATING");
+    p.state = "FROZEN";
+    expect(p.toNetState().phase).toBe("FROZEN");
+    p.state = "RESPAWNING";
+    expect(p.toNetState().phase).toBe("RESPAWNING");
+  });
+
+  it("snapshots copies of pos/vel/damage, not live references", () => {
+    const p = new ServerPlayer("Pilot", 0);
+    const net = p.toNetState();
+    p.pos.x = 99;
+    p.damage.frozen = true;
+    expect(net.pos.x).toBe(0);
+    expect(net.damage.frozen).toBe(false);
+  });
+});
+
+describe("Sim", () => {
+  it("adds and removes players by id", () => {
+    const sim = new Sim();
+    const p = new ServerPlayer("Pilot", 0);
+    sim.addPlayer(p);
+    expect(sim.players.get(p.id)).toBe(p);
+    sim.removePlayer(p.id);
+    expect(sim.players.size).toBe(0);
+  });
+
+  it("applies newer input rotation and ignores stale sequence numbers", () => {
+    const sim = new Sim();
+    const p = new ServerPlayer("Pilot", 0);
+    sim.addPlayer(p);
+
+    p.lastInput = makeInput({ seq: 5, rot: { yaw: 1.2, pitch: -0.3 } });
+    sim.tick(0.05);
+    expect(p.rot.yaw).toBeCloseTo(1.2, 6);
+    expect(p.rot.pitch).toBeCloseTo(-0.3, 6);
+    expect(p.seq).toBe(5);
+
+    p.lastInput = makeInput({ seq: 4, rot: { yaw: 0, pitch: 0 } });
+    sim.tick(0.05);
+    expect(p.rot.yaw).toBeCloseTo(1.2, 6); // stale input rejected
+    expect(p.seq).toBe(5);
+  });
+
+  it("accelerates forward along -Z at zero yaw", () => {
+    const sim = new Sim();
+    const p = new ServerPlayer("Pilot", 0);
+    sim.addPlayer(p);
+
+    let seq = 0;
+    for (let i = 0; i < 10; i += 1) {
+      p.lastInput = makeInput({ seq: ++seq, walkAxes: { x: 0, z: 1 } });
+      sim.tick(0.02);
+    }
+
+    expect(p.vel.z).toBeLessThan(0); // forward is -Z at yaw 0
+    expect(p.vel.x).toBeCloseTo(0, 6);
+    expect(p.pos.z).toBeLessThan(-15); // drifted forward from spawn
+  });
+
+  it("caps speed at MAX_SPEED", () => {
+    const sim = new Sim();
+    const p = new ServerPlayer("Pilot", 0);
+    sim.addPlayer(p);
+
+    // Large dt makes per-tick acceleration outrun damping; pin the player to
+    // the arena centre each tick so walls and goals never interfere.
+    let seq = 0;
+    for (let i = 0; i < 100; i += 1) {
+      p.pos = { x: 0, y: 0, z: 0 };
+      p.lastInput = makeInput({ seq: ++seq, walkAxes: { x: 0, z: 1 } });
+      sim.tick(0.2);
+    }
+
+    const speed = Math.hypot(p.vel.x, p.vel.y, p.vel.z);
+    expect(speed).toBeLessThanOrEqual(MAX_SPEED + 1e-9);
+    expect(speed).toBeGreaterThan(MAX_SPEED * 0.9);
+  });
+
+  it("bounces players off the arena walls with halved reflected velocity", () => {
+    const sim = new Sim();
+    const p = new ServerPlayer("Pilot", 0);
+    sim.addPlayer(p);
+    const limit = ARENA_SIZE / 2 - PLAYER_RADIUS;
+
+    // No lastInput → integration is skipped; the tick only runs wall checks.
+    p.pos.x = limit + 1;
+    p.vel.x = 4;
+    sim.tick(0.05);
+
+    expect(p.pos.x).toBe(limit);
+    expect(p.vel.x).toBe(-2); // -|4| * 0.5
+  });
+
+  it("thaws a frozen player back to ACTIVE after FREEZE_TIME", () => {
+    const sim = new Sim();
+    const p = new ServerPlayer("Pilot", 0);
+    sim.addPlayer(p);
+    p.state = "FROZEN";
+    p.frozenTimer = FREEZE_TIME;
+
+    sim.tick(FREEZE_TIME / 2);
+    expect(p.state).toBe("FROZEN");
+    sim.tick(FREEZE_TIME / 2 + 0.01);
+    expect(p.state).toBe("ACTIVE");
+  });
+
+  it("respawns a player at base with invulnerability after RESPAWN_TIME", () => {
+    const sim = new Sim();
+    const p = new ServerPlayer("Pilot", 1);
+    sim.addPlayer(p);
+    p.state = "RESPAWNING";
+    p.respawnTimer = RESPAWN_TIME;
+    p.pos = { x: 5, y: 5, z: 5 };
+    p.vel = { x: 1, y: 1, z: 1 };
+
+    // Tick in small steps — invulnTimer starts counting down the same tick
+    // the respawn fires, so one giant dt would also consume the invuln window.
+    for (let t = 0; t < RESPAWN_TIME + 0.05; t += 0.1) {
+      sim.tick(0.1);
+    }
+
+    expect(p.state).toBe("ACTIVE");
+    expect(p.invulnTimer).toBeGreaterThan(0);
+    expect(p.invulnTimer).toBeLessThanOrEqual(INVULN_TIME);
+    expect(p.pos).toEqual({ x: 0, y: 0, z: 15 }); // team 1 base
+    expect(p.vel).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it("handleShot freezes the target and knocks it away from the shooter", () => {
+    const sim = new Sim();
+    const shooter = new ServerPlayer("Shooter", 0);
+    const target = new ServerPlayer("Target", 1);
+    sim.addPlayer(shooter);
+    sim.addPlayer(target);
+    shooter.pos = { x: 0, y: 0, z: 0 };
+    target.pos = { x: 2, y: 0, z: 0 };
+
+    sim.handleShot(shooter.id, target.id);
+
+    expect(target.state).toBe("FROZEN");
+    expect(target.frozenTimer).toBe(FREEZE_TIME);
+    expect(target.vel.x).toBeCloseTo(3, 6); // unit direction * 3 impulse
+    expect(target.vel.y).toBeCloseTo(0, 6);
+  });
+
+  it("handleShot ignores invulnerable, already-frozen, and unknown targets", () => {
+    const sim = new Sim();
+    const shooter = new ServerPlayer("Shooter", 0);
+    const target = new ServerPlayer("Target", 1);
+    sim.addPlayer(shooter);
+    sim.addPlayer(target);
+
+    target.invulnTimer = 0.5;
+    sim.handleShot(shooter.id, target.id);
+    expect(target.state).toBe("ACTIVE");
+
+    target.invulnTimer = 0;
+    target.state = "FROZEN";
+    target.frozenTimer = 1;
+    sim.handleShot(shooter.id, target.id);
+    expect(target.frozenTimer).toBe(1); // not re-frozen
+
+    expect(() => sim.handleShot(shooter.id, "missing-id")).not.toThrow();
+  });
+
+  it("scores and respawns a player who reaches the enemy goal", () => {
+    const sim = new Sim();
+    const p = new ServerPlayer("Pilot", 0);
+    sim.addPlayer(p);
+    p.pos = { x: 0, y: 0, z: 19.9 }; // team 0 attacks +Z goal at z=20
+    p.lastInput = makeInput({ seq: 1 });
+
+    sim.tick(0.0001);
+
+    expect(sim.score.team0).toBe(1);
+    expect(sim.score.team1).toBe(0);
+    expect(p.state).toBe("RESPAWNING");
+    expect(p.pos.z).toBe(-15);
+  });
+
+  it("getSnapshot returns the wire-format state and bumps seq each call", () => {
+    const sim = new Sim();
+    const p = new ServerPlayer("Pilot", 0);
+    sim.addPlayer(p);
+
+    const first = sim.getSnapshot();
+    expect(first.t).toBe("state");
+    expect(first.players).toHaveLength(1);
+    expect(first.players[0].id).toBe(p.id);
+    expect(first.score).toEqual({ team0: 0, team1: 0 });
+    expect(first.phase).toBe("LOBBY");
+
+    const second = sim.getSnapshot();
+    expect(second.seq).toBe(first.seq + 1);
+
+    sim.removePlayer(p.id);
+    expect(sim.getSnapshot().players).toHaveLength(0);
+  });
+});

--- a/tests/utilMath.test.ts
+++ b/tests/utilMath.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { Vector3 } from "three";
+import { clamp, clampMagnitude, lerp, lerpVec3 } from "../client/src/util/math";
+
+describe("clamp", () => {
+  it("returns the value when inside the range", () => {
+    expect(clamp(3, 0, 10)).toBe(3);
+  });
+
+  it("clamps to min and max at the edges", () => {
+    expect(clamp(-5, 0, 10)).toBe(0);
+    expect(clamp(15, 0, 10)).toBe(10);
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+});
+
+describe("lerp", () => {
+  it("interpolates between endpoints", () => {
+    expect(lerp(0, 10, 0)).toBe(0);
+    expect(lerp(0, 10, 1)).toBe(10);
+    expect(lerp(0, 10, 0.5)).toBe(5);
+    expect(lerp(-4, 4, 0.25)).toBe(-2);
+  });
+
+  it("extrapolates outside [0, 1]", () => {
+    expect(lerp(0, 10, 2)).toBe(20);
+    expect(lerp(0, 10, -1)).toBe(-10);
+  });
+});
+
+describe("clampMagnitude", () => {
+  it("shortens a vector longer than max while keeping its direction", () => {
+    const v = new Vector3(3, 4, 0); // length 5
+    const out = clampMagnitude(v, 2);
+    expect(out).toBe(v); // mutates and returns the same instance
+    expect(v.length()).toBeCloseTo(2, 6);
+    expect(v.x / v.y).toBeCloseTo(3 / 4, 6);
+  });
+
+  it("leaves a vector within max untouched", () => {
+    const v = new Vector3(1, 1, 1);
+    clampMagnitude(v, 10);
+    expect(v.toArray()).toEqual([1, 1, 1]);
+  });
+});
+
+describe("lerpVec3", () => {
+  it("returns a new interpolated vector without mutating inputs", () => {
+    const a = new Vector3(0, 0, 0);
+    const b = new Vector3(10, -10, 4);
+    const mid = lerpVec3(a, b, 0.5);
+    expect(mid.toArray()).toEqual([5, -5, 2]);
+    expect(a.toArray()).toEqual([0, 0, 0]);
+    expect(b.toArray()).toEqual([10, -10, 4]);
+  });
+});

--- a/tests/vec3.test.ts
+++ b/tests/vec3.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { v3 } from "../shared/vec3";
+
+describe("v3.zero", () => {
+  it("returns a fresh origin vector each call", () => {
+    const a = v3.zero();
+    expect(a).toEqual({ x: 0, y: 0, z: 0 });
+    expect(v3.zero()).not.toBe(a);
+  });
+});
+
+describe("v3.clone", () => {
+  it("copies components into a new object", () => {
+    const src = { x: 1, y: 2, z: 3 };
+    const copy = v3.clone(src);
+    expect(copy).toEqual(src);
+    expect(copy).not.toBe(src);
+  });
+});
+
+describe("v3.add", () => {
+  it("adds componentwise", () => {
+    expect(v3.add({ x: 1, y: 2, z: 3 }, { x: -1, y: 10, z: 0.5 })).toEqual({ x: 0, y: 12, z: 3.5 });
+  });
+});
+
+describe("v3.sub", () => {
+  it("subtracts componentwise", () => {
+    expect(v3.sub({ x: 1, y: 2, z: 3 }, { x: 3, y: 2, z: 1 })).toEqual({ x: -2, y: 0, z: 2 });
+  });
+});
+
+describe("v3.scale", () => {
+  it("multiplies every component by the scalar", () => {
+    expect(v3.scale({ x: 1, y: -2, z: 0.5 }, 4)).toEqual({ x: 4, y: -8, z: 2 });
+  });
+});
+
+describe("v3.addScaled", () => {
+  it("computes a + b * s without mutating inputs", () => {
+    const a = { x: 1, y: 1, z: 1 };
+    const b = { x: 2, y: 0, z: -2 };
+    expect(v3.addScaled(a, b, 0.5)).toEqual({ x: 2, y: 1, z: 0 });
+    expect(a).toEqual({ x: 1, y: 1, z: 1 });
+    expect(b).toEqual({ x: 2, y: 0, z: -2 });
+  });
+});
+
+describe("v3.dot", () => {
+  it("is zero for orthogonal vectors and |a|^2 for self", () => {
+    expect(v3.dot({ x: 1, y: 0, z: 0 }, { x: 0, y: 1, z: 0 })).toBe(0);
+    expect(v3.dot({ x: 2, y: 3, z: 6 }, { x: 2, y: 3, z: 6 })).toBe(49);
+  });
+});
+
+describe("v3.cross", () => {
+  it("follows the right-hand rule on the basis vectors", () => {
+    expect(v3.cross({ x: 1, y: 0, z: 0 }, { x: 0, y: 1, z: 0 })).toEqual({ x: 0, y: 0, z: 1 });
+    expect(v3.cross({ x: 0, y: 1, z: 0 }, { x: 1, y: 0, z: 0 })).toEqual({ x: 0, y: 0, z: -1 });
+  });
+});
+
+describe("v3.length", () => {
+  it("matches lengthSq on a 3-4-12 triple", () => {
+    const v = { x: 3, y: 4, z: 12 };
+    expect(v3.lengthSq(v)).toBe(169);
+    expect(v3.length(v)).toBe(13);
+  });
+});
+
+describe("v3.normalize", () => {
+  it("returns a unit vector in the same direction", () => {
+    const n = v3.normalize({ x: 0, y: 3, z: 4 });
+    expect(n.x).toBeCloseTo(0, 6);
+    expect(n.y).toBeCloseTo(0.6, 6);
+    expect(n.z).toBeCloseTo(0.8, 6);
+  });
+
+  it("returns the zero vector for degenerate input instead of NaN", () => {
+    expect(v3.normalize({ x: 0, y: 0, z: 0 })).toEqual({ x: 0, y: 0, z: 0 });
+    expect(v3.normalize({ x: 1e-12, y: 0, z: 0 })).toEqual({ x: 0, y: 0, z: 0 });
+  });
+});
+
+describe("v3.dist", () => {
+  it("measures Euclidean distance between points", () => {
+    const a = { x: 1, y: 2, z: 3 };
+    const b = { x: 4, y: 6, z: 3 };
+    expect(v3.distSq(a, b)).toBe(25);
+    expect(v3.dist(a, b)).toBe(5);
+    expect(v3.dist(a, a)).toBe(0);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,9 +7,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["vitest/globals", "node"],
+    "types": ["vitest/globals", "node", "vite/client"],
     "paths": {
-      "three": ["./client/node_modules/three"]
+      "three": ["./client/node_modules/@types/three"]
     }
   },
   "include": ["tests/**/*.ts", "shared/**/*.ts"]


### PR DESCRIPTION
## Summary
QA pass on the test suite — no app code touched (tests, test config, docs, Claude tooling only).

- **+77 tests (275 → 352, 44 → 51 files)** targeting previously-uncovered pure modules: `bounceAgainstBoxes` (obstacle collision), legacy `Sim`/`ServerPlayer`, `integrateZeroG`/`bounceArena`/`clampBreachRoom`, server message codec, `v3` vector helpers, client math utils, `ObjectPool`
- Extended playerLogic tests: `findFullFreezeWinner`, `allLimbsDamaged`, left/right-arm grab asymmetry, spawn-position edge cases; extended match tests: `isMatchTeamSize`, magenta-side bot fill
- **Fixed `tsconfig.test.json`** (67 type errors → 0): point `three` at `@types/three`, add `vite/client` types; aligned the vitest `Assertion` augmentation with vitest 3's type parameters
- **SessionStart hook** (`.claude/hooks/session-start.mjs`): recreates the gitignored root vitest harness `package.json` and installs deps in Claude Code web sessions — gated on `CLAUDE_CODE_REMOTE`, never runs locally; harness contents documented in `docs/TESTING.md`
- **No Vercel impact**: `vercel.json` pins install/build to `client/` only; root `package.json` stays gitignored/untracked

## Validation
- `npm test` — 352/352 passing
- `tsc --noEmit` clean on client and server
- `tsc -p tsconfig.test.json` clean (was 67 errors)
- Hook validated: remote path recreates harness + installs; local path is a no-op

https://claude.ai/code/session_01W1GPdWxeiEMmC5YJGdDHDa

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1GPdWxeiEMmC5YJGdDHDa)_