### PR TITLE
docs(readme): fix fresh-clone dev commands and trim internal phrasing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ Shared hooks in `.claude/settings.json`, scripts in `.claude/hooks/`.
 
 ## README upkeep
 
-`README.md` has a **Current Codebase Coverage** section (prose, not a table). When a feature ships, add or update its bullet under "Shipped and implemented", and move anything no longer pending out of the "Evidence-backed pending or transitional surfaces" list. If a feature adds new user-facing capability, update the relevant section above it (e.g. Player-Facing Features, Tech Stack) too.
+`README.md` has a **Current Codebase Coverage** section (prose, not a table). When a feature ships, add or update its bullet under "Shipped and implemented", and move anything no longer pending out of the "Pending or transitional" list. If a feature adds new user-facing capability, update the relevant section above it (e.g. Player-Facing Features, Tech Stack) too.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [Play Orbital Breach](https://orbital-breach.vercel.app) | [Itch.io](https://dotanv.itch.io) | [Source](https://github.com/DotanVG/Orbital-Breach)
 
-Orbital Breach runs in the browser with no account or install. The game supports solo bot matches, online multiplayer rooms, mobile touch controls, Vibe Jam portal handoff, debrief stats, credits, Vercel Analytics, and Vercel Speed Insights.
+Orbital Breach runs in the browser with no account or install. The game supports solo bot matches, online multiplayer rooms, mobile touch controls, Vibe Jam portal handoff, and post-match debrief stats.
 
 ## The Match
 
@@ -89,7 +89,6 @@ On touch devices, Orbital Breach swaps in mobile controls: a movement joystick i
 - Winning-team victory dance animation at match end.
 - Credits screen and external project links.
 - Vibe Jam portal integration at `https://vibej.am/portal/2026`, including return portals for portal arrivals.
-- Landing attribution via Vercel Web Analytics and performance collection via Vercel Speed Insights.
 
 Debrief awards are generated from match stats:
 
@@ -118,20 +117,11 @@ Prerequisites: Node.js 18+ and npm.
 Install dependencies:
 
 ```bash
-npm install
 npm install --prefix client
 npm install --prefix server
 ```
 
-The root `npm install` pulls the dev tooling (`concurrently`, `vitest`) used by the repo-root scripts.
-
-Run the full local stack in one terminal:
-
-```bash
-npm run dev
-```
-
-This uses `concurrently` to start the server and client together. To run each service separately instead:
+Run the server and client in separate terminals:
 
 ```bash
 # terminal 1
@@ -146,8 +136,10 @@ Open [http://localhost:5173](http://localhost:5173). In development, the Vite se
 Useful commands:
 
 ```bash
-# repo-root test suite (vitest)
-npm test
+# test suite — run from the repo root
+# (the one-time install lands in a gitignored root package.json)
+npm install vitest
+npx vitest run
 
 # client build + typecheck
 npm run build --prefix client
@@ -206,7 +198,7 @@ graphify cluster-only .
 
 ## Current Codebase Coverage
 
-Shipped and implemented in the current `staging` tree:
+Shipped and implemented:
 
 - Browser-playable zero-G FPS with solo bot matches and Colyseus-backed online multiplayer.
 - Quick match, room browser, private/public room creation, invite URLs, native share, and QR joins.
@@ -214,7 +206,7 @@ Shipped and implemented in the current `staging` tree:
 - Post-match debrief stats, awards, credits, analytics, and Speed Insights instrumentation.
 - AI bot fill, ready checks, stale-player seat cleanup, and authoritative round/match scoring.
 
-Evidence-backed pending or transitional surfaces still visible in the repo:
+Pending or transitional:
 
 - `client/src/combat.ts` still carries a TODO to route firing through an active-weapon abstraction instead of the current fixed freeze-pistol path.
 - `server/src/net/`, `server/src/room.ts`, and `server/src/sim.ts` remain as legacy transport/test support while Colyseus is the production multiplayer path.


### PR DESCRIPTION
Follow-up accuracy pass on the README after #139.

## Why

Every gameplay/UI/lobby claim in the README was re-verified against source with file:line evidence (playlists, lobby phases/buttons, room creation limits, controls, win conditions, limb-hit effects, awards, env vars, endpoints, ports, versions, assets) — all correct. One section was not: **Local Development** told fresh cloners to run root `npm install` / `npm run dev` / `npm test`, but the root `package.json` is deliberately gitignored ("Root-level dev tooling — not part of deployable code"), so none of those commands work from a fresh clone.

## Changes

- **Local Development** now only contains commands verified to work from a fresh clone: per-package installs, two-terminal dev (`npm run dev --prefix server|client`), and the test flow `npm install vitest` + `npx vitest run` (verified in a clean clone: 44 files / 275 tests passing). Plain `npx vitest run` without the root install fails — `vitest/config` can't resolve — so the one-time install is documented.
- Dropped Vercel Analytics / Speed Insights mentions from the intro paragraph and Player-Facing Features (not player-facing; still listed in Tech Stack and Current Codebase Coverage).
- **Current Codebase Coverage** headers reworded for a public audience: removed the internal `staging`-tree reference and the "Evidence-backed … surfaces" audit phrasing; CLAUDE.md's README-upkeep pointer updated to match.

No gameplay-facing content was changed — all of it checked out.

https://claude.ai/code/session_01271zJcADTnhPrq2MbHUzA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01271zJcADTnhPrq2MbHUzA4)_